### PR TITLE
chore: suppress some of "unchecked cast" warnings

### DIFF
--- a/playwright/src/main/java/com/microsoft/playwright/impl/ChannelOwner.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/ChannelOwner.java
@@ -68,6 +68,7 @@ class ChannelOwner {
     connection.sendMessageNoWait(guid, method, params);
   }
 
+  @SuppressWarnings("unchecked")
   <T> Deferred<T> toDeferred(Waitable waitable) {
     return () -> {
       while (!waitable.isDone()) {

--- a/playwright/src/main/java/com/microsoft/playwright/impl/Serialization.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/Serialization.java
@@ -79,6 +79,7 @@ class Serialization {
       result.a = list.toArray(new SerializedValue[0]);
     } else if (value instanceof Map) {
       List<SerializedValue.O> list = new ArrayList<>();
+      @SuppressWarnings("unchecked")
       Map<String, Object> map = (Map<String, Object>) value;
       for (Map.Entry<String, Object> e : map.entrySet()) {
         SerializedValue.O o = new SerializedValue.O();
@@ -113,6 +114,7 @@ class Serialization {
     return result;
   }
 
+  @SuppressWarnings("unchecked")
   static <T> T deserialize(SerializedValue value) {
     if (value.n != null) {
       if (value.n.doubleValue() == (double) value.n.intValue()) {
@@ -142,14 +144,14 @@ class Serialization {
       }
     }
     if (value.a != null) {
-      List list = new ArrayList();
+      List<Object> list = new ArrayList<>();
       for (SerializedValue v : value.a) {
         list.add(deserialize(v));
       }
       return (T) list;
     }
     if (value.o != null) {
-      Map map = new LinkedHashMap<>();
+      Map<String, Object> map = new LinkedHashMap<>();
       for (SerializedValue.O o : value.o) {
         map.put(o.k, deserialize(o.v));
       }

--- a/playwright/src/main/java/com/microsoft/playwright/impl/WaitableEvent.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/WaitableEvent.java
@@ -56,6 +56,8 @@ class WaitableEvent<EventType, ResultType> implements Waitable<ResultType>, List
     listeners.remove(type, this);
   }
 
+  @SuppressWarnings("unchecked")
+  @Override
   public ResultType get() {
     return (ResultType) event.data();
   }

--- a/playwright/src/test/java/com/microsoft/playwright/TestPageExposeFunction.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestPageExposeFunction.java
@@ -136,6 +136,7 @@ public class TestPageExposeFunction {
       "  }\n" +
       "}");
     assertTrue(result instanceof Map);
+    @SuppressWarnings("unchecked")
     Map<String, String> m = (Map<String, String>) result;
     assertEquals("WOOF WOOF", m.get("message"));
     assertTrue(m.get("stack").contains("shouldThrowExceptionInPageContext"));
@@ -202,7 +203,9 @@ public class TestPageExposeFunction {
   @Test
   void shouldWorkWithComplexObjects() {
     page.exposeFunction("complexObject", args -> {
+      @SuppressWarnings("unchecked")
       Map<String, Integer> a = (Map<String, Integer>) args[0];
+      @SuppressWarnings("unchecked")
       Map<String, Integer> b = (Map<String, Integer>) args[1];
       int sum = a.get("x") + b.get("x");
       return mapOf("x", sum);

--- a/playwright/src/test/java/com/microsoft/playwright/TestPopup.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestPopup.java
@@ -106,6 +106,7 @@ public class TestPopup {
 
   @Test
   void shouldInheritExtraHeadersFromBrowserContext() throws ExecutionException, InterruptedException {
+    @SuppressWarnings("unchecked")
     BrowserContext context = browser.newContext(new Browser.NewContextOptions()
       .withExtraHTTPHeaders(mapOf("foo", "bar")));
     Page page = context.newPage();

--- a/playwright/src/test/java/com/microsoft/playwright/Utils.java
+++ b/playwright/src/test/java/com/microsoft/playwright/Utils.java
@@ -20,6 +20,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 class Utils {
+  @SuppressWarnings("unchecked")
   static Map mapOf(Object... entries) {
     Map result = new HashMap();
     for (int i = 0; i + 1 < entries.length; i += 2) {


### PR DESCRIPTION
This is not ideal as it may defer the type mismatch error until first use but still seems better than having to cast at each call site.