### PR TITLE
chore: remore redundant parameter from route handler

### DIFF
--- a/api-generator/src/main/java/com/microsoft/playwright/tools/ApiGenerator.java
+++ b/api-generator/src/main/java/com/microsoft/playwright/tools/ApiGenerator.java
@@ -240,9 +240,9 @@ class Method extends Element {
     customSignature.put("BrowserType.connect", new String[0]);
     customSignature.put("BrowserType.launchServer", new String[0]);
     customSignature.put("BrowserContext.route", new String[]{
-      "void route(String url, BiConsumer<Route, Request> handler);",
-      "void route(Pattern url, BiConsumer<Route, Request> handler);",
-      "void route(Predicate<String> url, BiConsumer<Route, Request> handler);",
+      "void route(String url, Consumer<Route> handler);",
+      "void route(Pattern url, Consumer<Route> handler);",
+      "void route(Predicate<String> url, Consumer<Route> handler);",
     });
     // There is no standard JSON type in Java.
     customSignature.put("Response.json", new String[0]);
@@ -254,25 +254,25 @@ class Method extends Element {
       "Frame frameByUrl(Predicate<String> predicate);",
     });
     customSignature.put("Page.route", new String[]{
-      "void route(String url, BiConsumer<Route, Request> handler);",
-      "void route(Pattern url, BiConsumer<Route, Request> handler);",
-      "void route(Predicate<String> url, BiConsumer<Route, Request> handler);",
+      "void route(String url, Consumer<Route> handler);",
+      "void route(Pattern url, Consumer<Route> handler);",
+      "void route(Predicate<String> url, Consumer<Route> handler);",
     });
     customSignature.put("BrowserContext.unroute", new String[]{
       "default void unroute(String url) { unroute(url, null); }",
       "default void unroute(Pattern url) { unroute(url, null); }",
       "default void unroute(Predicate<String> url) { unroute(url, null); }",
-      "void unroute(String url, BiConsumer<Route, Request> handler);",
-      "void unroute(Pattern url, BiConsumer<Route, Request> handler);",
-      "void unroute(Predicate<String> url, BiConsumer<Route, Request> handler);",
+      "void unroute(String url, Consumer<Route> handler);",
+      "void unroute(Pattern url, Consumer<Route> handler);",
+      "void unroute(Predicate<String> url, Consumer<Route> handler);",
     });
     customSignature.put("Page.unroute", new String[]{
       "default void unroute(String url) { unroute(url, null); }",
       "default void unroute(Pattern url) { unroute(url, null); }",
       "default void unroute(Predicate<String> url) { unroute(url, null); }",
-      "void unroute(String url, BiConsumer<Route, Request> handler);",
-      "void unroute(Pattern url, BiConsumer<Route, Request> handler);",
-      "void unroute(Predicate<String> url, BiConsumer<Route, Request> handler);",
+      "void unroute(String url, Consumer<Route> handler);",
+      "void unroute(Pattern url, Consumer<Route> handler);",
+      "void unroute(Predicate<String> url, Consumer<Route> handler);",
     });
     customSignature.put("BrowserContext.cookies", new String[]{
       "default List<Cookie> cookies() { return cookies((List<String>) null); }",
@@ -661,7 +661,7 @@ class Interface extends TypeDefinition {
     }
     output.add("import java.util.*;");
     if (asList("Page", "BrowserContext").contains(jsonName)) {
-      output.add("import java.util.function.BiConsumer;");
+      output.add("import java.util.function.Consumer;");
     }
     if (asList("Page", "Frame", "BrowserContext").contains(jsonName)) {
       output.add("import java.util.function.Predicate;");

--- a/api-generator/src/main/java/com/microsoft/playwright/tools/Types.java
+++ b/api-generator/src/main/java/com/microsoft/playwright/tools/Types.java
@@ -107,10 +107,10 @@ class Types {
     add("ChromiumBrowser.startTracing.options.path", "string", "Path");
 
     // Route
-    add("BrowserContext.route.handler", "function(Route, Request)", "BiConsumer<Route, Request>");
-    add("BrowserContext.unroute.handler", "function(Route, Request)", "BiConsumer<Route, Request>");
-    add("Page.route.handler", "function(Route, Request)", "BiConsumer<Route, Request>");
-    add("Page.unroute.handler", "function(Route, Request)", "BiConsumer<Route, Request>");
+    add("BrowserContext.route.handler", "function(Route, Request)", "Consumer<Route>");
+    add("BrowserContext.unroute.handler", "function(Route, Request)", "Consumer<Route>");
+    add("Page.route.handler", "function(Route, Request)", "Consumer<Route>");
+    add("Page.unroute.handler", "function(Route, Request)", "Consumer<Route>");
 
     // Viewport size.
     add("Browser.newContext.options.viewport", "null|Object", "Page.Viewport", new Empty());

--- a/playwright/src/main/java/com/microsoft/playwright/BrowserContext.java
+++ b/playwright/src/main/java/com/microsoft/playwright/BrowserContext.java
@@ -17,7 +17,7 @@
 package com.microsoft.playwright;
 
 import java.util.*;
-import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
@@ -183,9 +183,9 @@ public interface BrowserContext {
   void grantPermissions(List<String> permissions, GrantPermissionsOptions options);
   Page newPage();
   List<Page> pages();
-  void route(String url, BiConsumer<Route, Request> handler);
-  void route(Pattern url, BiConsumer<Route, Request> handler);
-  void route(Predicate<String> url, BiConsumer<Route, Request> handler);
+  void route(String url, Consumer<Route> handler);
+  void route(Pattern url, Consumer<Route> handler);
+  void route(Predicate<String> url, Consumer<Route> handler);
   void setDefaultNavigationTimeout(int timeout);
   void setDefaultTimeout(int timeout);
   void setExtraHTTPHeaders(Map<String, String> headers);
@@ -194,9 +194,9 @@ public interface BrowserContext {
   default void unroute(String url) { unroute(url, null); }
   default void unroute(Pattern url) { unroute(url, null); }
   default void unroute(Predicate<String> url) { unroute(url, null); }
-  void unroute(String url, BiConsumer<Route, Request> handler);
-  void unroute(Pattern url, BiConsumer<Route, Request> handler);
-  void unroute(Predicate<String> url, BiConsumer<Route, Request> handler);
+  void unroute(String url, Consumer<Route> handler);
+  void unroute(Pattern url, Consumer<Route> handler);
+  void unroute(Predicate<String> url, Consumer<Route> handler);
   default Deferred<Event<EventType>> waitForEvent(EventType event) {
     return waitForEvent(event, (WaitForEventOptions) null);
   }

--- a/playwright/src/main/java/com/microsoft/playwright/Page.java
+++ b/playwright/src/main/java/com/microsoft/playwright/Page.java
@@ -18,7 +18,7 @@ package com.microsoft.playwright;
 
 import java.nio.file.Path;
 import java.util.*;
-import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
@@ -875,9 +875,9 @@ public interface Page {
     return reload(null);
   }
   Response reload(ReloadOptions options);
-  void route(String url, BiConsumer<Route, Request> handler);
-  void route(Pattern url, BiConsumer<Route, Request> handler);
-  void route(Predicate<String> url, BiConsumer<Route, Request> handler);
+  void route(String url, Consumer<Route> handler);
+  void route(Pattern url, Consumer<Route> handler);
+  void route(Predicate<String> url, Consumer<Route> handler);
   default byte[] screenshot() {
     return screenshot(null);
   }
@@ -953,9 +953,9 @@ public interface Page {
   default void unroute(String url) { unroute(url, null); }
   default void unroute(Pattern url) { unroute(url, null); }
   default void unroute(Predicate<String> url) { unroute(url, null); }
-  void unroute(String url, BiConsumer<Route, Request> handler);
-  void unroute(Pattern url, BiConsumer<Route, Request> handler);
-  void unroute(Predicate<String> url, BiConsumer<Route, Request> handler);
+  void unroute(String url, Consumer<Route> handler);
+  void unroute(Pattern url, Consumer<Route> handler);
+  void unroute(Predicate<String> url, Consumer<Route> handler);
   String url();
   Video video();
   Viewport viewportSize();

--- a/playwright/src/main/java/com/microsoft/playwright/impl/PageImpl.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/PageImpl.java
@@ -24,6 +24,7 @@ import com.microsoft.playwright.*;
 import java.nio.file.Path;
 import java.util.*;
 import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
@@ -147,10 +148,9 @@ public class PageImpl extends ChannelOwner implements Page {
       listeners.notify(EventType.FRAMEDETACHED, frame);
     } else if ("route".equals(event)) {
       Route route = connection.getExistingObject(params.getAsJsonObject("route").get("guid").getAsString());
-      Request request = connection.getExistingObject(params.getAsJsonObject("request").get("guid").getAsString());
-      boolean handled = routes.handle(route, request);
+      boolean handled = routes.handle(route);
       if (!handled) {
-        handled = browserContext.routes.handle(route, request);
+        handled = browserContext.routes.handle(route);
       }
       if (!handled) {
         route.continue_();
@@ -507,21 +507,21 @@ public class PageImpl extends ChannelOwner implements Page {
   }
 
   @Override
-  public void route(String url, BiConsumer<Route, Request> handler) {
+  public void route(String url, Consumer<Route> handler) {
     route(new UrlMatcher(url), handler);
   }
 
   @Override
-  public void route(Pattern url, BiConsumer<Route, Request> handler) {
+  public void route(Pattern url, Consumer<Route> handler) {
     route(new UrlMatcher(url), handler);
   }
 
   @Override
-  public void route(Predicate<String> url, BiConsumer<Route, Request> handler) {
+  public void route(Predicate<String> url, Consumer<Route> handler) {
     route(new UrlMatcher(url), handler);
   }
 
-  private void route(UrlMatcher matcher, BiConsumer<Route, Request> handler) {
+  private void route(UrlMatcher matcher, Consumer<Route> handler) {
     routes.add(matcher, handler);
     if (routes.size() == 1) {
       JsonObject params = new JsonObject();
@@ -649,21 +649,21 @@ public class PageImpl extends ChannelOwner implements Page {
   }
 
   @Override
-  public void unroute(String url, BiConsumer<Route, Request> handler) {
+  public void unroute(String url, Consumer<Route> handler) {
     unroute(new UrlMatcher(url), handler);
   }
 
   @Override
-  public void unroute(Pattern url, BiConsumer<Route, Request> handler) {
+  public void unroute(Pattern url, Consumer<Route> handler) {
     unroute(new UrlMatcher(url), handler);
   }
 
   @Override
-  public void unroute(Predicate<String> url, BiConsumer<Route, Request> handler) {
+  public void unroute(Predicate<String> url, Consumer<Route> handler) {
     unroute(new UrlMatcher(url), handler);
   }
 
-  private void unroute(UrlMatcher matcher, BiConsumer<Route, Request> handler) {
+  private void unroute(UrlMatcher matcher, Consumer<Route> handler) {
     routes.remove(matcher, handler);
     if (routes.size() == 0) {
       JsonObject params = new JsonObject();

--- a/playwright/src/main/java/com/microsoft/playwright/impl/Router.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/Router.java
@@ -22,6 +22,7 @@ import com.microsoft.playwright.Route;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 class Router {
@@ -29,19 +30,19 @@ class Router {
 
   private static class RouteInfo {
     final UrlMatcher matcher;
-    final BiConsumer<Route, Request> handler;
+    final Consumer<Route> handler;
 
-    RouteInfo(UrlMatcher matcher, BiConsumer<Route, Request> handler) {
+    RouteInfo(UrlMatcher matcher, Consumer<Route> handler) {
       this.matcher = matcher;
       this.handler = handler;
     }
   }
 
-  void add(UrlMatcher matcher, BiConsumer<Route, Request> handler) {
+  void add(UrlMatcher matcher, Consumer<Route> handler) {
     routes.add(new RouteInfo(matcher, handler));
   }
 
-  void remove(UrlMatcher matcher, BiConsumer<Route, Request> handler) {
+  void remove(UrlMatcher matcher, Consumer<Route> handler) {
     routes = routes.stream()
       .filter(info -> !info.matcher.equals(matcher) || (handler != null && info.handler != handler))
       .collect(Collectors.toList());
@@ -51,10 +52,10 @@ class Router {
     return routes.size();
   }
 
-  boolean handle(Route route, Request request) {
+  boolean handle(Route route) {
     for (RouteInfo info : routes) {
-      if (info.matcher.test(request.url())) {
-        info.handler.accept(route, request);
+      if (info.matcher.test(route.request().url())) {
+        info.handler.accept(route);
         return true;
       }
     }

--- a/playwright/src/test/java/com/microsoft/playwright/TestBrowserContextRoute.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestBrowserContextRoute.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 
 import static java.util.Arrays.asList;
 import static org.junit.jupiter.api.Assertions.*;
@@ -32,7 +33,7 @@ public class TestBrowserContextRoute extends TestBase {
     BrowserContext context = browser.newContext();
     boolean[] intercepted = {false};
     Page page = context.newPage();
-    context.route("**/empty.html", (route, req) -> {
+    context.route("**/empty.html", route -> {
       intercepted[0] = true;
       Request request = route.request();
       assertTrue(request.url().contains("empty.html"));
@@ -57,20 +58,20 @@ public class TestBrowserContextRoute extends TestBase {
     Page page = context.newPage();
 
     List<Integer> intercepted = new ArrayList<>();
-    BiConsumer<Route, Request>  handler1 = (route, request) -> {
+    Consumer<Route> handler1 = route -> {
       intercepted.add(1);
       route.continue_();
     };
     context.route("**/empty.html", handler1);
-    context.route("**/empty.html", (route, request) -> {
+    context.route("**/empty.html", route -> {
       intercepted.add(2);
       route.continue_();
     });
-    context.route("**/empty.html", (route, request) -> {
+    context.route("**/empty.html", route -> {
       intercepted.add(3);
       route.continue_();
     });
-    context.route("**/*", (route, request) -> {
+    context.route("**/*", route -> {
       intercepted.add(4);
       route.continue_();
     });
@@ -93,11 +94,11 @@ public class TestBrowserContextRoute extends TestBase {
   @Test
   void shouldYieldToPageRoute() {
     BrowserContext context = browser.newContext();
-    context.route("**/empty.html", (route, request) -> {
+    context.route("**/empty.html", route -> {
       route.fulfill(new Route.FulfillResponse().withStatus(200).withBody("context"));
     });
     Page page = context.newPage();
-    page.route("**/empty.html", (route, request) -> {
+    page.route("**/empty.html", route -> {
       route.fulfill(new Route.FulfillResponse().withStatus(200).withBody("page"));
     });
     Response response = page.navigate(server.EMPTY_PAGE);
@@ -109,11 +110,11 @@ public class TestBrowserContextRoute extends TestBase {
   @Test
   void shouldFallBackToContextRoute() {
     BrowserContext context = browser.newContext();
-    context.route("**/empty.html", (route, request) -> {
+    context.route("**/empty.html", route -> {
       route.fulfill(new Route.FulfillResponse().withStatus(200).withBody("context"));
     });
     Page page = context.newPage();
-    page.route("**/non-empty.html", (route, request) -> {
+    page.route("**/non-empty.html", route -> {
       route.fulfill(new Route.FulfillResponse().withStatus(200).withBody("page"));
     });
     Response response = page.navigate(server.EMPTY_PAGE);

--- a/playwright/src/test/java/com/microsoft/playwright/TestNetworkRequest.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestNetworkRequest.java
@@ -81,7 +81,7 @@ public class TestNetworkRequest extends TestBase {
   void shouldNotWorkForARedirectAndInterception() {
     server.setRedirect("/foo.html", "/empty.html");
     List<Request> requests = new ArrayList<>();
-    page.route("**", (route, request) -> {
+    page.route("**", route -> {
       requests.add(route.request());
       route.continue_();
     });
@@ -189,7 +189,7 @@ public class TestNetworkRequest extends TestBase {
     });
     Request[] request = {null};
     page.addListener(REQUEST, event -> request[0] = (Request) event.data());
-    page.route("/post", (route, req) -> route.continue_());
+    page.route("/post", route -> route.continue_());
     page.evaluate("async () => {\n" +
       "  await fetch('./post', { method: 'POST', body: new Uint8Array(Array.from(Array(256).keys())) });\n" +
       "}");

--- a/playwright/src/test/java/com/microsoft/playwright/TestPopup.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestPopup.java
@@ -56,7 +56,7 @@ public class TestPopup extends TestBase {
     page.navigate(server.EMPTY_PAGE);
     page.setContent("<a target=_blank rel=noopener href='empty.html'>link</a>");
     boolean[] intercepted = {false};
-    context.route("**/empty.html", (route, request) -> {
+    context.route("**/empty.html", route -> {
       route.continue_();
       intercepted[0] = true;
     });
@@ -166,7 +166,7 @@ public class TestPopup extends TestBase {
     Page page = context.newPage();
     page.navigate(server.EMPTY_PAGE);
     boolean[] intercepted = {false};
-    context.route("**/empty.html", (route, request) -> {
+    context.route("**/empty.html", route -> {
       route.continue_();
       intercepted[0] = true;
     });

--- a/playwright/src/test/java/com/microsoft/playwright/TestRequestContinue.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestRequestContinue.java
@@ -32,13 +32,13 @@ public class TestRequestContinue extends TestBase {
 
   @Test
   void shouldWork() {
-    page.route("**/*", (route, request) -> route.continue_());
+    page.route("**/*", route -> route.continue_());
     page.navigate(server.EMPTY_PAGE);
   }
 
   @Test
   void shouldAmendHTTPHeaders() throws ExecutionException, InterruptedException {
-    page.route("**/*", (route, request) -> {
+    page.route("**/*", route -> {
       Map<String, String> headers = new HashMap<>(route.request().headers());
       headers.put("FOO", "bar");
       route.continue_(new Route.ContinueOverrides().withHeaders(headers));
@@ -53,7 +53,7 @@ public class TestRequestContinue extends TestBase {
   void shouldAmendMethod() throws ExecutionException, InterruptedException {
     Future<Server.Request> sRequest = server.waitForRequest("/sleep.zzz");
     page.navigate(server.EMPTY_PAGE);
-    page.route("**/*", (route, request) -> route.continue_(new Route.ContinueOverrides().withMethod("POST")));
+    page.route("**/*", route -> route.continue_(new Route.ContinueOverrides().withMethod("POST")));
     Future<Server.Request> request = server.waitForRequest("/sleep.zzz");
     page.evaluate("() => fetch('/sleep.zzz')");
     assertEquals("POST", request.get().method);
@@ -63,7 +63,7 @@ public class TestRequestContinue extends TestBase {
   @Test
   void shouldAmendMethodOnMainRequest() throws ExecutionException, InterruptedException {
     Future<Server.Request> request = server.waitForRequest("/empty.html");
-    page.route("**/*", (route, req) -> route.continue_(new Route.ContinueOverrides().withMethod("POST")));
+    page.route("**/*", route -> route.continue_(new Route.ContinueOverrides().withMethod("POST")));
     page.navigate(server.EMPTY_PAGE);
     assertEquals("POST", request.get().method);
   }
@@ -71,7 +71,7 @@ public class TestRequestContinue extends TestBase {
   @Test
   void shouldAmendPostData() throws ExecutionException, InterruptedException {
     page.navigate(server.EMPTY_PAGE);
-    page.route("**/*", (route, request) -> {
+    page.route("**/*", route -> {
       route.continue_(new Route.ContinueOverrides().withPostData("doggo"));
     });
     Future<Server.Request> serverRequest = server.waitForRequest("/sleep.zzz");
@@ -82,7 +82,7 @@ public class TestRequestContinue extends TestBase {
   @Test
   void shouldAmendUtf8PostData() throws ExecutionException, InterruptedException {
     page.navigate(server.EMPTY_PAGE);
-    page.route("**/*", (route, request) -> {
+    page.route("**/*", route -> {
       route.continue_(new Route.ContinueOverrides().withPostData("пушкин"));
     });
     Future<Server.Request> serverRequest = server.waitForRequest("/sleep.zzz");
@@ -94,7 +94,7 @@ public class TestRequestContinue extends TestBase {
   @Test
   void shouldAmendLongerPostData() throws ExecutionException, InterruptedException {
     page.navigate(server.EMPTY_PAGE);
-    page.route("**/*", (route, request) -> {
+    page.route("**/*", route -> {
       route.continue_(new Route.ContinueOverrides().withPostData("doggo-is-longer-than-birdy"));
     });
     Future<Server.Request> serverRequest = server.waitForRequest("/sleep.zzz");
@@ -110,7 +110,7 @@ public class TestRequestContinue extends TestBase {
     for (int i = 0; i < arr.length; i++) {
       arr[i] = (byte) i;
     }
-    page.route("**/*", (route, request) -> {
+    page.route("**/*", route -> {
       route.continue_(new Route.ContinueOverrides().withPostData(arr));
     });
     Future<Server.Request> serverRequest = server.waitForRequest("/sleep.zzz");

--- a/playwright/src/test/java/com/microsoft/playwright/TestRequestFulfill.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestRequestFulfill.java
@@ -29,7 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class TestRequestFulfill extends TestBase {
   @Test
   void shouldWork() {
-    page.route("**/*", (route, request) -> {
+    page.route("**/*", route -> {
       route.fulfill(new Route.FulfillResponse()
         .withStatus(201)
         .withContentType("text/html")
@@ -44,7 +44,7 @@ public class TestRequestFulfill extends TestBase {
 
   @Test
   void shouldWorkWithStatusCode422() {
-    page.route("**/*", (route, request) -> {
+    page.route("**/*", route -> {
       route.fulfill(new Route.FulfillResponse()
         .withStatus(422)
         .withBody("Yo, page!"));
@@ -58,7 +58,7 @@ public class TestRequestFulfill extends TestBase {
   @Test
   void shouldAllowMockingBinaryResponses() {
 // TODO:    test.skip(browserName === "firefox" && headful, "// Firefox headful produces a different image.");
-    page.route("**/*", (route, request) -> {
+    page.route("**/*", route -> {
       byte[] imageBuffer;
       try {
         imageBuffer = Files.readAllBytes(new File("src/test/resources/pptr.png").toPath());
@@ -84,7 +84,7 @@ public class TestRequestFulfill extends TestBase {
   void shouldAllowMockingSvgWithCharset() {
     // TODO: test.skip(browserName === "firefox" && headful, "// Firefox headful produces a different image.");
     // Firefox headful produces a different image.
-    page.route("**/*", (route, request) -> {
+    page.route("**/*", route -> {
       route.fulfill(new Route.FulfillResponse()
         .withContentType("image/svg+xml ; charset=utf-8")
         .withBody("<svg width=\"50\" height=\"50\" version=\"1.1\" xmlns=\"http://www.w3.org/2000/svg\"><rect x=\"10\" y=\"10\" width=\"30\" height=\"30\" stroke=\"black\" fill=\"transparent\" stroke-width=\"5\"/></svg>"));


### PR DESCRIPTION
`Route` already gives access to `Request` so passing it as second argument to the route handlers is unnecessary.