### PR TITLE
devops: add basic Dockerfile

### DIFF
--- a/Dockerfile.focal
+++ b/Dockerfile.focal
@@ -1,0 +1,69 @@
+FROM ubuntu:focal
+
+# === INSTALL BROWSER DEPENDENCIES ===
+
+# Install WebKit dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libwoff1 \
+    libopus0 \
+    libwebp6 \
+    libwebpdemux2 \
+    libenchant1c2a \
+    libgudev-1.0-0 \
+    libsecret-1-0 \
+    libhyphen0 \
+    libgdk-pixbuf2.0-0 \
+    libegl1 \
+    libnotify4 \
+    libxslt1.1 \
+    libevent-2.1-7 \
+    libgles2 \
+    libxcomposite1 \
+    libatk1.0-0 \
+    libatk-bridge2.0-0 \
+    libepoxy0 \
+    libgtk-3-0 \
+    libharfbuzz-icu0
+
+# Install gstreamer and plugins to support video playback in WebKit.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libgstreamer-gl1.0-0 \
+    libgstreamer-plugins-bad1.0-0 \
+    gstreamer1.0-plugins-good \
+    gstreamer1.0-libav
+
+# Install Chromium dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libnss3 \
+    libxss1 \
+    libasound2 \
+    fonts-noto-color-emoji \
+    libxtst6
+
+# Install Firefox dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libdbus-glib-1-2 \
+    libxt6
+
+# Install ffmpeg to bring in audio and video codecs necessary for playing videos in Firefox.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ffmpeg
+
+# (Optional) Install XVFB if there's a need to run browsers in headful mode
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    xvfb
+
+# === INSTALL JDK and Maven ===
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    openjdk-8-jdk maven
+
+# Install utilities required for downloading driver
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl unzip
+
+# === INSTALL Playwright-java ===
+
+RUN mkdir /tmp/pw-java
+COPY . /tmp/pw-java
+RUN cd /tmp/pw-java && ./scripts/download_driver.sh && mvn install -D skipTests --no-transfer-progress


### PR DESCRIPTION
The file is based on https://github.com/microsoft/playwright/blob/master/docs/docker/Dockerfile.focal and replaces node dependencies with JDK and Maven.