### PR TITLE
fix: skip javadoc generation for .impl package

### DIFF
--- a/playwright/pom.xml
+++ b/playwright/pom.xml
@@ -32,6 +32,7 @@
           <subpackages>com.microsoft.playwright</subpackages>
           <excludePackageNames>com.microsoft.playwright.impl</excludePackageNames>
           <additionalOptions>--allow-script-in-comments</additionalOptions>
+          <failOnError>false</failOnError>
         </configuration>
         <executions>
           <execution>

--- a/playwright/pom.xml
+++ b/playwright/pom.xml
@@ -29,10 +29,9 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
-          <source>8</source>
-          <!--excludePackageNames>com.microsoft.playwright.impl</excludePackageNames -->
+          <subpackages>com.microsoft.playwright</subpackages>
+          <excludePackageNames>com.microsoft.playwright.impl</excludePackageNames>
           <additionalOptions>--allow-script-in-comments</additionalOptions>
-          <failOnError>false</failOnError>
         </configuration>
         <executions>
           <execution>


### PR DESCRIPTION
Having `<source>8</source>` in the javadoc plugin config results in very bizarre behavior. It wouldn't respect excludePackageNames tag, or even crash with assertion failure. Also excludePackageNames only works in conjunction with subpackages. 