### PR TITLE
docs: correct a document error and Fix an error about executing ./install_local_driver.sh

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ cd playwright-java
 2. Run the following script to download playwright-cli binary for your platform into `driver/src/main/resources/driver/` directory. It will also install Playwright and download browser binaries for Chromium, Firefox and WebKit.
 
 ```bash
-scripts/download_driver.sh
+scripts/install_local_driver.sh
 ```
 
 Names of published driver archives can be found at https://github.com/microsoft/playwright-cli/actions


### PR DESCRIPTION
1. Problem one
[Detail] docs(CONTRIBUTING.md): correct the filename of playwright-cli binary download script. It should be 'scripts/install_local_driver.sh' now instead of 'scripts/download_driver.sh'.

2. Problem two
[Detail] fix: an error 'No such file or directory' occurred when execute ./install_local_driver.sh. The detail error is './install_local_driver.sh: line 12: cd: ../driver/src/main/resources: No such file or directory', and its reason is that there is no 'resources' directory in the module 'driver', just create it and problem solved.