### PR TITLE
chore: set example encoding to utf-8

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -8,6 +8,9 @@
   <artifactId>examples</artifactId>
   <version>0.1-SNAPSHOT</version>
   <name>Playwright Client Examples</name>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
   <dependencies>
     <dependency>
       <groupId>com.microsoft.playwright</groupId>


### PR DESCRIPTION
It avoid the following warning:
  
[WARNING] Using platform encoding (UTF-8 actually) to copy filtered resources, i.e. build is platform dependent!
