### PR TITLE
fix: java main process will be suspended when browsers installation t…

### DIFF
--- a/driver-bundle/src/main/java/com/microsoft/playwright/impl/DriverJar.java
+++ b/driver-bundle/src/main/java/com/microsoft/playwright/impl/DriverJar.java
@@ -41,6 +41,7 @@ public class DriverJar extends Driver {
     Process p = pb.start();
     boolean result = p.waitFor(10, TimeUnit.MINUTES);
     if (!result) {
+      p.destroy();
       throw new RuntimeException("Timed out waiting for browsers to install");
     }
   }


### PR DESCRIPTION
Hi, I meet the `java.lang.RuntimeException: Timed out waiting for browsers to install` when I am running `mvn test`, but I find that the main process (java process) didn't exit immediately when this exception is thrown, because its subprocess (playwright-cli process) is still alive at this time. Maybe java process will exit until the subprocess finish executing, but it could take a while and cause java process to hang up in this duration.

Maybe I think we should shutdown the subprocess manually in this exception case so that the java process can exit immediately instead of waiting.