### PR TITLE
chore: give more friendly exception info while create driver

### DIFF
--- a/driver-bundle/src/main/java/com/microsoft/playwright/impl/DriverJar.java
+++ b/driver-bundle/src/main/java/com/microsoft/playwright/impl/DriverJar.java
@@ -35,6 +35,9 @@ public class DriverJar extends Driver {
 
   private void installBrowsers() throws IOException, InterruptedException {
     Path driver = driverTempDir.resolve("playwright-cli");
+    if (!Files.exists(driver)) {
+      throw new RuntimeException("Failed to find playwright-cli");
+    }
     ProcessBuilder pb = new ProcessBuilder(driver.toString(), "install");
     pb.redirectError(ProcessBuilder.Redirect.INHERIT);
     pb.redirectOutput(ProcessBuilder.Redirect.INHERIT);

--- a/driver-bundle/src/main/java/com/microsoft/playwright/impl/DriverJar.java
+++ b/driver-bundle/src/main/java/com/microsoft/playwright/impl/DriverJar.java
@@ -34,7 +34,8 @@ public class DriverJar extends Driver {
   }
 
   private void installBrowsers() throws IOException, InterruptedException {
-    Path driver = driverTempDir.resolve("playwright-cli");
+    String cliFileName = super.cliFileName();
+    Path driver = driverTempDir.resolve(cliFileName);
     if (!Files.exists(driver)) {
       throw new RuntimeException("Failed to find playwright-cli");
     }

--- a/driver/src/main/java/com/microsoft/playwright/impl/Driver.java
+++ b/driver/src/main/java/com/microsoft/playwright/impl/Driver.java
@@ -43,7 +43,7 @@ public abstract class Driver {
       try {
         instance = createDriver();
       } catch (Exception exception) {
-        throw new RuntimeException("Failed to find playwright-cli", exception);
+        throw new RuntimeException("Failed to create driver", exception);
       }
     }
     String name = System.getProperty("os.name").toLowerCase().contains("windows") ?

--- a/driver/src/main/java/com/microsoft/playwright/impl/Driver.java
+++ b/driver/src/main/java/com/microsoft/playwright/impl/Driver.java
@@ -46,9 +46,13 @@ public abstract class Driver {
         throw new RuntimeException("Failed to create driver", exception);
       }
     }
-    String name = System.getProperty("os.name").toLowerCase().contains("windows") ?
-      "playwright-cli.exe" : "playwright-cli";
+    String name = instance.cliFileName();
     return instance.driverDir().resolve(name);
+  }
+
+  protected String cliFileName() {
+    return System.getProperty("os.name").toLowerCase().contains("windows") ?
+      "playwright-cli.exe" : "playwright-cli";
   }
 
   private static Driver createDriver() throws Exception {


### PR DESCRIPTION
Hi, I find an exception message which make me a little confused, so I try to improve it. Here are the details:

I meet the exception `java.lang.RuntimeException: Failed to find playwright-cli` when run `mvn test`, and another exception followed by this exception is `java.lang.RuntimeException: Timed out waiting for browsers to install`, just like this:
![image](https://user-images.githubusercontent.com/56674109/103449943-3dee0780-4cea-11eb-80d4-61198320db27.png)

But the truth is that `playwright-cli` has already exists, the real exception is due to timeout waiting for browser to install.

Maybe it could be improved here and make it easily understood. We can give the exception and message `Failed to find playwright-cli` just only where it could happen, and as for the place where this exception message was given before, we can give the exception message like `Failed to create driver`, just like this screenshot (not really exception, I mocked it), or you could learn about more details from my commit.
![image](https://user-images.githubusercontent.com/56674109/103450086-30d21800-4cec-11eb-8bb5-4128e74c4005.png)

Now I think there is more friendly exception info and less confusion to understand where the real exception occurred.
