### PR TITLE
chore: bump maven dependency version to 0.172.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ To run Playwright simply add following dependency to your Maven project:
 <dependency>
   <groupId>com.microsoft.playwright</groupId>
   <artifactId>playwright</artifactId>
-  <version>0.171.0</version>
+  <version>0.172.3</version>
 </dependency>
 ```
 

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.microsoft.playwright</groupId>
       <artifactId>playwright</artifactId>
-      <version>0.171.0</version>
+      <version>0.172.3</version>
     </dependency>
   </dependencies>
   <build>


### PR DESCRIPTION
Bump maven dependency version to 0.172.3 in `README.md` and module `example/pom.xml`.