### PR TITLE
fix(api): redo waitFor* methods

### DIFF
--- a/playwright/src/main/java/com/microsoft/playwright/BrowserContext.java
+++ b/playwright/src/main/java/com/microsoft/playwright/BrowserContext.java
@@ -91,14 +91,14 @@ public interface BrowserContext {
     }
   }
 
-  class WaitForEventOptions {
+  class FutureEventOptions {
     public Integer timeout;
     public Predicate<Event<EventType>> predicate;
-    public WaitForEventOptions withTimeout(int millis) {
+    public FutureEventOptions withTimeout(int millis) {
       timeout = millis;
       return this;
     }
-    public WaitForEventOptions withPredicate(Predicate<Event<EventType>> predicate) {
+    public FutureEventOptions withPredicate(Predicate<Event<EventType>> predicate) {
       this.predicate = predicate;
       return this;
     }
@@ -433,13 +433,13 @@ public interface BrowserContext {
    * @param handler Optional handler function used to register a routing with {@code browserContext.route(url, handler)}.
    */
   void unroute(Predicate<String> url, Consumer<Route> handler);
-  default Deferred<Event<EventType>> waitForEvent(EventType event) {
-    return waitForEvent(event, (WaitForEventOptions) null);
+  default Deferred<Event<EventType>> futureEvent(EventType event) {
+    return futureEvent(event, (FutureEventOptions) null);
   }
-  default Deferred<Event<EventType>> waitForEvent(EventType event, Predicate<Event<EventType>> predicate) {
-    WaitForEventOptions options = new WaitForEventOptions();
+  default Deferred<Event<EventType>> futureEvent(EventType event, Predicate<Event<EventType>> predicate) {
+    FutureEventOptions options = new FutureEventOptions();
     options.predicate = predicate;
-    return waitForEvent(event, options);
+    return futureEvent(event, options);
   }
   /**
    * Waits for event to fire and passes its value into the predicate function. Returns when the predicate returns truthy value. Will throw an error if the context closes before the event is fired. Returns the event data value.
@@ -447,6 +447,6 @@ public interface BrowserContext {
    * 
    * @param event Event name, same one would pass into {@code browserContext.on(event)}.
    */
-  Deferred<Event<EventType>> waitForEvent(EventType event, WaitForEventOptions options);
+  Deferred<Event<EventType>> futureEvent(EventType event, FutureEventOptions options);
 }
 

--- a/playwright/src/main/java/com/microsoft/playwright/ElementHandle.java
+++ b/playwright/src/main/java/com/microsoft/playwright/ElementHandle.java
@@ -921,8 +921,8 @@ public interface ElementHandle extends JSHandle {
    * When all steps combined have not finished during the specified {@code timeout}, this method rejects with a TimeoutError. Passing zero timeout disables this.
    */
   void uncheck(UncheckOptions options);
-  default Deferred<Void> waitForElementState(ElementState state) {
-    return waitForElementState(state, null);
+  default void waitForElementState(ElementState state) {
+    waitForElementState(state, null);
   }
   /**
    * Returns the element satisfies the {@code state}.
@@ -942,8 +942,8 @@ public interface ElementHandle extends JSHandle {
    * If the element does not satisfy the condition for the {@code timeout} milliseconds, this method will throw.
    * @param state A state to wait for, see below for more details.
    */
-  Deferred<Void> waitForElementState(ElementState state, WaitForElementStateOptions options);
-  default Deferred<ElementHandle> waitForSelector(String selector) {
+  void waitForElementState(ElementState state, WaitForElementStateOptions options);
+  default ElementHandle waitForSelector(String selector) {
     return waitForSelector(selector, null);
   }
   /**
@@ -956,6 +956,6 @@ public interface ElementHandle extends JSHandle {
    * <strong>NOTE</strong> This method does not work across navigations, use {@code page.waitForSelector(selector[, options])} instead.
    * @param selector A selector to query for. See working with selectors for more details.
    */
-  Deferred<ElementHandle> waitForSelector(String selector, WaitForSelectorOptions options);
+  ElementHandle waitForSelector(String selector, WaitForSelectorOptions options);
 }
 

--- a/playwright/src/main/java/com/microsoft/playwright/Frame.java
+++ b/playwright/src/main/java/com/microsoft/playwright/Frame.java
@@ -1199,10 +1199,10 @@ public interface Frame {
    * Returns frame's url.
    */
   String url();
-  default Deferred<JSHandle> waitForFunction(String pageFunction, Object arg) {
+  default JSHandle waitForFunction(String pageFunction, Object arg) {
     return waitForFunction(pageFunction, arg, null);
   }
-  default Deferred<JSHandle> waitForFunction(String pageFunction) {
+  default JSHandle waitForFunction(String pageFunction) {
     return waitForFunction(pageFunction, null);
   }
   /**
@@ -1216,12 +1216,12 @@ public interface Frame {
    * @param pageFunction Function to be evaluated in browser context
    * @param arg Optional argument to pass to {@code pageFunction}
    */
-  Deferred<JSHandle> waitForFunction(String pageFunction, Object arg, WaitForFunctionOptions options);
-  default Deferred<Void> waitForLoadState(LoadState state) {
-    return waitForLoadState(state, null);
+  JSHandle waitForFunction(String pageFunction, Object arg, WaitForFunctionOptions options);
+  default void waitForLoadState(LoadState state) {
+    waitForLoadState(state, null);
   }
-  default Deferred<Void> waitForLoadState() {
-    return waitForLoadState(null);
+  default void waitForLoadState() {
+    waitForLoadState(null);
   }
   /**
    * Waits for the required load state to be reached.
@@ -1234,7 +1234,7 @@ public interface Frame {
    *  - {@code 'domcontentloaded'} - wait for the {@code DOMContentLoaded} event to be fired.
    *  - {@code 'networkidle'} - wait until there are no network connections for at least {@code 500} ms.
    */
-  Deferred<Void> waitForLoadState(LoadState state, WaitForLoadStateOptions options);
+  void waitForLoadState(LoadState state, WaitForLoadStateOptions options);
   default Deferred<Response> waitForNavigation() {
     return waitForNavigation(null);
   }
@@ -1246,7 +1246,7 @@ public interface Frame {
    * <strong>NOTE</strong> Usage of the History API to change the URL is considered a navigation.
    */
   Deferred<Response> waitForNavigation(WaitForNavigationOptions options);
-  default Deferred<ElementHandle> waitForSelector(String selector) {
+  default ElementHandle waitForSelector(String selector) {
     return waitForSelector(selector, null);
   }
   /**
@@ -1259,13 +1259,13 @@ public interface Frame {
    * 
    * @param selector A selector to query for. See working with selectors for more details.
    */
-  Deferred<ElementHandle> waitForSelector(String selector, WaitForSelectorOptions options);
+  ElementHandle waitForSelector(String selector, WaitForSelectorOptions options);
   /**
    * Waits for the given {@code timeout} in milliseconds.
    * <p>
    * Note that {@code frame.waitForTimeout()} should only be used for debugging. Tests using the timer in production are going to be flaky. Use signals such as network events, selectors becoming visible and others instead.
    * @param timeout A timeout to wait for
    */
-  Deferred<Void> waitForTimeout(int timeout);
+  void waitForTimeout(int timeout);
 }
 

--- a/playwright/src/main/java/com/microsoft/playwright/Frame.java
+++ b/playwright/src/main/java/com/microsoft/playwright/Frame.java
@@ -646,7 +646,7 @@ public interface Frame {
       return this;
     }
   }
-  class WaitForNavigationOptions {
+  class FutureNavigationOptions {
     /**
      * Maximum operation time in milliseconds, defaults to 30 seconds, pass {@code 0} to disable timeout. The default value can be changed by using the {@code browserContext.setDefaultNavigationTimeout(timeout)}, {@code browserContext.setDefaultTimeout(timeout)}, {@code page.setDefaultNavigationTimeout(timeout)} or {@code page.setDefaultTimeout(timeout)} methods.
      */
@@ -665,23 +665,23 @@ public interface Frame {
      */
     public LoadState waitUntil;
 
-    public WaitForNavigationOptions withTimeout(Integer timeout) {
+    public FutureNavigationOptions withTimeout(Integer timeout) {
       this.timeout = timeout;
       return this;
     }
-    public WaitForNavigationOptions withUrl(String glob) {
+    public FutureNavigationOptions withUrl(String glob) {
       this.glob = glob;
       return this;
     }
-    public WaitForNavigationOptions withUrl(Pattern pattern) {
+    public FutureNavigationOptions withUrl(Pattern pattern) {
       this.pattern = pattern;
       return this;
     }
-    public WaitForNavigationOptions withUrl(Predicate<String> predicate) {
+    public FutureNavigationOptions withUrl(Predicate<String> predicate) {
       this.predicate = predicate;
       return this;
     }
-    public WaitForNavigationOptions withWaitUntil(LoadState waitUntil) {
+    public FutureNavigationOptions withWaitUntil(LoadState waitUntil) {
       this.waitUntil = waitUntil;
       return this;
     }
@@ -1235,8 +1235,8 @@ public interface Frame {
    *  - {@code 'networkidle'} - wait until there are no network connections for at least {@code 500} ms.
    */
   void waitForLoadState(LoadState state, WaitForLoadStateOptions options);
-  default Deferred<Response> waitForNavigation() {
-    return waitForNavigation(null);
+  default Deferred<Response> futureNavigation() {
+    return futureNavigation(null);
   }
   /**
    * Returns the main resource response. In case of multiple redirects, the navigation will resolve with the response of the last redirect. In case of navigation to a different anchor or navigation due to History API usage, the navigation will resolve with {@code null}.
@@ -1245,7 +1245,7 @@ public interface Frame {
    * <p>
    * <strong>NOTE</strong> Usage of the History API to change the URL is considered a navigation.
    */
-  Deferred<Response> waitForNavigation(WaitForNavigationOptions options);
+  Deferred<Response> futureNavigation(FutureNavigationOptions options);
   default ElementHandle waitForSelector(String selector) {
     return waitForSelector(selector, null);
   }

--- a/playwright/src/main/java/com/microsoft/playwright/Page.java
+++ b/playwright/src/main/java/com/microsoft/playwright/Page.java
@@ -69,14 +69,14 @@ public interface Page {
     String stack();
   }
 
-  class WaitForEventOptions {
+  class FutureEventOptions {
     public Integer timeout;
     public Predicate<Event<EventType>> predicate;
-    public WaitForEventOptions withTimeout(int millis) {
+    public FutureEventOptions withTimeout(int millis) {
       timeout = millis;
       return this;
     }
-    public WaitForEventOptions withPredicate(Predicate<Event<EventType>> predicate) {
+    public FutureEventOptions withPredicate(Predicate<Event<EventType>> predicate) {
       this.predicate = predicate;
       return this;
     }
@@ -1922,13 +1922,13 @@ public interface Page {
    */
   Video video();
   Viewport viewportSize();
-  default Deferred<Event<EventType>> waitForEvent(EventType event) {
-    return waitForEvent(event, (WaitForEventOptions) null);
+  default Deferred<Event<EventType>> futureEvent(EventType event) {
+    return futureEvent(event, (FutureEventOptions) null);
   }
-  default Deferred<Event<EventType>> waitForEvent(EventType event, Predicate<Event<EventType>> predicate) {
-    WaitForEventOptions options = new WaitForEventOptions();
+  default Deferred<Event<EventType>> futureEvent(EventType event, Predicate<Event<EventType>> predicate) {
+    FutureEventOptions options = new FutureEventOptions();
     options.predicate = predicate;
-    return waitForEvent(event, options);
+    return futureEvent(event, options);
   }
   /**
    * Returns the event data value.
@@ -1936,7 +1936,7 @@ public interface Page {
    * Waits for event to fire and passes its value into the predicate function. Returns when the predicate returns truthy value. Will throw an error if the page is closed before the event is fired.
    * @param event Event name, same one would pass into {@code page.on(event)}.
    */
-  Deferred<Event<EventType>> waitForEvent(EventType event, WaitForEventOptions options);
+  Deferred<Event<EventType>> futureEvent(EventType event, FutureEventOptions options);
   default JSHandle waitForFunction(String pageFunction, Object arg) {
     return waitForFunction(pageFunction, arg, null);
   }

--- a/playwright/src/main/java/com/microsoft/playwright/Page.java
+++ b/playwright/src/main/java/com/microsoft/playwright/Page.java
@@ -1080,7 +1080,7 @@ public interface Page {
       return this;
     }
   }
-  class WaitForNavigationOptions {
+  class FutureNavigationOptions {
     /**
      * Maximum operation time in milliseconds, defaults to 30 seconds, pass {@code 0} to disable timeout. The default value can be changed by using the {@code browserContext.setDefaultNavigationTimeout(timeout)}, {@code browserContext.setDefaultTimeout(timeout)}, {@code page.setDefaultNavigationTimeout(timeout)} or {@code page.setDefaultTimeout(timeout)} methods.
      */
@@ -1099,23 +1099,23 @@ public interface Page {
      */
     public Frame.LoadState waitUntil;
 
-    public WaitForNavigationOptions withTimeout(Integer timeout) {
+    public FutureNavigationOptions withTimeout(Integer timeout) {
       this.timeout = timeout;
       return this;
     }
-    public WaitForNavigationOptions withUrl(String glob) {
+    public FutureNavigationOptions withUrl(String glob) {
       this.glob = glob;
       return this;
     }
-    public WaitForNavigationOptions withUrl(Pattern pattern) {
+    public FutureNavigationOptions withUrl(Pattern pattern) {
       this.pattern = pattern;
       return this;
     }
-    public WaitForNavigationOptions withUrl(Predicate<String> predicate) {
+    public FutureNavigationOptions withUrl(Predicate<String> predicate) {
       this.predicate = predicate;
       return this;
     }
-    public WaitForNavigationOptions withWaitUntil(Frame.LoadState waitUntil) {
+    public FutureNavigationOptions withWaitUntil(Frame.LoadState waitUntil) {
       this.waitUntil = waitUntil;
       return this;
     }
@@ -1975,8 +1975,8 @@ public interface Page {
    *  - {@code 'networkidle'} - wait until there are no network connections for at least {@code 500} ms.
    */
   void waitForLoadState(LoadState state, WaitForLoadStateOptions options);
-  default Deferred<Response> waitForNavigation() {
-    return waitForNavigation(null);
+  default Deferred<Response> futureNavigation() {
+    return futureNavigation(null);
   }
   /**
    * Returns the main resource response. In case of multiple redirects, the navigation will resolve with the response of the last redirect. In case of navigation to a different anchor or navigation due to History API usage, the navigation will resolve with {@code null}.
@@ -1987,7 +1987,7 @@ public interface Page {
    * <p>
    * Shortcut for main frame's {@code frame.waitForNavigation([options])}.
    */
-  Deferred<Response> waitForNavigation(WaitForNavigationOptions options);
+  Deferred<Response> futureNavigation(FutureNavigationOptions options);
   default Deferred<Request> waitForRequest(String urlGlob) { return waitForRequest(urlGlob, null); }
   default Deferred<Request> waitForRequest(Pattern urlPattern) { return waitForRequest(urlPattern, null); }
   default Deferred<Request> waitForRequest(Predicate<String> urlPredicate) { return waitForRequest(urlPredicate, null); }

--- a/playwright/src/main/java/com/microsoft/playwright/Page.java
+++ b/playwright/src/main/java/com/microsoft/playwright/Page.java
@@ -1120,24 +1120,24 @@ public interface Page {
       return this;
     }
   }
-  class WaitForRequestOptions {
+  class FutureRequestOptions {
     /**
      * Maximum wait time in milliseconds, defaults to 30 seconds, pass {@code 0} to disable the timeout. The default value can be changed by using the {@code page.setDefaultTimeout(timeout)} method.
      */
     public Integer timeout;
 
-    public WaitForRequestOptions withTimeout(Integer timeout) {
+    public FutureRequestOptions withTimeout(Integer timeout) {
       this.timeout = timeout;
       return this;
     }
   }
-  class WaitForResponseOptions {
+  class FutureResponseOptions {
     /**
      * Maximum wait time in milliseconds, defaults to 30 seconds, pass {@code 0} to disable the timeout. The default value can be changed by using the {@code browserContext.setDefaultTimeout(timeout)} or {@code page.setDefaultTimeout(timeout)} methods.
      */
     public Integer timeout;
 
-    public WaitForResponseOptions withTimeout(Integer timeout) {
+    public FutureResponseOptions withTimeout(Integer timeout) {
       this.timeout = timeout;
       return this;
     }
@@ -1988,18 +1988,18 @@ public interface Page {
    * Shortcut for main frame's {@code frame.waitForNavigation([options])}.
    */
   Deferred<Response> futureNavigation(FutureNavigationOptions options);
-  default Deferred<Request> waitForRequest(String urlGlob) { return waitForRequest(urlGlob, null); }
-  default Deferred<Request> waitForRequest(Pattern urlPattern) { return waitForRequest(urlPattern, null); }
-  default Deferred<Request> waitForRequest(Predicate<String> urlPredicate) { return waitForRequest(urlPredicate, null); }
-  Deferred<Request> waitForRequest(String urlGlob, WaitForRequestOptions options);
-  Deferred<Request> waitForRequest(Pattern urlPattern, WaitForRequestOptions options);
-  Deferred<Request> waitForRequest(Predicate<String> urlPredicate, WaitForRequestOptions options);
-  default Deferred<Response> waitForResponse(String urlGlob) { return waitForResponse(urlGlob, null); }
-  default Deferred<Response> waitForResponse(Pattern urlPattern) { return waitForResponse(urlPattern, null); }
-  default Deferred<Response> waitForResponse(Predicate<String> urlPredicate) { return waitForResponse(urlPredicate, null); }
-  Deferred<Response> waitForResponse(String urlGlob, WaitForResponseOptions options);
-  Deferred<Response> waitForResponse(Pattern urlPattern, WaitForResponseOptions options);
-  Deferred<Response> waitForResponse(Predicate<String> urlPredicate, WaitForResponseOptions options);
+  default Deferred<Request> futureRequest(String urlGlob) { return futureRequest(urlGlob, null); }
+  default Deferred<Request> futureRequest(Pattern urlPattern) { return futureRequest(urlPattern, null); }
+  default Deferred<Request> futureRequest(Predicate<String> urlPredicate) { return futureRequest(urlPredicate, null); }
+  Deferred<Request> futureRequest(String urlGlob, FutureRequestOptions options);
+  Deferred<Request> futureRequest(Pattern urlPattern, FutureRequestOptions options);
+  Deferred<Request> futureRequest(Predicate<String> urlPredicate, FutureRequestOptions options);
+  default Deferred<Response> futureResponse(String urlGlob) { return futureResponse(urlGlob, null); }
+  default Deferred<Response> futureResponse(Pattern urlPattern) { return futureResponse(urlPattern, null); }
+  default Deferred<Response> futureResponse(Predicate<String> urlPredicate) { return futureResponse(urlPredicate, null); }
+  Deferred<Response> futureResponse(String urlGlob, FutureResponseOptions options);
+  Deferred<Response> futureResponse(Pattern urlPattern, FutureResponseOptions options);
+  Deferred<Response> futureResponse(Predicate<String> urlPredicate, FutureResponseOptions options);
   default ElementHandle waitForSelector(String selector) {
     return waitForSelector(selector, null);
   }

--- a/playwright/src/main/java/com/microsoft/playwright/Page.java
+++ b/playwright/src/main/java/com/microsoft/playwright/Page.java
@@ -1937,10 +1937,10 @@ public interface Page {
    * @param event Event name, same one would pass into {@code page.on(event)}.
    */
   Deferred<Event<EventType>> waitForEvent(EventType event, WaitForEventOptions options);
-  default Deferred<JSHandle> waitForFunction(String pageFunction, Object arg) {
+  default JSHandle waitForFunction(String pageFunction, Object arg) {
     return waitForFunction(pageFunction, arg, null);
   }
-  default Deferred<JSHandle> waitForFunction(String pageFunction) {
+  default JSHandle waitForFunction(String pageFunction) {
     return waitForFunction(pageFunction, null);
   }
   /**
@@ -1954,12 +1954,12 @@ public interface Page {
    * @param pageFunction Function to be evaluated in browser context
    * @param arg Optional argument to pass to {@code pageFunction}
    */
-  Deferred<JSHandle> waitForFunction(String pageFunction, Object arg, WaitForFunctionOptions options);
-  default Deferred<Void> waitForLoadState(LoadState state) {
-    return waitForLoadState(state, null);
+  JSHandle waitForFunction(String pageFunction, Object arg, WaitForFunctionOptions options);
+  default void waitForLoadState(LoadState state) {
+    waitForLoadState(state, null);
   }
-  default Deferred<Void> waitForLoadState() {
-    return waitForLoadState(null);
+  default void waitForLoadState() {
+    waitForLoadState(null);
   }
   /**
    * Returns when the required load state has been reached.
@@ -1974,7 +1974,7 @@ public interface Page {
    *  - {@code 'domcontentloaded'} - wait for the {@code DOMContentLoaded} event to be fired.
    *  - {@code 'networkidle'} - wait until there are no network connections for at least {@code 500} ms.
    */
-  Deferred<Void> waitForLoadState(LoadState state, WaitForLoadStateOptions options);
+  void waitForLoadState(LoadState state, WaitForLoadStateOptions options);
   default Deferred<Response> waitForNavigation() {
     return waitForNavigation(null);
   }
@@ -2000,7 +2000,7 @@ public interface Page {
   Deferred<Response> waitForResponse(String urlGlob, WaitForResponseOptions options);
   Deferred<Response> waitForResponse(Pattern urlPattern, WaitForResponseOptions options);
   Deferred<Response> waitForResponse(Predicate<String> urlPredicate, WaitForResponseOptions options);
-  default Deferred<ElementHandle> waitForSelector(String selector) {
+  default ElementHandle waitForSelector(String selector) {
     return waitForSelector(selector, null);
   }
   /**
@@ -2013,7 +2013,7 @@ public interface Page {
    * 
    * @param selector A selector to query for. See working with selectors for more details.
    */
-  Deferred<ElementHandle> waitForSelector(String selector, WaitForSelectorOptions options);
+  ElementHandle waitForSelector(String selector, WaitForSelectorOptions options);
   /**
    * Waits for the given {@code timeout} in milliseconds.
    * <p>
@@ -2022,7 +2022,7 @@ public interface Page {
    * Shortcut for main frame's {@code frame.waitForTimeout(timeout)}.
    * @param timeout A timeout to wait for
    */
-  Deferred<Void> waitForTimeout(int timeout);
+  void waitForTimeout(int timeout);
   /**
    * This method returns all of the dedicated WebWorkers associated with the page.
    * <p>

--- a/playwright/src/main/java/com/microsoft/playwright/WebSocket.java
+++ b/playwright/src/main/java/com/microsoft/playwright/WebSocket.java
@@ -28,14 +28,14 @@ public interface WebSocket {
     String text();
   }
 
-  class WaitForEventOptions {
+  class FutureEventOptions {
     public Integer timeout;
     public Predicate<Event<EventType>> predicate;
-    public WaitForEventOptions withTimeout(int millis) {
+    public FutureEventOptions withTimeout(int millis) {
       timeout = millis;
       return this;
     }
-    public WaitForEventOptions withPredicate(Predicate<Event<EventType>> predicate) {
+    public FutureEventOptions withPredicate(Predicate<Event<EventType>> predicate) {
       this.predicate = predicate;
       return this;
     }
@@ -58,13 +58,13 @@ public interface WebSocket {
    * Contains the URL of the WebSocket.
    */
   String url();
-  default Deferred<Event<EventType>> waitForEvent(EventType event) {
-    return waitForEvent(event, (WaitForEventOptions) null);
+  default Deferred<Event<EventType>> futureEvent(EventType event) {
+    return futureEvent(event, (FutureEventOptions) null);
   }
-  default Deferred<Event<EventType>> waitForEvent(EventType event, Predicate<Event<EventType>> predicate) {
-    WaitForEventOptions options = new WaitForEventOptions();
+  default Deferred<Event<EventType>> futureEvent(EventType event, Predicate<Event<EventType>> predicate) {
+    FutureEventOptions options = new FutureEventOptions();
     options.predicate = predicate;
-    return waitForEvent(event, options);
+    return futureEvent(event, options);
   }
   /**
    * Returns the event data value.
@@ -72,6 +72,6 @@ public interface WebSocket {
    * Waits for event to fire and passes its value into the predicate function. Returns when the predicate returns truthy value. Will throw an error if the webSocket is closed before the event is fired.
    * @param event Event name, same one would pass into {@code webSocket.on(event)}.
    */
-  Deferred<Event<EventType>> waitForEvent(EventType event, WaitForEventOptions options);
+  Deferred<Event<EventType>> futureEvent(EventType event, FutureEventOptions options);
 }
 

--- a/playwright/src/main/java/com/microsoft/playwright/Worker.java
+++ b/playwright/src/main/java/com/microsoft/playwright/Worker.java
@@ -56,6 +56,6 @@ public interface Worker {
    */
   JSHandle evaluateHandle(String pageFunction, Object arg);
   String url();
-  Deferred<Event<EventType>> waitForEvent(EventType event);
+  Deferred<Event<EventType>> futureEvent(EventType event);
 }
 

--- a/playwright/src/main/java/com/microsoft/playwright/impl/BrowserContextImpl.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/BrowserContextImpl.java
@@ -311,9 +311,9 @@ class BrowserContextImpl extends ChannelOwner implements BrowserContext {
   }
 
   @Override
-  public Deferred<Event<EventType>> waitForEvent(EventType event, WaitForEventOptions options) {
+  public Deferred<Event<EventType>> futureEvent(EventType event, FutureEventOptions options) {
     if (options == null) {
-      options = new WaitForEventOptions();
+      options = new FutureEventOptions();
     }
     List<Waitable<Event<EventType>>> waitables = new ArrayList<>();
     waitables.add(new WaitableEvent<>(listeners, event, options.predicate));

--- a/playwright/src/main/java/com/microsoft/playwright/impl/ChannelOwner.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/ChannelOwner.java
@@ -89,7 +89,7 @@ class ChannelOwner {
   }
 
   @SuppressWarnings("unchecked")
-  <T> Deferred<T> toDeferred(Waitable waitable) {
+  <T> Deferred<T> toDeferred(Waitable<T> waitable) {
     return new Deferred<T>() {
       Exception constructionStackTrace = new Exception();
       @Override

--- a/playwright/src/main/java/com/microsoft/playwright/impl/ElementHandleImpl.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/ElementHandleImpl.java
@@ -361,13 +361,13 @@ public class ElementHandleImpl extends JSHandleImpl implements ElementHandle {
   }
 
   @Override
-  public Deferred<Void> waitForElementState(ElementState state, WaitForElementStateOptions options) {
+  public void waitForElementState(ElementState state, WaitForElementStateOptions options) {
     if (options == null) {
       options = new WaitForElementStateOptions();
     }
     JsonObject params = gson().toJsonTree(options).getAsJsonObject();
     params.addProperty("state", toProtocol(state));
-    return toDeferred(sendMessageAsync("waitForElementState", params).apply(json -> null));
+    sendMessage("waitForElementState", params);
   }
 
   private static String toProtocol(ElementState state) {
@@ -378,7 +378,7 @@ public class ElementHandleImpl extends JSHandleImpl implements ElementHandle {
   }
 
   @Override
-  public Deferred<ElementHandle> waitForSelector(String selector, WaitForSelectorOptions options) {
+  public ElementHandle waitForSelector(String selector, WaitForSelectorOptions options) {
     if (options == null) {
       options = new WaitForSelectorOptions();
     }
@@ -386,7 +386,12 @@ public class ElementHandleImpl extends JSHandleImpl implements ElementHandle {
     params.remove("state");
     params.addProperty("state", toProtocol(options.state));
     params.addProperty("selector", selector);
-    return toDeferred(sendMessageAsync("waitForElementState", params).apply(json -> null));
+    JsonElement json = sendMessage("waitForSelector", params);
+    JsonObject element = json.getAsJsonObject().getAsJsonObject("element");
+    if (element == null) {
+      return null;
+    }
+    return connection.getExistingObject(element.get("guid").getAsString());
   }
 
   public String createSelectorForTest(String name) {

--- a/playwright/src/main/java/com/microsoft/playwright/impl/FrameImpl.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/FrameImpl.java
@@ -576,7 +576,7 @@ public class FrameImpl extends ChannelOwner implements Frame {
     }
   }
 
-  private class WaitForNavigationHelper implements Waitable<Response>, Listener<InternalEventType> {
+  private class FutureNavigationHelper implements Waitable<Response>, Listener<InternalEventType> {
     private final UrlMatcher matcher;
     private final LoadState expectedLoadState;
     private WaitForLoadStateHelper loadStateHelper;
@@ -584,7 +584,7 @@ public class FrameImpl extends ChannelOwner implements Frame {
     private RequestImpl request;
     private RuntimeException exception;
 
-    WaitForNavigationHelper(UrlMatcher matcher, LoadState expectedLoadState) {
+    FutureNavigationHelper(UrlMatcher matcher, LoadState expectedLoadState) {
       this.matcher = matcher;
       this.expectedLoadState = expectedLoadState;
       internalListeners.add(InternalEventType.NAVIGATED, this);
@@ -644,9 +644,9 @@ public class FrameImpl extends ChannelOwner implements Frame {
   }
 
   @Override
-  public Deferred<Response> waitForNavigation(WaitForNavigationOptions options) {
+  public Deferred<Response> futureNavigation(FutureNavigationOptions options) {
     if (options == null) {
-      options = new WaitForNavigationOptions();
+      options = new FutureNavigationOptions();
     }
     if (options.waitUntil == null) {
       options.waitUntil = LOAD;
@@ -654,7 +654,7 @@ public class FrameImpl extends ChannelOwner implements Frame {
 
     List<Waitable<Response>> waitables = new ArrayList<>();
     UrlMatcher matcher = UrlMatcher.forOneOf(options.glob, options.pattern, options.predicate);
-    waitables.add(new WaitForNavigationHelper(matcher, options.waitUntil));
+    waitables.add(new FutureNavigationHelper(matcher, options.waitUntil));
     waitables.add(page.createWaitForCloseHelper());
     waitables.add(page.createWaitableFrameDetach(this));
     waitables.add(page.createWaitableNavigationTimeout(options.timeout));

--- a/playwright/src/main/java/com/microsoft/playwright/impl/FrameImpl.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/FrameImpl.java
@@ -512,7 +512,7 @@ public class FrameImpl extends ChannelOwner implements Frame {
   }
 
   @Override
-  public Deferred<JSHandle> waitForFunction(String pageFunction, Object arg, WaitForFunctionOptions options) {
+  public JSHandle waitForFunction(String pageFunction, Object arg, WaitForFunctionOptions options) {
     if (options == null) {
       options = new WaitForFunctionOptions();
     }
@@ -520,15 +520,13 @@ public class FrameImpl extends ChannelOwner implements Frame {
     params.addProperty("expression", pageFunction);
     params.addProperty("isFunction", isFunctionBody(pageFunction));
     params.add("arg", gson().toJsonTree(serializeArgument(arg)));
-    Waitable<JSHandle> handle = sendMessageAsync("waitForFunction", params).apply(json -> {
-      JsonObject element = json.getAsJsonObject().getAsJsonObject("handle");
-      return connection.getExistingObject(element.get("guid").getAsString());
-    });
-    return toDeferred(handle);
+    JsonElement json = sendMessage("waitForFunction", params);
+    JsonObject element = json.getAsJsonObject().getAsJsonObject("handle");
+    return connection.getExistingObject(element.get("guid").getAsString());
   }
 
   @Override
-  public Deferred<Void> waitForLoadState(LoadState state, WaitForLoadStateOptions options) {
+  public void waitForLoadState(LoadState state, WaitForLoadStateOptions options) {
     if (options == null) {
       options = new WaitForLoadStateOptions();
     }
@@ -540,7 +538,7 @@ public class FrameImpl extends ChannelOwner implements Frame {
     waitables.add(new WaitForLoadStateHelper(state));
     waitables.add(page.createWaitForCloseHelper());
     waitables.add(page.createWaitableTimeout(options.timeout));
-    return toDeferred(new WaitableRace<>(waitables));
+    toDeferred(new WaitableRace<>(waitables)).get();
   }
 
   private class WaitForLoadStateHelper implements Waitable<Void>, Listener<InternalEventType> {
@@ -668,7 +666,7 @@ public class FrameImpl extends ChannelOwner implements Frame {
   }
 
   @Override
-  public Deferred<ElementHandle> waitForSelector(String selector, WaitForSelectorOptions options) {
+  public ElementHandle waitForSelector(String selector, WaitForSelectorOptions options) {
     if (options == null) {
       options = new WaitForSelectorOptions();
     }
@@ -678,25 +676,23 @@ public class FrameImpl extends ChannelOwner implements Frame {
       params.remove("state");
       params.addProperty("state", toProtocol(options.state));
     }
-    Waitable<ElementHandle> handle = sendMessageAsync("waitForSelector", params).apply(json -> {
-      JsonObject element = json.getAsJsonObject().getAsJsonObject("element");
-      if (element == null) {
-        return null;
-      }
-      return connection.getExistingObject(element.get("guid").getAsString());
-    });
-    return toDeferred(handle);
+    JsonElement json = sendMessage("waitForSelector", params);
+    JsonObject element = json.getAsJsonObject().getAsJsonObject("element");
+    if (element == null) {
+      return null;
+    }
+    return connection.getExistingObject(element.get("guid").getAsString());
   }
 
   @Override
-  public Deferred<Void> waitForTimeout(int timeout) {
-    return toDeferred(new WaitableTimeout<Void>(timeout) {
+  public void waitForTimeout(int timeout) {
+    toDeferred(new WaitableTimeout<Void>(timeout) {
       @Override
       public Void get() {
         // Override to not throw.
         return null;
       }
-    });
+    }).get();
   }
 
   protected void handleEvent(String event, JsonObject params) {

--- a/playwright/src/main/java/com/microsoft/playwright/impl/PageImpl.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/PageImpl.java
@@ -745,13 +745,13 @@ public class PageImpl extends ChannelOwner implements Page {
   }
 
   @Override
-  public Deferred<JSHandle> waitForFunction(String pageFunction, Object arg, WaitForFunctionOptions options) {
+  public JSHandle waitForFunction(String pageFunction, Object arg, WaitForFunctionOptions options) {
     return mainFrame.waitForFunction(pageFunction, arg, convertViaJson(options, Frame.WaitForFunctionOptions.class));
   }
 
   @Override
-  public Deferred<Void> waitForLoadState(LoadState state, WaitForLoadStateOptions options) {
-    return mainFrame.waitForLoadState(convertViaJson(state, Frame.LoadState.class), convertViaJson(options, Frame.WaitForLoadStateOptions.class));
+  public void waitForLoadState(LoadState state, WaitForLoadStateOptions options) {
+    mainFrame.waitForLoadState(convertViaJson(state, Frame.LoadState.class), convertViaJson(options, Frame.WaitForLoadStateOptions.class));
   }
 
   @Override
@@ -911,13 +911,13 @@ public class PageImpl extends ChannelOwner implements Page {
   }
 
   @Override
-  public Deferred<ElementHandle> waitForSelector(String selector, WaitForSelectorOptions options) {
+  public ElementHandle waitForSelector(String selector, WaitForSelectorOptions options) {
     return mainFrame.waitForSelector(selector, convertViaJson(options, Frame.WaitForSelectorOptions.class));
   }
 
   @Override
-  public Deferred<Void> waitForTimeout(int timeout) {
-    return mainFrame.waitForTimeout(timeout);
+  public void waitForTimeout(int timeout) {
+    mainFrame.waitForTimeout(timeout);
   }
 
   @Override

--- a/playwright/src/main/java/com/microsoft/playwright/impl/PageImpl.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/PageImpl.java
@@ -755,8 +755,8 @@ public class PageImpl extends ChannelOwner implements Page {
   }
 
   @Override
-  public Deferred<Response> waitForNavigation(WaitForNavigationOptions options) {
-    Frame.WaitForNavigationOptions frameOptions = new Frame.WaitForNavigationOptions();
+  public Deferred<Response> futureNavigation(FutureNavigationOptions options) {
+    Frame.FutureNavigationOptions frameOptions = new Frame.FutureNavigationOptions();
     if (options != null) {
       frameOptions.timeout = options.timeout;
       frameOptions.waitUntil = options.waitUntil;
@@ -764,7 +764,7 @@ public class PageImpl extends ChannelOwner implements Page {
       frameOptions.pattern = options.pattern;
       frameOptions.predicate = options.predicate;
     }
-    return mainFrame.waitForNavigation(frameOptions);
+    return mainFrame.futureNavigation(frameOptions);
   }
 
   void frameNavigated(FrameImpl frame) {

--- a/playwright/src/main/java/com/microsoft/playwright/impl/PageImpl.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/PageImpl.java
@@ -857,23 +857,23 @@ public class PageImpl extends ChannelOwner implements Page {
   }
 
   @Override
-  public Deferred<Request> waitForRequest(String urlGlob, WaitForRequestOptions options) {
-    return waitForRequest(new UrlMatcher(urlGlob), options);
+  public Deferred<Request> futureRequest(String urlGlob, FutureRequestOptions options) {
+    return futureRequest(new UrlMatcher(urlGlob), options);
   }
 
   @Override
-  public Deferred<Request> waitForRequest(Pattern urlPattern, WaitForRequestOptions options) {
-    return waitForRequest(new UrlMatcher(urlPattern), options);
+  public Deferred<Request> futureRequest(Pattern urlPattern, FutureRequestOptions options) {
+    return futureRequest(new UrlMatcher(urlPattern), options);
   }
 
   @Override
-  public Deferred<Request> waitForRequest(Predicate<String> urlPredicate, WaitForRequestOptions options) {
-    return waitForRequest(new UrlMatcher(urlPredicate), options);
+  public Deferred<Request> futureRequest(Predicate<String> urlPredicate, FutureRequestOptions options) {
+    return futureRequest(new UrlMatcher(urlPredicate), options);
   }
 
-  private Deferred<Request> waitForRequest(UrlMatcher matcher, WaitForRequestOptions options) {
+  private Deferred<Request> futureRequest(UrlMatcher matcher, FutureRequestOptions options) {
     if (options == null) {
-      options = new WaitForRequestOptions();
+      options = new FutureRequestOptions();
     }
     List<Waitable<Request>> waitables = new ArrayList<>();
     waitables.add(new WaitableEvent<>(listeners, EventType.REQUEST, e -> matcher.test(((Request) e.data()).url()))
@@ -884,23 +884,23 @@ public class PageImpl extends ChannelOwner implements Page {
   }
 
   @Override
-  public Deferred<Response> waitForResponse(String urlGlob, WaitForResponseOptions options) {
-    return waitForResponse(new UrlMatcher(urlGlob), options);
+  public Deferred<Response> futureResponse(String urlGlob, FutureResponseOptions options) {
+    return futureResponse(new UrlMatcher(urlGlob), options);
   }
 
   @Override
-  public Deferred<Response> waitForResponse(Pattern urlPattern, WaitForResponseOptions options) {
-    return waitForResponse(new UrlMatcher(urlPattern), options);
+  public Deferred<Response> futureResponse(Pattern urlPattern, FutureResponseOptions options) {
+    return futureResponse(new UrlMatcher(urlPattern), options);
   }
 
   @Override
-  public Deferred<Response> waitForResponse(Predicate<String> urlPredicate, WaitForResponseOptions options) {
-    return waitForResponse(new UrlMatcher(urlPredicate), options);
+  public Deferred<Response> futureResponse(Predicate<String> urlPredicate, FutureResponseOptions options) {
+    return futureResponse(new UrlMatcher(urlPredicate), options);
   }
 
-  private Deferred<Response> waitForResponse(UrlMatcher matcher, WaitForResponseOptions options) {
+  private Deferred<Response> futureResponse(UrlMatcher matcher, FutureResponseOptions options) {
     if (options == null) {
-      options = new WaitForResponseOptions();
+      options = new FutureResponseOptions();
     }
     List<Waitable<Response>> waitables = new ArrayList<>();
     waitables.add(new WaitableEvent<>(listeners, EventType.RESPONSE, e -> matcher.test(((Response) e.data()).url()))

--- a/playwright/src/main/java/com/microsoft/playwright/impl/PageImpl.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/PageImpl.java
@@ -723,9 +723,9 @@ public class PageImpl extends ChannelOwner implements Page {
   }
 
   @Override
-  public Deferred<Event<EventType>> waitForEvent(EventType event, WaitForEventOptions options) {
+  public Deferred<Event<EventType>> futureEvent(EventType event, FutureEventOptions options) {
     if (options == null) {
-      options = new WaitForEventOptions();
+      options = new FutureEventOptions();
     }
     List<Waitable<Event<EventType>>> waitables = new ArrayList<>();
     if (event == EventType.FILECHOOSER) {

--- a/playwright/src/main/java/com/microsoft/playwright/impl/WebSocketImpl.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/WebSocketImpl.java
@@ -97,9 +97,9 @@ class WebSocketImpl extends ChannelOwner implements WebSocket {
   }
 
   @Override
-  public Deferred<Event<EventType>> waitForEvent(EventType event, WaitForEventOptions options) {
+  public Deferred<Event<EventType>> futureEvent(EventType event, FutureEventOptions options) {
     if (options == null) {
-      options = new WaitForEventOptions();
+      options = new FutureEventOptions();
     }
     List<Waitable<Event<EventType>>> waitables = new ArrayList<>();
     waitables.add(new WaitableEvent<>(listeners, event, options.predicate));

--- a/playwright/src/main/java/com/microsoft/playwright/impl/WorkerImpl.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/WorkerImpl.java
@@ -69,7 +69,7 @@ class WorkerImpl extends ChannelOwner implements Worker {
   }
 
   @Override
-  public Deferred<Event<EventType>> waitForEvent(EventType event) {
+  public Deferred<Event<EventType>> futureEvent(EventType event) {
     return toDeferred(new WaitableEvent<>(listeners, event));
   }
 

--- a/playwright/src/test/java/com/microsoft/playwright/Server.java
+++ b/playwright/src/test/java/com/microsoft/playwright/Server.java
@@ -114,7 +114,7 @@ public class Server implements HttpHandler {
     }
   }
 
-  Future<Request> waitForRequest(String path) {
+  Future<Request> futureRequest(String path) {
     CompletableFuture<Request> future = requestSubscribers.get(path);
     if (future == null) {
       future = new CompletableFuture<>();

--- a/playwright/src/test/java/com/microsoft/playwright/TestBrowserContextAddCookies.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestBrowserContextAddCookies.java
@@ -349,7 +349,7 @@ public class TestBrowserContextAddCookies extends TestBase {
       "  return promise;\n" +
       "}", server.CROSS_PROCESS_PREFIX + "/grid.html");
     page.frames().get(1).evaluate("document.cookie = 'username=John Doe'");
-    page.waitForTimeout(2000).get();
+    page.waitForTimeout(2000);
     boolean allowsThirdParty = isChromium() || isFirefox();
     List<BrowserContext.Cookie> cookies = context.cookies(server.CROSS_PROCESS_PREFIX + "/grid.html");
     if (allowsThirdParty) {

--- a/playwright/src/test/java/com/microsoft/playwright/TestBrowserContextAddCookies.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestBrowserContextAddCookies.java
@@ -64,7 +64,7 @@ public class TestBrowserContextAddCookies extends TestBase {
 
   @Test
   void shouldSendCookieHeader() throws ExecutionException, InterruptedException {
-    Future<Server.Request> request = server.waitForRequest("/empty.html");
+    Future<Server.Request> request = server.futureRequest("/empty.html");
     context.addCookies(asList(
       new BrowserContext.AddCookie().withUrl(server.EMPTY_PAGE).withName("cookie").withValue("value")));
     Page page = context.newPage();
@@ -150,7 +150,7 @@ public class TestBrowserContextAddCookies extends TestBase {
       new BrowserContext.AddCookie().withUrl(server.EMPTY_PAGE).withName("sendcookie").withValue("value")));
     {
       Page page = context.newPage();
-      Future<Server.Request> request = server.waitForRequest("/empty.html");
+      Future<Server.Request> request = server.futureRequest("/empty.html");
       page.navigate(server.EMPTY_PAGE);
       List<String> cookies = request.get().headers.get("cookie");
       assertEquals(asList("sendcookie=value"), cookies);
@@ -158,7 +158,7 @@ public class TestBrowserContextAddCookies extends TestBase {
     {
       BrowserContext context = browser.newContext();
       Page page = context.newPage();
-      Future<Server.Request> request = server.waitForRequest("/empty.html");
+      Future<Server.Request> request = server.futureRequest("/empty.html");
       page.navigate(server.EMPTY_PAGE);
       List<String> cookies = request.get().headers.get("cookie");
       assertNull(cookies);

--- a/playwright/src/test/java/com/microsoft/playwright/TestBrowserContextBasic.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestBrowserContextBasic.java
@@ -44,7 +44,7 @@ public class TestBrowserContextBasic extends TestBase {
     BrowserContext context = browser.newContext();
     Page page = context.newPage();
     page.navigate(server.EMPTY_PAGE);
-    Deferred<Event<Page.EventType>> popupEvent = page.waitForEvent(POPUP);
+    Deferred<Event<Page.EventType>> popupEvent = page.futureEvent(POPUP);
     page.evaluate("url => window.open(url)", server.EMPTY_PAGE);
     Page popup = (Page) popupEvent.get().data();
     assertEquals(context, popup.context());
@@ -153,9 +153,9 @@ public class TestBrowserContextBasic extends TestBase {
   }
 
   @Test
-  void closeShouldAbortWaitForEvent() {
+  void closeShouldAbortFutureEvent() {
     BrowserContext context = browser.newContext();
-    Deferred<Event<BrowserContext.EventType>> pageEvent = context.waitForEvent(PAGE);
+    Deferred<Event<BrowserContext.EventType>> pageEvent = context.futureEvent(PAGE);
     context.close();
     try {
       pageEvent.get();

--- a/playwright/src/test/java/com/microsoft/playwright/TestClick.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestClick.java
@@ -104,7 +104,7 @@ public class TestClick extends TestBase {
     Page page = context.newPage();
     page.navigate(server.PREFIX + "/wrappedlink.html");
 
-    Deferred<Response> navigationPromise = page.waitForNavigation();
+    Deferred<Response> navigationPromise = page.futureNavigation();
     page.click("a");
     navigationPromise.get();
 

--- a/playwright/src/test/java/com/microsoft/playwright/TestDefaultBrowserContext2.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestDefaultBrowserContext2.java
@@ -109,7 +109,7 @@ public class TestDefaultBrowserContext2 extends TestBase {
   void shouldSupportExtraHTTPHeadersOption() throws ExecutionException, InterruptedException {
 //   TODO: test.flaky(browserName === "firefox" && headful && platform === "linux", "Intermittent timeout on bots");
     Page page = launchPersistent(new BrowserType.LaunchPersistentContextOptions().withExtraHTTPHeaders(mapOf("foo", "bar")));
-    Future<Server.Request> request = server.waitForRequest("/empty.html");
+    Future<Server.Request> request = server.futureRequest("/empty.html");
     page.navigate(server.EMPTY_PAGE);
     assertEquals(asList("bar"), request.get().headers.get("foo"));
   }

--- a/playwright/src/test/java/com/microsoft/playwright/TestDeferred.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestDeferred.java
@@ -26,7 +26,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 public class TestDeferred extends TestBase {
   @Test
   void throwIfGetNotCalled() {
-    page.waitForNavigation();
+    page.futureNavigation();
     context.futureEvent(BrowserContext.EventType.PAGE);
     closeContext();
     closeBrowser();
@@ -48,7 +48,7 @@ public class TestDeferred extends TestBase {
       p.close();
       fail("did not throw");
     } catch (Exception e) {
-      assertTrue(e.getMessage().contains("com.microsoft.playwright.impl.PageImpl.waitForNavigation"));
+      assertTrue(e.getMessage().contains("com.microsoft.playwright.impl.PageImpl.futureNavigation"));
       assertTrue(e.getMessage().contains("com.microsoft.playwright.impl.BrowserContextImpl.futureEvent"));
     }
   }

--- a/playwright/src/test/java/com/microsoft/playwright/TestDeferred.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestDeferred.java
@@ -27,7 +27,7 @@ public class TestDeferred extends TestBase {
   @Test
   void throwIfGetNotCalled() {
     page.waitForNavigation();
-    context.waitForEvent(BrowserContext.EventType.PAGE);
+    context.futureEvent(BrowserContext.EventType.PAGE);
     closeContext();
     closeBrowser();
 
@@ -49,7 +49,7 @@ public class TestDeferred extends TestBase {
       fail("did not throw");
     } catch (Exception e) {
       assertTrue(e.getMessage().contains("com.microsoft.playwright.impl.PageImpl.waitForNavigation"));
-      assertTrue(e.getMessage().contains("com.microsoft.playwright.impl.BrowserContextImpl.waitForEvent"));
+      assertTrue(e.getMessage().contains("com.microsoft.playwright.impl.BrowserContextImpl.futureEvent"));
     }
   }
 }

--- a/playwright/src/test/java/com/microsoft/playwright/TestDialog.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestDialog.java
@@ -92,7 +92,7 @@ public class TestDialog extends TestBase {
   void shouldBeAbleToCloseContextWithOpenAlert() {
     BrowserContext context = browser.newContext();
     Page page = context.newPage();
-//    const alertPromise = page.waitForEvent("dialog");
+//    const alertPromise = page.futureEvent("dialog");
     page.evaluate("() => {\n" +
       "    setTimeout(() => alert('hello'), 0);\n" +
       "}");

--- a/playwright/src/test/java/com/microsoft/playwright/TestDownload.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestDownload.java
@@ -61,7 +61,7 @@ public class TestDownload extends TestBase {
   @Test
   void shouldReportDownloadsWithAcceptDownloadsFalse() {
     page.setContent("<a href='" + server.PREFIX + "/downloadWithFilename'>download</a>");
-    Deferred<Event<Page.EventType>> downloadEvent = page.waitForEvent(DOWNLOAD);
+    Deferred<Event<Page.EventType>> downloadEvent = page.futureEvent(DOWNLOAD);
     page.click("a");
     Download download = (Download) downloadEvent.get().data();
     assertEquals(server.PREFIX + "/downloadWithFilename", download.url());
@@ -78,7 +78,7 @@ public class TestDownload extends TestBase {
   void shouldReportDownloadsWithAcceptDownloadsTrue() throws IOException {
     Page page = browser.newPage(new Browser.NewPageOptions().withAcceptDownloads(true));
     page.setContent("<a href='" + server.PREFIX + "/download'>download</a>");
-    Deferred<Event<Page.EventType>> downloadEvent = page.waitForEvent(DOWNLOAD);
+    Deferred<Event<Page.EventType>> downloadEvent = page.futureEvent(DOWNLOAD);
     page.click("a");
     Download download = (Download) downloadEvent.get().data();
     Path path = download.path();
@@ -92,7 +92,7 @@ public class TestDownload extends TestBase {
   void shouldSaveToUserSpecifiedPath() throws IOException {
     Page page = browser.newPage(new Browser.NewPageOptions().withAcceptDownloads(true));
     page.setContent("<a href='" + server.PREFIX + "/download'>download</a>");
-    Deferred<Event<Page.EventType>> downloadEvent = page.waitForEvent(DOWNLOAD);
+    Deferred<Event<Page.EventType>> downloadEvent = page.futureEvent(DOWNLOAD);
     page.click("a");
     Download download = (Download) downloadEvent.get().data();
 
@@ -108,7 +108,7 @@ public class TestDownload extends TestBase {
   void shouldSaveToUserSpecifiedPathWithoutUpdatingOriginalPath() throws IOException {
     Page page = browser.newPage(new Browser.NewPageOptions().withAcceptDownloads(true));
     page.setContent("<a href='" + server.PREFIX + "/download'>download</a>");
-    Deferred<Event<Page.EventType>> downloadEvent = page.waitForEvent(DOWNLOAD);
+    Deferred<Event<Page.EventType>> downloadEvent = page.futureEvent(DOWNLOAD);
     page.click("a");
     Download download = (Download) downloadEvent.get().data();
 
@@ -133,7 +133,7 @@ public class TestDownload extends TestBase {
   void shouldSaveToTwoDifferentPathsWithMultipleSaveAsCalls() throws IOException {
     Page page = browser.newPage(new Browser.NewPageOptions().withAcceptDownloads(true));
     page.setContent("<a href='" + server.PREFIX + "/download'>download</a>");
-    Deferred<Event<Page.EventType>> downloadEvent = page.waitForEvent(DOWNLOAD);
+    Deferred<Event<Page.EventType>> downloadEvent = page.futureEvent(DOWNLOAD);
     page.click("a");
     Download download = (Download) downloadEvent.get().data();
     {
@@ -157,7 +157,7 @@ public class TestDownload extends TestBase {
   void shouldSaveToOverwrittenFilepath() throws IOException {
     Page page = browser.newPage(new Browser.NewPageOptions().withAcceptDownloads(true));
     page.setContent("<a href='" + server.PREFIX + "/download'>download</a>");
-    Deferred<Event<Page.EventType>> downloadEvent = page.waitForEvent(DOWNLOAD);
+    Deferred<Event<Page.EventType>> downloadEvent = page.futureEvent(DOWNLOAD);
     page.click("a");
     Download download = (Download) downloadEvent.get().data();
     Path userFile = Files.createTempFile("download-", ".txt");
@@ -180,7 +180,7 @@ public class TestDownload extends TestBase {
   void shouldCreateSubdirectoriesWhenSavingToNonExistentUserSpecifiedPath() throws IOException {
     Page page = browser.newPage(new Browser.NewPageOptions().withAcceptDownloads(true));
     page.setContent("<a href='" + server.PREFIX + "/download'>download</a>");
-    Deferred<Event<Page.EventType>> downloadEvent = page.waitForEvent(DOWNLOAD);
+    Deferred<Event<Page.EventType>> downloadEvent = page.futureEvent(DOWNLOAD);
     page.click("a");
     Download download = (Download) downloadEvent.get().data();
 
@@ -201,7 +201,7 @@ public class TestDownload extends TestBase {
   void shouldErrorWhenSavingWithDownloadsDisabled() throws IOException {
     Page page = browser.newPage(new Browser.NewPageOptions().withAcceptDownloads(false));
     page.setContent("<a href='" + server.PREFIX + "/download'>download</a>");
-    Deferred<Event<Page.EventType>> downloadEvent = page.waitForEvent(DOWNLOAD);
+    Deferred<Event<Page.EventType>> downloadEvent = page.futureEvent(DOWNLOAD);
     page.click("a");
     Download download = (Download) downloadEvent.get().data();
 
@@ -219,7 +219,7 @@ public class TestDownload extends TestBase {
   void shouldErrorWhenSavingAfterDeletion() throws IOException {
     Page page = browser.newPage(new Browser.NewPageOptions().withAcceptDownloads(true));
     page.setContent("<a href='" + server.PREFIX + "/download'>download</a>");
-    Deferred<Event<Page.EventType>> downloadEvent = page.waitForEvent(DOWNLOAD);
+    Deferred<Event<Page.EventType>> downloadEvent = page.futureEvent(DOWNLOAD);
     page.click("a");
     Download download = (Download) downloadEvent.get().data();
 
@@ -252,7 +252,7 @@ public class TestDownload extends TestBase {
     Page page = browser.newPage(new Browser.NewPageOptions().withAcceptDownloads(true));
     page.navigate(server.EMPTY_PAGE);
     page.setContent("<a download='file.txt' href='" + server.PREFIX + "/download'>download</a>");
-    Deferred<Event<Page.EventType>> downloadEvent = page.waitForEvent(DOWNLOAD);
+    Deferred<Event<Page.EventType>> downloadEvent = page.futureEvent(DOWNLOAD);
     page.click("a");
     Download download = (Download) downloadEvent.get().data();
 
@@ -320,7 +320,7 @@ public class TestDownload extends TestBase {
     });
     Page page = browser.newPage(new Browser.NewPageOptions().withAcceptDownloads(true));
     page.setContent("<a href='" + server.PREFIX + "/download'>download</a>");
-    Deferred<Event<Page.EventType>> downloadEvent = page.waitForEvent(DOWNLOAD);
+    Deferred<Event<Page.EventType>> downloadEvent = page.futureEvent(DOWNLOAD);
     page.click("a", new Page.ClickOptions().withModifiers(ALT));
     Download download = (Download) downloadEvent.get().data();
     Path path = download.path();
@@ -343,7 +343,7 @@ public class TestDownload extends TestBase {
     // - WebKit doesn't close the popup page
     Page page = browser.newPage(new Browser.NewPageOptions().withAcceptDownloads(true));
     page.setContent("<a target=_blank href='" + server.PREFIX + "/download'>download</a>");
-    Deferred<Event<Page.EventType>> downloadEvent = page.waitForEvent(DOWNLOAD);
+    Deferred<Event<Page.EventType>> downloadEvent = page.futureEvent(DOWNLOAD);
     page.click("a");
     Download download = (Download) downloadEvent.get().data();
     Path path = download.path();
@@ -357,7 +357,7 @@ public class TestDownload extends TestBase {
   void shouldDeleteFile() {
     Page page = browser.newPage(new Browser.NewPageOptions().withAcceptDownloads(true));
     page.setContent("<a href='" + server.PREFIX + "/download'>download</a>");
-    Deferred<Event<Page.EventType>> downloadEvent = page.waitForEvent(DOWNLOAD);
+    Deferred<Event<Page.EventType>> downloadEvent = page.futureEvent(DOWNLOAD);
     page.click("a");
     Download download = (Download) downloadEvent.get().data();
     Path path = download.path();
@@ -371,7 +371,7 @@ public class TestDownload extends TestBase {
   void shouldExposeStream() throws IOException {
     Page page = browser.newPage(new Browser.NewPageOptions().withAcceptDownloads(true));
     page.setContent("<a href='" + server.PREFIX + "/download'>download</a>");
-    Deferred<Event<Page.EventType>> downloadEvent = page.waitForEvent(DOWNLOAD);
+    Deferred<Event<Page.EventType>> downloadEvent = page.futureEvent(DOWNLOAD);
     page.click("a");
     Download download = (Download) downloadEvent.get().data();
 
@@ -386,11 +386,11 @@ public class TestDownload extends TestBase {
   void shouldDeleteDownloadsOnContextDestruction() {
     Page page = browser.newPage(new Browser.NewPageOptions().withAcceptDownloads(true));
     page.setContent("<a href='" + server.PREFIX + "/download'>download</a>");
-    Deferred<Event<Page.EventType>> downloadEvent1 = page.waitForEvent(DOWNLOAD);
+    Deferred<Event<Page.EventType>> downloadEvent1 = page.futureEvent(DOWNLOAD);
     page.click("a");
     Download download1 = (Download) downloadEvent1.get().data();
 
-    Deferred<Event<Page.EventType>> downloadEvent2 = page.waitForEvent(DOWNLOAD);
+    Deferred<Event<Page.EventType>> downloadEvent2 = page.futureEvent(DOWNLOAD);
     page.click("a");
     Download download2 = (Download) downloadEvent2.get().data();
 
@@ -408,11 +408,11 @@ public class TestDownload extends TestBase {
     Browser browser = browserType.launch();
     Page page = browser.newPage(new Browser.NewPageOptions().withAcceptDownloads(true));
     page.setContent("<a href='" + server.PREFIX + "/download'>download</a>");
-    Deferred<Event<Page.EventType>> downloadEvent1 = page.waitForEvent(DOWNLOAD);
+    Deferred<Event<Page.EventType>> downloadEvent1 = page.futureEvent(DOWNLOAD);
     page.click("a");
     Download download1 = (Download) downloadEvent1.get().data();
 
-    Deferred<Event<Page.EventType>> downloadEvent2 = page.waitForEvent(DOWNLOAD);
+    Deferred<Event<Page.EventType>> downloadEvent2 = page.futureEvent(DOWNLOAD);
     page.click("a");
     Download download2 = (Download) downloadEvent2.get().data();
 

--- a/playwright/src/test/java/com/microsoft/playwright/TestDownload.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestDownload.java
@@ -274,7 +274,7 @@ public class TestDownload extends TestBase {
     page.click("a");
     Instant start = Instant.now();
     while (event[0] == null) {
-      page.waitForTimeout(100).get();
+      page.waitForTimeout(100);
       assertTrue(Duration.between(start, Instant.now()).getSeconds() < 30, "Timed out");
     }
     Download download = (Download) event[0].data();
@@ -295,7 +295,7 @@ public class TestDownload extends TestBase {
     page.click("a");
     Instant start = Instant.now();
     while (event[0] == null) {
-      page.waitForTimeout(100).get();
+      page.waitForTimeout(100);
       assertTrue(Duration.between(start, Instant.now()).getSeconds() < 1, "Timed out");
     }
     Download download = (Download) event[0].data();

--- a/playwright/src/test/java/com/microsoft/playwright/TestElementHandleOwnerFrame.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestElementHandleOwnerFrame.java
@@ -96,7 +96,7 @@ public class TestElementHandleOwnerFrame extends TestBase {
   @Test
   void shouldWorkForAdoptedElements() {
     page.navigate(server.EMPTY_PAGE);
-    Deferred<Event<Page.EventType>> popupEvent = page.waitForEvent(Page.EventType.POPUP);
+    Deferred<Event<Page.EventType>> popupEvent = page.futureEvent(Page.EventType.POPUP);
     page.evaluate("url => window['__popup'] = window.open(url)", server.EMPTY_PAGE);
     JSHandle divHandle = page.evaluateHandle("() => {\n" +
      "  const div = document.createElement('div');\n" +

--- a/playwright/src/test/java/com/microsoft/playwright/TestElementHandleOwnerFrame.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestElementHandleOwnerFrame.java
@@ -105,7 +105,7 @@ public class TestElementHandleOwnerFrame extends TestBase {
      "}");
     assertEquals(page.mainFrame(), divHandle.asElement().ownerFrame());
     Page popup = (Page) popupEvent.get().data();
-    popup.waitForLoadState(Page.LoadState.DOMCONTENTLOADED).get();
+    popup.waitForLoadState(Page.LoadState.DOMCONTENTLOADED);
     page.evaluate("() => {\n" +
       "  const div = document.querySelector('div');\n" +
       "  window['__popup'].document.body.appendChild(div);\n" +

--- a/playwright/src/test/java/com/microsoft/playwright/TestElementHandleWaitForElementState.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestElementHandleWaitForElementState.java
@@ -35,26 +35,24 @@ public class TestElementHandleWaitForElementState extends TestBase {
   void shouldWaitForVisible() {
     page.setContent("<div style='display:none'>content</div>");
     ElementHandle div = page.querySelector("div");
-    Deferred<Void> promise = div.waitForElementState(VISIBLE);
     giveItAChanceToResolve(page);
     div.evaluate("div => div.style.display = 'block'");
-    promise.get();
+    div.waitForElementState(VISIBLE);
   }
 
   @Test
   void shouldWaitForAlreadyVisible() {
     page.setContent("<div>content</div>");
     ElementHandle div = page.querySelector("div");
-    div.waitForElementState(VISIBLE).get();
+    div.waitForElementState(VISIBLE);
   }
 
   @Test
   void shouldTimeoutWaitingForVisible() {
     page.setContent("<div style='display:none'>content</div>");
     ElementHandle div = page.querySelector("div");
-    Deferred<Void> result = div.waitForElementState(VISIBLE, new ElementHandle.WaitForElementStateOptions().withTimeout(1000));
     try {
-      result.get();
+      div.waitForElementState(VISIBLE, new ElementHandle.WaitForElementStateOptions().withTimeout(1000));
       fail("did not throw");
     } catch (PlaywrightException e) {
       assertTrue(e.getMessage().contains("Timeout 1000ms exceeded"));
@@ -65,10 +63,9 @@ public class TestElementHandleWaitForElementState extends TestBase {
   void shouldThrowWaitingForVisibleWhenDetached() {
     page.setContent("<div style='display:none'>content</div>");
     ElementHandle div = page.querySelector("div");
-    Deferred<Void> promise = div.waitForElementState(VISIBLE);
     div.evaluate("div => div.remove()");
     try {
-      promise.get();
+      div.waitForElementState(VISIBLE);
       fail("did not throw");
     } catch (PlaywrightException e) {
       assertTrue(e.getMessage().contains("Element is not attached to the DOM"));
@@ -79,48 +76,43 @@ public class TestElementHandleWaitForElementState extends TestBase {
   void shouldWaitForHidden() {
     page.setContent("<div>content</div>");
     ElementHandle div = page.querySelector("div");
-    Deferred<Void> promise = div.waitForElementState(HIDDEN);
     giveItAChanceToResolve(page);
     div.evaluate("div => div.style.display = 'none'");
-    promise.get();
+    div.waitForElementState(HIDDEN);
   }
 
   @Test
   void shouldWaitForAlreadyHidden() {
     page.setContent("<div></div>");
     ElementHandle div = page.querySelector("div");
-    Deferred<Void> result = div.waitForElementState(HIDDEN);
-    result.get();
+    div.waitForElementState(HIDDEN);
   }
 
   @Test
   void shouldWaitForHiddenWhenDetached() {
     page.setContent("<div>content</div>");
     ElementHandle div = page.querySelector("div");
-    Deferred<Void> promise = div.waitForElementState(HIDDEN);
     giveItAChanceToResolve(page);
     div.evaluate("div => div.remove()");
-    promise.get();
+    div.waitForElementState(HIDDEN);
   }
 
   @Test
   void shouldWaitForEnabledButton() {
     page.setContent("<button disabled><span>Target</span></button>");
     ElementHandle span = page.querySelector("text=Target");
-    Deferred<Void> promise = span.waitForElementState(ENABLED);
     giveItAChanceToResolve(page);
     span.evaluate("span => span.parentElement.disabled = false");
-    promise.get();
+    span.waitForElementState(ENABLED);
   }
 
   @Test
   void shouldThrowWaitingForEnabledWhenDetached() {
     page.setContent("<button disabled>Target</button>");
     ElementHandle button = page.querySelector("button");
-    Deferred<Void> promise = button.waitForElementState(ENABLED);
     button.evaluate("button => button.remove()");
     try {
-      promise.get();
+      button.waitForElementState(ENABLED);
       fail("did not throw");
     } catch (PlaywrightException e) {
       assertTrue(e.getMessage().contains("Element is not attached to the DOM"));
@@ -131,10 +123,9 @@ public class TestElementHandleWaitForElementState extends TestBase {
   void shouldWaitForDisabledButton() {
     page.setContent("<button><span>Target</span></button>");
     ElementHandle span = page.querySelector("text=Target");
-    Deferred<Void> promise = span.waitForElementState(DISABLED);
     giveItAChanceToResolve(page);
     span.evaluate("span => span.parentElement.disabled = true");
-    promise.get();
+    span.waitForElementState(DISABLED);
   }
 
   static boolean isFirefoxLinux() {
@@ -149,9 +140,8 @@ public class TestElementHandleWaitForElementState extends TestBase {
       "  button.style.transition = 'margin 10000ms linear 0s';\n" +
       "  button.style.marginLeft = '20000px';\n" +
       "}");
-    Deferred<Void> promise = button.waitForElementState(STABLE);
     giveItAChanceToResolve(page);
     button.evaluate("button => button.style.transition = ''");
-    promise.get();
+    button.waitForElementState(STABLE);
   }
 }

--- a/playwright/src/test/java/com/microsoft/playwright/TestEvalOnSelector.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestEvalOnSelector.java
@@ -186,10 +186,10 @@ public class TestEvalOnSelector extends TestBase {
   @Test
   void shouldWorkWithSpacesInCssAttributes() {
     page.setContent("<div><input placeholder='Select date'></div>");
-    assertNotNull(page.waitForSelector("[placeholder=\"Select date\"]").get());
-    assertNotNull(page.waitForSelector("[placeholder='Select date']").get());
-    assertNotNull(page.waitForSelector("input[placeholder=\"Select date\"]").get());
-    assertNotNull(page.waitForSelector("input[placeholder='Select date']").get());
+    assertNotNull(page.waitForSelector("[placeholder=\"Select date\"]"));
+    assertNotNull(page.waitForSelector("[placeholder='Select date']"));
+    assertNotNull(page.waitForSelector("input[placeholder=\"Select date\"]"));
+    assertNotNull(page.waitForSelector("input[placeholder='Select date']"));
     assertNotNull(page.querySelector("[placeholder=\"Select date\"]"));
     assertNotNull(page.querySelector("[placeholder='Select date']"));
     assertNotNull(page.querySelector("input[placeholder=\"Select date\"]"));
@@ -224,18 +224,16 @@ public class TestEvalOnSelector extends TestBase {
 
   @Test
   void shouldWorkWithSpacesInCssAttributesWhenMissing() {
-    Deferred<ElementHandle> inputPromise = page.waitForSelector("[placeholder='Select date']");
     assertNull(page.querySelector("[placeholder='Select date']"));
     page.setContent("<div><input placeholder='Select date'></div>");
-    inputPromise.get();
+    page.waitForSelector("[placeholder='Select date']");
   }
 
   @Test
   void shouldWorkWithQuotesInCssAttributesWhenMissing() {
-    Deferred<ElementHandle> inputPromise = page.waitForSelector("[placeholder='Select\\\"date']");
     assertNull(page.querySelector("[placeholder='Select\\\"date']"));
     page.setContent("<div><input placeholder='Select&quot;date'></div>");
-    inputPromise.get();
+    page.waitForSelector("[placeholder='Select\\\"date']");
   }
 
   @Test

--- a/playwright/src/test/java/com/microsoft/playwright/TestGeolocation.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestGeolocation.java
@@ -120,17 +120,17 @@ public class TestGeolocation extends TestBase {
       "  }, err => {});\n" +
       "}");
     {
-      Deferred<Event<Page.EventType>> deferred = page.waitForEvent(CONSOLE, event -> ((ConsoleMessage) event.data()).text().contains("lat=0 lng=10"));
+      Deferred<Event<Page.EventType>> deferred = page.futureEvent(CONSOLE, event -> ((ConsoleMessage) event.data()).text().contains("lat=0 lng=10"));
       context.setGeolocation(new Geolocation(0, 10));
       deferred.get();
     }
     {
-      Deferred<Event<Page.EventType>> deferred = page.waitForEvent(CONSOLE, event -> ((ConsoleMessage) event.data()).text().contains("lat=20 lng=30"));
+      Deferred<Event<Page.EventType>> deferred = page.futureEvent(CONSOLE, event -> ((ConsoleMessage) event.data()).text().contains("lat=20 lng=30"));
       context.setGeolocation(new Geolocation(20, 30));
       deferred.get();
     }
     {
-      Deferred<Event<Page.EventType>> deferred = page.waitForEvent(CONSOLE, event -> ((ConsoleMessage) event.data()).text().contains("lat=40 lng=50"));
+      Deferred<Event<Page.EventType>> deferred = page.futureEvent(CONSOLE, event -> ((ConsoleMessage) event.data()).text().contains("lat=40 lng=50"));
       context.setGeolocation(new Geolocation(40, 50));
       deferred.get();
     }
@@ -143,7 +143,7 @@ public class TestGeolocation extends TestBase {
   void shouldUseContextOptionsForPopup() {
     context.grantPermissions(asList("geolocation"));
     context.setGeolocation(new Geolocation(10, 10));
-    Deferred<Event<Page.EventType>> popupEvent = page.waitForEvent(POPUP);
+    Deferred<Event<Page.EventType>> popupEvent = page.futureEvent(POPUP);
     page.evaluate("url => window['_popup'] = window.open(url)", server.PREFIX + "/geolocation.html");
     Page popup = (Page) popupEvent.get().data();
     popup.waitForLoadState();

--- a/playwright/src/test/java/com/microsoft/playwright/TestGeolocation.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestGeolocation.java
@@ -146,7 +146,7 @@ public class TestGeolocation extends TestBase {
     Deferred<Event<Page.EventType>> popupEvent = page.waitForEvent(POPUP);
     page.evaluate("url => window['_popup'] = window.open(url)", server.PREFIX + "/geolocation.html");
     Page popup = (Page) popupEvent.get().data();
-    popup.waitForLoadState().get();
+    popup.waitForLoadState();
     Object geolocation = popup.evaluate("window['geolocationPromise']");
     assertEquals(mapOf("longitude", 10, "latitude", 10), geolocation);
   }

--- a/playwright/src/test/java/com/microsoft/playwright/TestHar.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestHar.java
@@ -101,8 +101,7 @@ public class TestHar extends TestBase {
   void shouldHavePages() throws IOException {
     pageWithHar.page.navigate("data:text/html,<title>Hello</title>");
     // For data: load comes before domcontentloaded...
-    Deferred<Void> loadEvent = pageWithHar.page.waitForLoadState(Page.LoadState.DOMCONTENTLOADED);
-    loadEvent.get();
+    pageWithHar.page.waitForLoadState(Page.LoadState.DOMCONTENTLOADED);
     JsonObject log = pageWithHar.log();
 
     assertEquals(1, log.getAsJsonArray("pages").size());
@@ -125,8 +124,7 @@ public class TestHar extends TestBase {
 
     page.navigate("data:text/html,<title>Hello</title>");
     // For data: load comes before domcontentloaded...
-    Deferred<Void> loadEvent = page.waitForLoadState(Page.LoadState.DOMCONTENTLOADED);
-    loadEvent.get();
+    page.waitForLoadState(Page.LoadState.DOMCONTENTLOADED);
     context.close();
     JsonObject log;
     try (Reader reader = new FileReader(harPath.toFile())) {

--- a/playwright/src/test/java/com/microsoft/playwright/TestNetworkRequest.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestNetworkRequest.java
@@ -107,7 +107,7 @@ public class TestNetworkRequest extends TestBase {
   @Test
   @DisabledIf(value="com.microsoft.playwright.TestBase#isWebKit", disabledReason="fail")
   void shouldGetTheSameHeadersAsTheServer() throws ExecutionException, InterruptedException {
-    Future<Server.Request> serverRequest = server.waitForRequest("/empty.html");
+    Future<Server.Request> serverRequest = server.futureRequest("/empty.html");
     server.setRoute("/empty.html", exchange -> {
       exchange.sendResponseHeaders(200, 0);
       try (OutputStreamWriter writer = new OutputStreamWriter(exchange.getResponseBody())) {
@@ -124,7 +124,7 @@ public class TestNetworkRequest extends TestBase {
   @DisabledIf(value="com.microsoft.playwright.TestBase#isWebKit", disabledReason="fail")
   void shouldGetTheSameHeadersAsTheServerCORP() throws ExecutionException, InterruptedException {
     page.navigate(server.PREFIX + "/empty.html");
-    Future<Server.Request> serverRequest = server.waitForRequest("/something");
+    Future<Server.Request> serverRequest = server.futureRequest("/something");
     server.setRoute("/something", exchange -> {
       exchange.getResponseHeaders().add("Access-Control-Allow-Origin", "*");
       exchange.sendResponseHeaders(200, 0);

--- a/playwright/src/test/java/com/microsoft/playwright/TestNetworkRequest.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestNetworkRequest.java
@@ -132,7 +132,7 @@ public class TestNetworkRequest extends TestBase {
         writer.write("done");
       }
     });
-    Deferred<Event<Page.EventType>> responsePromise = page.waitForEvent(RESPONSE);
+    Deferred<Event<Page.EventType>> responsePromise = page.futureEvent(RESPONSE);
     Object text = page.evaluate("async url => {\n" +
       "  const data = await fetch(url);\n" +
       "  return data.text();\n" +

--- a/playwright/src/test/java/com/microsoft/playwright/TestNetworkResponse.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestNetworkResponse.java
@@ -105,7 +105,7 @@ public class TestNetworkResponse extends TestBase {
       requestFinished[0] |= ((Request) event.data()).url().contains("/get");
     });
     // send request and wait for server response
-    Deferred<Event<Page.EventType>> responseEvent = page.waitForEvent(RESPONSE);
+    Deferred<Event<Page.EventType>> responseEvent = page.futureEvent(RESPONSE);
     page.evaluate("() => fetch('./get', { method: 'GET'})");
     assertNotNull(responseEvent.get());
     responseWritten.acquire();

--- a/playwright/src/test/java/com/microsoft/playwright/TestPageBasic.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestPageBasic.java
@@ -103,8 +103,8 @@ public class TestPageBasic extends TestBase {
   @Test
   void shouldTerminateNetworkWaiters() {
     Page newPage = context.newPage();
-    Deferred<Request> request = newPage.waitForRequest(server.EMPTY_PAGE);
-    Deferred<Response> response = newPage.waitForResponse(server.EMPTY_PAGE);
+    Deferred<Request> request = newPage.futureRequest(server.EMPTY_PAGE);
+    Deferred<Response> response = newPage.futureResponse(server.EMPTY_PAGE);
     newPage.close();
     try {
       request.get();

--- a/playwright/src/test/java/com/microsoft/playwright/TestPageBasic.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestPageBasic.java
@@ -133,7 +133,7 @@ public class TestPageBasic extends TestBase {
   @Test
   void shouldFireLoadWhenExpected() {
     page.navigate("about:blank");
-    page.waitForLoadState(LOAD).get();
+    page.waitForLoadState(LOAD);
   }
 
   // TODO: not supported in sync api
@@ -162,7 +162,7 @@ public class TestPageBasic extends TestBase {
   @Test
   void shouldFireDomcontentloadedWhenExpected() {
     page.navigate("about:blank");
-    page.waitForLoadState(DOMCONTENTLOADED).get();
+    page.waitForLoadState(DOMCONTENTLOADED);
   }
 
   // TODO: downloads

--- a/playwright/src/test/java/com/microsoft/playwright/TestPageBasic.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestPageBasic.java
@@ -142,7 +142,7 @@ public class TestPageBasic extends TestBase {
 
   @Test
   void shouldProvideAccessToTheOpenerPage() {
-    Deferred<Event<Page.EventType>> popupEvent = page.waitForEvent(POPUP);
+    Deferred<Event<Page.EventType>> popupEvent = page.futureEvent(POPUP);
     page.evaluate("() => window.open('about:blank')");
     Page popup = (Page) popupEvent.get().data();
     Page opener = popup.opener();
@@ -151,7 +151,7 @@ public class TestPageBasic extends TestBase {
 
   @Test
   void shouldReturnNullIfParentPageHasBeenClosed() {
-    Deferred<Event<Page.EventType>> popupEvent = page.waitForEvent(POPUP);
+    Deferred<Event<Page.EventType>> popupEvent = page.futureEvent(POPUP);
     page.evaluate("() => window.open('about:blank')");
     Page popup = (Page) popupEvent.get().data();
     page.close();
@@ -194,10 +194,10 @@ public class TestPageBasic extends TestBase {
 
   @Test
   void pageCloseShouldWorkWithWindowClose() {
-    Deferred<Event<Page.EventType>> newPagePromise = page.waitForEvent(POPUP);
+    Deferred<Event<Page.EventType>> newPagePromise = page.futureEvent(POPUP);
     page.evaluate("() => window['newPage'] = window.open('about:blank')");
     Page newPage = (Page) newPagePromise.get().data();
-    Deferred<Event<Page.EventType>> closedPromise = newPage.waitForEvent(CLOSE);
+    Deferred<Event<Page.EventType>> closedPromise = newPage.futureEvent(CLOSE);
     page.evaluate("() => window['newPage'].close()");
     closedPromise.get();
   }
@@ -205,7 +205,7 @@ public class TestPageBasic extends TestBase {
   @Test
   void pageCloseShouldWorkWithPageClose() {
     Page newPage = context.newPage();
-    Deferred<Event<Page.EventType>> closedPromise = newPage.waitForEvent(CLOSE);
+    Deferred<Event<Page.EventType>> closedPromise = newPage.futureEvent(CLOSE);
     newPage.close();
     closedPromise.get();
   }

--- a/playwright/src/test/java/com/microsoft/playwright/TestPageEmulateMedia.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestPageEmulateMedia.java
@@ -86,7 +86,7 @@ public class TestPageEmulateMedia extends TestBase {
       BrowserContext context = browser.newContext(new Browser.NewContextOptions().withColorScheme(DARK));
       Page page = context.newPage();
       page.navigate(server.EMPTY_PAGE);
-      Deferred<Event<Page.EventType>> popupEvent = page.waitForEvent(POPUP);
+      Deferred<Event<Page.EventType>> popupEvent = page.futureEvent(POPUP);
       page.evaluate("url => { window.open(url); }", server.EMPTY_PAGE);
       Page popup = (Page) popupEvent.get().data();
       assertEquals(false, popup.evaluate("() => matchMedia('(prefers-color-scheme: light)').matches"));
@@ -96,7 +96,7 @@ public class TestPageEmulateMedia extends TestBase {
     {
       Page page = browser.newPage(new Browser.NewPageOptions().withColorScheme(LIGHT));
       page.navigate(server.EMPTY_PAGE);
-      Deferred<Event<Page.EventType>> popupEvent = page.waitForEvent(POPUP);
+      Deferred<Event<Page.EventType>> popupEvent = page.futureEvent(POPUP);
       page.evaluate("url => { window.open(url); }", server.EMPTY_PAGE);
       Page popup = (Page) popupEvent.get().data();
       assertEquals(true, popup.evaluate("() => matchMedia('(prefers-color-scheme: light)').matches"));

--- a/playwright/src/test/java/com/microsoft/playwright/TestPageEvaluate.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestPageEvaluate.java
@@ -435,7 +435,7 @@ public class TestPageEvaluate extends TestBase {
 
   @Test
   void shouldThrowANiceErrorAfterANavigation() {
-    Deferred<Response> navigation = page.waitForNavigation();
+    Deferred<Response> navigation = page.futureNavigation();
     try {
       page.evaluate("() => {\n" +
         "  const promise = new Promise(f => window['__resolve'] = f);\n" +

--- a/playwright/src/test/java/com/microsoft/playwright/TestPageEventNetwork.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestPageEventNetwork.java
@@ -79,7 +79,7 @@ public class TestPageEventNetwork extends TestBase {
 
   @Test
   void PageEventsRequestFinished() {
-    Deferred<Event<Page.EventType>> event = page.waitForEvent(REQUESTFINISHED);
+    Deferred<Event<Page.EventType>> event = page.futureEvent(REQUESTFINISHED);
     Response response = page.navigate(server.EMPTY_PAGE);
     event.get();
     Request request = response.request();

--- a/playwright/src/test/java/com/microsoft/playwright/TestPageExposeFunction.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestPageExposeFunction.java
@@ -184,7 +184,7 @@ public class TestPageExposeFunction extends TestBase {
     }, new Page.ExposeBindingOptions().withHandle(true));
     page.navigate(server.EMPTY_PAGE);
 
-    Deferred<Response> navigation = page.waitForNavigation(new Page.WaitForNavigationOptions().withWaitUntil(LOAD));
+    Deferred<Response> navigation = page.futureNavigation(new Page.FutureNavigationOptions().withWaitUntil(LOAD));
     page.evaluate("async url => {\n" +
       "  window['logme']({ foo: 42 });\n" +
       "  window.location.href = url;\n" +

--- a/playwright/src/test/java/com/microsoft/playwright/TestPageRoute.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestPageRoute.java
@@ -101,8 +101,9 @@ public class TestPageRoute extends TestBase {
     page.setContent("<form action='/rredirect' method='post'>\n" +
       "  <input type='hidden' id='foo' name='foo' value='FOOBAR'>\n" +
       "</form>");
+    Deferred<Response> navigationResponse = page.waitForNavigation();
     page.evalOnSelector("form", "form => form.submit()");
-    page.waitForNavigation().get();
+    navigationResponse.get();
   }
 
   // @see https://github.com/GoogleChrome/puppeteer/issues/3973

--- a/playwright/src/test/java/com/microsoft/playwright/TestPageRoute.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestPageRoute.java
@@ -101,7 +101,7 @@ public class TestPageRoute extends TestBase {
     page.setContent("<form action='/rredirect' method='post'>\n" +
       "  <input type='hidden' id='foo' name='foo' value='FOOBAR'>\n" +
       "</form>");
-    Deferred<Response> navigationResponse = page.waitForNavigation();
+    Deferred<Response> navigationResponse = page.futureNavigation();
     page.evalOnSelector("form", "form => form.submit()");
     navigationResponse.get();
   }

--- a/playwright/src/test/java/com/microsoft/playwright/TestPageRoute.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestPageRoute.java
@@ -435,7 +435,7 @@ public class TestPageRoute extends TestBase {
     Route[] route = {null};
     page.route("**/*", r -> route[0] = r);
     // Wait for request interception.
-    Deferred<Event<Page.EventType>> event = page.waitForEvent(REQUEST);
+    Deferred<Event<Page.EventType>> event = page.futureEvent(REQUEST);
     page.evalOnSelector("iframe", "(frame, url) => frame.src = url", server.EMPTY_PAGE);
     event.get();
     // Delete frame to cause request to be canceled.

--- a/playwright/src/test/java/com/microsoft/playwright/TestPageRoute.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestPageRoute.java
@@ -128,7 +128,7 @@ public class TestPageRoute extends TestBase {
       route.continue_(new Route.ContinueOverrides().withHeaders(headers));
     });
 
-    Future<Server.Request> serverRequest = server.waitForRequest("/title.html");
+    Future<Server.Request> serverRequest = server.futureRequest("/title.html");
     page.evaluate("url => fetch(url, { headers: {foo: 'bar'} })", server.PREFIX + "/title.html");
     assertFalse(serverRequest.get().headers.containsKey("foo"));
   }
@@ -233,7 +233,7 @@ public class TestPageRoute extends TestBase {
   void shouldSendReferer() throws ExecutionException, InterruptedException {
     page.setExtraHTTPHeaders(mapOf("referer", "http://google.com/"));
     page.route("**/*", route -> route.continue_());
-    Future<Server.Request> request = server.waitForRequest("/grid.html");
+    Future<Server.Request> request = server.futureRequest("/grid.html");
     page.navigate(server.PREFIX + "/grid.html");
     assertEquals(asList("http://google.com/"), request.get().headers.get("referer"));
   }

--- a/playwright/src/test/java/com/microsoft/playwright/TestPageSelectOption.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestPageSelectOption.java
@@ -94,7 +94,7 @@ public class TestPageSelectOption extends TestBase {
   void shouldNotThrowWhenSelectCausesNavigation() {
     page.navigate(server.PREFIX + "/input/select.html");
     page.evalOnSelector("select", "select => select.addEventListener('input', () => window.location.href = '/empty.html')");
-    Deferred<Response> response = page.waitForNavigation();
+    Deferred<Response> response = page.futureNavigation();
     page.selectOption("select", "blue");
     response.get();
     assertTrue(page.url().contains("empty.html"));

--- a/playwright/src/test/java/com/microsoft/playwright/TestPageSetExtraHttpHeaders.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestPageSetExtraHttpHeaders.java
@@ -29,7 +29,7 @@ public class TestPageSetExtraHttpHeaders extends TestBase {
   @Test
   void shouldWork() throws ExecutionException, InterruptedException {
     page.setExtraHTTPHeaders(mapOf("foo", "bar"));
-    Future<Server.Request> request = server.waitForRequest("/empty.html");
+    Future<Server.Request> request = server.futureRequest("/empty.html");
     page.navigate(server.EMPTY_PAGE);
     assertEquals(asList("bar"), request.get().headers.get("foo"));
     assertNull(request.get().headers.get("baz"));
@@ -39,7 +39,7 @@ public class TestPageSetExtraHttpHeaders extends TestBase {
   void shouldWorkWithRedirects() throws ExecutionException, InterruptedException {
     server.setRedirect("/foo.html", "/empty.html");
     page.setExtraHTTPHeaders(mapOf("foo", "bar"));
-    Future<Server.Request> request = server.waitForRequest("/empty.html");
+    Future<Server.Request> request = server.futureRequest("/empty.html");
     page.navigate(server.PREFIX + "/foo.html");
     assertEquals(asList("bar"), request.get().headers.get("foo"));
   }
@@ -49,7 +49,7 @@ public class TestPageSetExtraHttpHeaders extends TestBase {
     BrowserContext context = browser.newContext();
     context.setExtraHTTPHeaders(mapOf("foo", "bar"));
     Page page = context.newPage();
-    Future<Server.Request> request = server.waitForRequest("/empty.html");
+    Future<Server.Request> request = server.futureRequest("/empty.html");
     page.navigate(server.EMPTY_PAGE);
     context.close();
     assertEquals(asList("bar"), request.get().headers.get("foo"));
@@ -61,7 +61,7 @@ public class TestPageSetExtraHttpHeaders extends TestBase {
       .withExtraHTTPHeaders(mapOf("fOo", "bAr", "baR", "foO")));
     Page page = context.newPage();
     page.setExtraHTTPHeaders(mapOf("Foo", "Bar"));
-    Future<Server.Request> request = server.waitForRequest("/empty.html");
+    Future<Server.Request> request = server.futureRequest("/empty.html");
     page.navigate(server.EMPTY_PAGE);
     context.close();
     assertEquals(asList("Bar"), request.get().headers.get("foo"));

--- a/playwright/src/test/java/com/microsoft/playwright/TestPageSetInputFiles.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestPageSetInputFiles.java
@@ -67,7 +67,7 @@ public class TestPageSetInputFiles extends TestBase {
   @Test
   void shouldEmitEventOnce() {
     page.setContent("<input type=file>");
-    Deferred<Event<Page.EventType>> event = page.waitForEvent(Page.EventType.FILECHOOSER);
+    Deferred<Event<Page.EventType>> event = page.futureEvent(Page.EventType.FILECHOOSER);
     page.click("input");
     FileChooser chooser = (FileChooser) event.get().data();
     assertNotNull(chooser);
@@ -99,14 +99,14 @@ public class TestPageSetInputFiles extends TestBase {
   @Test
   void shouldWorkWhenFileInputIsAttachedToDOM() {
     page.setContent("<input type=file>");
-    Deferred<Event<Page.EventType>> chooser = page.waitForEvent(Page.EventType.FILECHOOSER);
+    Deferred<Event<Page.EventType>> chooser = page.futureEvent(Page.EventType.FILECHOOSER);
     page.click("input");
     assertNotNull(chooser.get());
   }
 
   @Test
   void shouldWorkWhenFileInputIsNotAttachedToDOM() {
-    Deferred<Event<Page.EventType>> chooser = page.waitForEvent(Page.EventType.FILECHOOSER);
+    Deferred<Event<Page.EventType>> chooser = page.futureEvent(Page.EventType.FILECHOOSER);
     page.evaluate("() => {\n" +
       "  const el = document.createElement('input');\n" +
       "  el.type = 'file';\n" +
@@ -128,7 +128,7 @@ public class TestPageSetInputFiles extends TestBase {
   @Test
   void shouldRespectTimeout() {
     try {
-      Deferred<Event<Page.EventType>> event = page.waitForEvent(Page.EventType.FILECHOOSER, new Page.WaitForEventOptions().withTimeout(1));
+      Deferred<Event<Page.EventType>> event = page.futureEvent(Page.EventType.FILECHOOSER, new Page.FutureEventOptions().withTimeout(1));
       event.get();
       fail("did not throw");
     } catch (PlaywrightException e) {
@@ -140,7 +140,7 @@ public class TestPageSetInputFiles extends TestBase {
   void shouldRespectDefaultTimeoutWhenThereIsNoCustomTimeout() {
     page.setDefaultTimeout(1);
     try {
-      Deferred<Event<Page.EventType>> event = page.waitForEvent(Page.EventType.FILECHOOSER);
+      Deferred<Event<Page.EventType>> event = page.futureEvent(Page.EventType.FILECHOOSER);
       event.get();
       fail("did not throw");
     } catch (PlaywrightException e) {
@@ -151,8 +151,8 @@ public class TestPageSetInputFiles extends TestBase {
   @Test
   void shouldPrioritizeExactTimeoutOverDefaultTimeout() {
     page.setDefaultTimeout(0);
-    Deferred<Event<Page.EventType>> event = page.waitForEvent(Page.EventType.FILECHOOSER,
-      new Page.WaitForEventOptions().withTimeout(1));
+    Deferred<Event<Page.EventType>> event = page.futureEvent(Page.EventType.FILECHOOSER,
+      new Page.FutureEventOptions().withTimeout(1));
     try {
       event.get();
       fail("did not throw");
@@ -163,8 +163,8 @@ public class TestPageSetInputFiles extends TestBase {
 
   @Test
   void shouldWorkWithNoTimeout() {
-    Deferred<Event<Page.EventType>> event = page.waitForEvent(Page.EventType.FILECHOOSER,
-      new Page.WaitForEventOptions().withTimeout(0));
+    Deferred<Event<Page.EventType>> event = page.futureEvent(Page.EventType.FILECHOOSER,
+      new Page.FutureEventOptions().withTimeout(0));
     page.evaluate("() => setTimeout(() => {\n" +
       "  const el = document.createElement('input');\n" +
       "  el.type = 'file';\n" +
@@ -176,8 +176,8 @@ public class TestPageSetInputFiles extends TestBase {
   @Test
   void shouldReturnTheSameFileChooserWhenThereAreManyWatchdogsSimultaneously() {
     page.setContent("<input type=file>");
-    Deferred<Event<Page.EventType>> fileChooser1 = page.waitForEvent(Page.EventType.FILECHOOSER);
-    Deferred<Event<Page.EventType>> fileChooser2 = page.waitForEvent(Page.EventType.FILECHOOSER);
+    Deferred<Event<Page.EventType>> fileChooser1 = page.futureEvent(Page.EventType.FILECHOOSER);
+    Deferred<Event<Page.EventType>> fileChooser2 = page.futureEvent(Page.EventType.FILECHOOSER);
     page.evalOnSelector("input", "input => input.click()");
     assertEquals(fileChooser1.get().data(), fileChooser2.get().data());
   }
@@ -185,7 +185,7 @@ public class TestPageSetInputFiles extends TestBase {
   @Test
   void shouldAcceptSingleFile() {
     page.setContent("<input type=file oninput='javascript:console.timeStamp()'>");
-    Deferred<Event<Page.EventType>> event = page.waitForEvent(Page.EventType.FILECHOOSER);
+    Deferred<Event<Page.EventType>> event = page.futureEvent(Page.EventType.FILECHOOSER);
     page.click("input");
     FileChooser fileChooser = (FileChooser) event.get().data();
     assertEquals(page, fileChooser.page());
@@ -255,7 +255,7 @@ public class TestPageSetInputFiles extends TestBase {
   @Test
   void shouldNotAcceptMultipleFilesForSingleFileInput() {
     page.setContent("<input type=file>");
-    Deferred<Event<Page.EventType>> event = page.waitForEvent(Page.EventType.FILECHOOSER);
+    Deferred<Event<Page.EventType>> event = page.futureEvent(Page.EventType.FILECHOOSER);
     page.click("input");
     FileChooser fileChooser = (FileChooser) event.get().data();
     try {
@@ -281,7 +281,7 @@ public class TestPageSetInputFiles extends TestBase {
   @Test
   void shouldWorkForSingleFilePick() {
     page.setContent("<input type=file>");
-    Deferred<Event<Page.EventType>> event = page.waitForEvent(Page.EventType.FILECHOOSER);
+    Deferred<Event<Page.EventType>> event = page.futureEvent(Page.EventType.FILECHOOSER);
     page.click("input");
     FileChooser fileChooser = (FileChooser) event.get().data();
     assertFalse(fileChooser.isMultiple());
@@ -290,7 +290,7 @@ public class TestPageSetInputFiles extends TestBase {
   @Test
   void shouldWorkForMultiple() {
     page.setContent("<input multiple type=file>");
-    Deferred<Event<Page.EventType>> event = page.waitForEvent(Page.EventType.FILECHOOSER);
+    Deferred<Event<Page.EventType>> event = page.futureEvent(Page.EventType.FILECHOOSER);
     page.click("input");
     FileChooser fileChooser = (FileChooser) event.get().data();
     assertTrue(fileChooser.isMultiple());
@@ -299,7 +299,7 @@ public class TestPageSetInputFiles extends TestBase {
   @Test
   void shouldWorkForWebkitdirectory() {
     page.setContent("<input multiple webkitdirectory type=file>");
-    Deferred<Event<Page.EventType>> event = page.waitForEvent(Page.EventType.FILECHOOSER);
+    Deferred<Event<Page.EventType>> event = page.futureEvent(Page.EventType.FILECHOOSER);
     page.click("input");
     FileChooser fileChooser = (FileChooser) event.get().data();
     assertTrue(fileChooser.isMultiple());

--- a/playwright/src/test/java/com/microsoft/playwright/TestPageSetInputFiles.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestPageSetInputFiles.java
@@ -91,7 +91,7 @@ public class TestPageSetInputFiles extends TestBase {
     page.click("input");
     Instant start = Instant.now();
     while (chooser[0] == null && Duration.between(start, Instant.now()).toMillis() < 10_000) {
-      page.waitForTimeout(100).get();
+      page.waitForTimeout(100);
     }
     assertNotNull(chooser[0]);
   }

--- a/playwright/src/test/java/com/microsoft/playwright/TestPageWaitForNavigation.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestPageWaitForNavigation.java
@@ -32,7 +32,7 @@ public class TestPageWaitForNavigation extends TestBase {
   @Test
   void shouldWork() {
     page.navigate(server.EMPTY_PAGE);
-    Deferred<Response> response = page.waitForNavigation();
+    Deferred<Response> response = page.futureNavigation();
     page.evaluate("url => window.location.href = url", server.PREFIX + "/grid.html");
     assertTrue(response.get().ok());
     assertTrue(response.get().url().contains("grid.html"));
@@ -40,13 +40,13 @@ public class TestPageWaitForNavigation extends TestBase {
 
   @Test
   void shouldRespectTimeout() {
-    Deferred<Response> promise = page.waitForNavigation(new Page.WaitForNavigationOptions().withUrl("**/frame.html").withTimeout(5000));
+    Deferred<Response> promise = page.futureNavigation(new Page.FutureNavigationOptions().withUrl("**/frame.html").withTimeout(5000));
     page.navigate(server.EMPTY_PAGE);
     try {
       promise.get();
       fail("did not throw");
     } catch (PlaywrightException e) {
-//      assertTrue(e.getMessage().contains("page.waitForNavigation: Timeout 5000ms exceeded."));
+//      assertTrue(e.getMessage().contains("page.futureNavigation: Timeout 5000ms exceeded."));
       assertTrue(e.getMessage().contains("Timeout 5000ms exceeded"));
 //      assertTrue(e.getMessage().contains("waiting for navigation to '**/frame.html' until 'load'"));
 //      assertTrue(e.getMessage().contains("navigated to '${server.EMPTY_PAGE}'"));
@@ -61,7 +61,7 @@ public class TestPageWaitForNavigation extends TestBase {
   void shouldWorkWithClickingOnAnchorLinks() {
     page.navigate(server.EMPTY_PAGE);
     page.setContent("<a href='#foobar'>foobar</a>");
-    Deferred<Response> response = page.waitForNavigation();
+    Deferred<Response> response = page.futureNavigation();
     page.click("a");
     assertNull(response.get());
     assertEquals(server.EMPTY_PAGE + "#foobar", page.url());
@@ -70,7 +70,7 @@ public class TestPageWaitForNavigation extends TestBase {
   @Test
   void shouldWorkWithClickingOnLinksWhichDoNotCommitNavigation() throws InterruptedException {
     page.navigate(server.EMPTY_PAGE);
-    Deferred<Response> event = page.waitForNavigation();
+    Deferred<Response> event = page.futureNavigation();
     page.setContent("<a href='" + httpsServer.EMPTY_PAGE + "'>foobar</a>");
     try {
       page.click("a");
@@ -91,7 +91,7 @@ public class TestPageWaitForNavigation extends TestBase {
       "<script>\n" +
       "  function pushState() { history.pushState({}, '', 'wow.html') }\n" +
       "</script>");
-    Deferred<Response> response = page.waitForNavigation();
+    Deferred<Response> response = page.futureNavigation();
     page.click("a");
     assertNull(response.get());
     assertEquals(server.PREFIX + "/wow.html", page.url());
@@ -104,7 +104,7 @@ public class TestPageWaitForNavigation extends TestBase {
       "<script>\n" +
       "  function replaceState() { history.replaceState({}, '', '/replaced.html') }\n" +
       "</script>");
-    Deferred<Response> response = page.waitForNavigation();
+    Deferred<Response> response = page.futureNavigation();
     page.click("a");
     assertNull(response.get());
     assertEquals(server.PREFIX + "/replaced.html", page.url());
@@ -123,12 +123,12 @@ public class TestPageWaitForNavigation extends TestBase {
       "</script>");
     assertEquals(server.PREFIX + "/second.html", page.url());
 
-    Deferred<Response> backResponse = page.waitForNavigation();
+    Deferred<Response> backResponse = page.futureNavigation();
     page.click("a#back");
     assertNull(backResponse.get());
     assertEquals(server.PREFIX + "/first.html", page.url());
 
-    Deferred<Response> forwardResponse = page.waitForNavigation();
+    Deferred<Response> forwardResponse = page.futureNavigation();
     page.click("a#forward");
     assertNull(forwardResponse.get());
     assertEquals(server.PREFIX + "/second.html", page.url());
@@ -155,17 +155,17 @@ public class TestPageWaitForNavigation extends TestBase {
   void shouldWorkWithUrlMatch() {
     page.navigate(server.EMPTY_PAGE);
 
-    Deferred<Response> response1 = page.waitForNavigation(new Page.WaitForNavigationOptions().withUrl("**/one-style.html"));
+    Deferred<Response> response1 = page.futureNavigation(new Page.FutureNavigationOptions().withUrl("**/one-style.html"));
     page.navigate(server.PREFIX + "/one-style.html");
     assertNotNull(response1.get());
     assertEquals(server.PREFIX + "/one-style.html", response1.get().url());
 
-    Deferred<Response> response2 = page.waitForNavigation(new Page.WaitForNavigationOptions().withUrl(Pattern.compile("frame.html$")));
+    Deferred<Response> response2 = page.futureNavigation(new Page.FutureNavigationOptions().withUrl(Pattern.compile("frame.html$")));
     page.navigate(server.PREFIX + "/frame.html");
     assertNotNull(response2.get());
     assertEquals(server.PREFIX + "/frame.html", response2.get().url());
 
-    Deferred<Response> response3 = page.waitForNavigation(new Page.WaitForNavigationOptions().withUrl(url -> {
+    Deferred<Response> response3 = page.futureNavigation(new Page.FutureNavigationOptions().withUrl(url -> {
       try {
         return new URL(url).getQuery().contains("foo=bar");
       } catch (MalformedURLException e) {
@@ -180,7 +180,7 @@ public class TestPageWaitForNavigation extends TestBase {
   @Test
   void shouldWorkWithUrlMatchForSameDocumentNavigations() {
     page.navigate(server.EMPTY_PAGE);
-    Deferred<Response> waitPromise = page.waitForNavigation(new Page.WaitForNavigationOptions().withUrl("**/third.html"));
+    Deferred<Response> waitPromise = page.futureNavigation(new Page.FutureNavigationOptions().withUrl("**/third.html"));
     page.evaluate("() => {\n" +
       "  history.pushState({}, '', '/first.html');\n" +
       "}");
@@ -196,7 +196,7 @@ public class TestPageWaitForNavigation extends TestBase {
   @Test
   void shouldWorkForCrossProcessNavigations() {
     page.navigate(server.EMPTY_PAGE);
-    Deferred<Response> waitPromise = page.waitForNavigation(new Page.WaitForNavigationOptions().withWaitUntil(Frame.LoadState.DOMCONTENTLOADED));
+    Deferred<Response> waitPromise = page.futureNavigation(new Page.FutureNavigationOptions().withWaitUntil(Frame.LoadState.DOMCONTENTLOADED));
     String url = server.CROSS_PROCESS_PREFIX + "/empty.html";
     page.navigate(url);
     Response response = waitPromise.get();
@@ -209,7 +209,7 @@ public class TestPageWaitForNavigation extends TestBase {
   void shouldWorkOnFrame() {
     page.navigate(server.PREFIX + "/frames/one-frame.html");
     Frame frame = page.frames().get(1);
-    Deferred<Response> response = frame.waitForNavigation();
+    Deferred<Response> response = frame.futureNavigation();
     frame.evaluate("url => window.location.href = url", server.PREFIX + "/grid.html");
     assertTrue(response.get().ok());
     assertTrue(response.get().url().contains("grid.html"));
@@ -223,7 +223,7 @@ public class TestPageWaitForNavigation extends TestBase {
     Frame frame = page.frames().get(1);
     server.setRoute("/empty.html", exchange -> {});
     try {
-      Deferred<Response> response = frame.waitForNavigation();
+      Deferred<Response> response = frame.futureNavigation();
       page.evaluate("() => {\n" +
         "  frames[0].location.href = '/empty.html';\n" +
         "  setTimeout(() => document.querySelector('iframe').remove());\n" +

--- a/playwright/src/test/java/com/microsoft/playwright/TestPageWaitForRequest.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestPageWaitForRequest.java
@@ -52,7 +52,7 @@ public class TestPageWaitForRequest extends TestBase {
   @Test
   void shouldRespectTimeout() {
     try {
-      page.waitForEvent(REQUEST, new Page.WaitForEventOptions()
+      page.futureEvent(REQUEST, new Page.FutureEventOptions()
         .withPredicate(url -> false).withTimeout(1)).get();
       fail("did not throw");
     } catch (PlaywrightException e) {
@@ -64,7 +64,7 @@ public class TestPageWaitForRequest extends TestBase {
   void shouldRespectDefaultTimeout() {
     page.setDefaultTimeout(1);
     try {
-      page.waitForEvent(REQUEST, url -> false).get();
+      page.futureEvent(REQUEST, url -> false).get();
       fail("did not throw");
     } catch (PlaywrightException e) {
       assertTrue(e.getMessage().contains("Timeout"), e.getMessage());

--- a/playwright/src/test/java/com/microsoft/playwright/TestPageWaitForRequest.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestPageWaitForRequest.java
@@ -28,7 +28,7 @@ public class TestPageWaitForRequest extends TestBase {
   @Test
   void shouldWork() {
     page.navigate(server.EMPTY_PAGE);
-    Deferred<Request> request = page.waitForRequest(server.PREFIX + "/digits/2.png");
+    Deferred<Request> request = page.futureRequest(server.PREFIX + "/digits/2.png");
     page.evaluate("() => {\n" +
       "  fetch('/digits/1.png');\n" +
       "  fetch('/digits/2.png');\n" +
@@ -40,7 +40,7 @@ public class TestPageWaitForRequest extends TestBase {
   @Test
   void shouldWorkWithPredicate() {
     page.navigate(server.EMPTY_PAGE);
-    Deferred<Request> request = page.waitForRequest(url -> url.equals(server.PREFIX + "/digits/2.png"));
+    Deferred<Request> request = page.futureRequest(url -> url.equals(server.PREFIX + "/digits/2.png"));
     page.evaluate("() => {\n" +
       "  fetch('/digits/1.png');\n" +
       "  fetch('/digits/2.png');\n" +
@@ -74,8 +74,8 @@ public class TestPageWaitForRequest extends TestBase {
   @Test
   void shouldWorkWithNoTimeout() {
     page.navigate(server.EMPTY_PAGE);
-    Deferred<Request> request = page.waitForRequest(server.PREFIX + "/digits/2.png",
-      new Page.WaitForRequestOptions().withTimeout(0));
+    Deferred<Request> request = page.futureRequest(server.PREFIX + "/digits/2.png",
+      new Page.FutureRequestOptions().withTimeout(0));
     page.evaluate("() => setTimeout(() => {\n" +
       "  fetch('/digits/1.png');\n" +
       "  fetch('/digits/2.png');\n" +
@@ -87,7 +87,7 @@ public class TestPageWaitForRequest extends TestBase {
   @Test
   void shouldWorkWithUrlMatch() {
     page.navigate(server.EMPTY_PAGE);
-    Deferred<Request> request = page.waitForRequest(Pattern.compile(".*digits/\\d\\.png"));
+    Deferred<Request> request = page.futureRequest(Pattern.compile(".*digits/\\d\\.png"));
     page.evaluate("() => {\n" +
       "  fetch('/digits/1.png');\n" +
       "}");

--- a/playwright/src/test/java/com/microsoft/playwright/TestPageWaitForResponse.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestPageWaitForResponse.java
@@ -63,7 +63,7 @@ public class TestPageWaitForResponse extends TestBase {
   void shouldRespectDefaultTimeout() {
     page.setDefaultTimeout(1);
     try {
-      page.waitForEvent(RESPONSE, url -> false).get();
+      page.futureEvent(RESPONSE, url -> false).get();
       fail("did not throw");
     } catch (PlaywrightException e) {
       assertTrue(e.getMessage().contains("Timeout"), e.getMessage());

--- a/playwright/src/test/java/com/microsoft/playwright/TestPageWaitForResponse.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestPageWaitForResponse.java
@@ -26,7 +26,7 @@ public class TestPageWaitForResponse extends TestBase {
   @Test
   void shouldWork() {
     page.navigate(server.EMPTY_PAGE);
-    Deferred<Response> response = page.waitForResponse(server.PREFIX + "/digits/2.png");
+    Deferred<Response> response = page.futureResponse(server.PREFIX + "/digits/2.png");
     page.evaluate("() => {\n" +
       "  fetch('/digits/1.png');\n" +
       "  fetch('/digits/2.png');\n" +
@@ -38,7 +38,7 @@ public class TestPageWaitForResponse extends TestBase {
   @Test
   void shouldRespectTimeout() {
     page.navigate(server.EMPTY_PAGE);
-    Deferred<Response> response = page.waitForResponse(url -> url.equals(server.PREFIX + "/digits/2.png"));
+    Deferred<Response> response = page.futureResponse(url -> url.equals(server.PREFIX + "/digits/2.png"));
     page.evaluate("() => {\n" +
       "  fetch('/digits/1.png');\n" +
       "  fetch('/digits/2.png');\n" +
@@ -50,7 +50,7 @@ public class TestPageWaitForResponse extends TestBase {
   @Test
   void shouldWorkWithPredicate() {
     page.navigate(server.EMPTY_PAGE);
-    Deferred<Response> response = page.waitForResponse(url -> url.equals(server.PREFIX + "/digits/2.png"));
+    Deferred<Response> response = page.futureResponse(url -> url.equals(server.PREFIX + "/digits/2.png"));
     page.evaluate("() => {\n" +
       "  fetch('/digits/1.png');\n" +
       "  fetch('/digits/2.png');\n" +
@@ -73,8 +73,8 @@ public class TestPageWaitForResponse extends TestBase {
   @Test
   void shouldWorkWithNoTimeout() {
     page.navigate(server.EMPTY_PAGE);
-    Deferred<Response> response = page.waitForResponse(server.PREFIX + "/digits/2.png",
-      new Page.WaitForResponseOptions().withTimeout(0));
+    Deferred<Response> response = page.futureResponse(server.PREFIX + "/digits/2.png",
+      new Page.FutureResponseOptions().withTimeout(0));
     page.evaluate("() => setTimeout(() => {\n" +
       "  fetch('/digits/1.png');\n" +
       "  fetch('/digits/2.png');\n" +

--- a/playwright/src/test/java/com/microsoft/playwright/TestPopup.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestPopup.java
@@ -41,7 +41,7 @@ public class TestPopup extends TestBase {
     Deferred<Event<BrowserContext.EventType>> popupEvent = context.waitForEvent(BrowserContext.EventType.PAGE);
     page.click("a");
     Page popup = (Page) popupEvent.get().data();
-    popup.waitForLoadState(DOMCONTENTLOADED).get();
+    popup.waitForLoadState(DOMCONTENTLOADED);
     String userAgent = (String) popup.evaluate("() => window['initialUserAgent']");
     Server.Request request = requestPromise.get();
     context.close();
@@ -106,7 +106,7 @@ public class TestPopup extends TestBase {
     Deferred<Event<Page.EventType>> popupEvent = page.waitForEvent(POPUP);
     page.evaluate("url => window['_popup'] = window.open(url)", server.PREFIX + "/title.html");
     Page popup = (Page) popupEvent.get().data();
-    popup.waitForLoadState(DOMCONTENTLOADED).get();
+    popup.waitForLoadState(DOMCONTENTLOADED);
     assertEquals("Woof-Woof", popup.title());
     context.close();
   }
@@ -153,7 +153,7 @@ public class TestPopup extends TestBase {
       "}");
     Page popup = (Page) popupEvent.get().data();
     popup.setViewportSize(500, 400);
-    popup.waitForLoadState().get();
+    popup.waitForLoadState();
     Object resized = popup.evaluate("() => ({ width: window.innerWidth, height: window.innerHeight })");
     context.close();
     assertEquals(mapOf("width", 600, "height", 300), size);

--- a/playwright/src/test/java/com/microsoft/playwright/TestPopup.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestPopup.java
@@ -37,7 +37,7 @@ public class TestPopup extends TestBase {
     Page page = context.newPage();
     page.navigate(server.EMPTY_PAGE);
     page.setContent("<a target=_blank rel=noopener href='/popup/popup.html'>link</a>");
-    Future<Server.Request> requestPromise = server.waitForRequest("/popup/popup.html");
+    Future<Server.Request> requestPromise = server.futureRequest("/popup/popup.html");
     Deferred<Event<BrowserContext.EventType>> popupEvent = context.futureEvent(BrowserContext.EventType.PAGE);
     page.click("a");
     Page popup = (Page) popupEvent.get().data();
@@ -75,7 +75,7 @@ public class TestPopup extends TestBase {
       .withExtraHTTPHeaders(mapOf("foo", "bar")));
     Page page = context.newPage();
     page.navigate(server.EMPTY_PAGE);
-    Future<Server.Request> requestPromise = server.waitForRequest("/dummy.html");
+    Future<Server.Request> requestPromise = server.futureRequest("/dummy.html");
     page.evaluate("url => window['_popup'] = window.open(url)", server.PREFIX + "/dummy.html");
     Server.Request request = requestPromise.get();
     context.close();

--- a/playwright/src/test/java/com/microsoft/playwright/TestPopup.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestPopup.java
@@ -38,7 +38,7 @@ public class TestPopup extends TestBase {
     page.navigate(server.EMPTY_PAGE);
     page.setContent("<a target=_blank rel=noopener href='/popup/popup.html'>link</a>");
     Future<Server.Request> requestPromise = server.waitForRequest("/popup/popup.html");
-    Deferred<Event<BrowserContext.EventType>> popupEvent = context.waitForEvent(BrowserContext.EventType.PAGE);
+    Deferred<Event<BrowserContext.EventType>> popupEvent = context.futureEvent(BrowserContext.EventType.PAGE);
     page.click("a");
     Page popup = (Page) popupEvent.get().data();
     popup.waitForLoadState(DOMCONTENTLOADED);
@@ -60,7 +60,7 @@ public class TestPopup extends TestBase {
       route.continue_();
       intercepted[0] = true;
     });
-    Deferred<Event<BrowserContext.EventType>> popup = context.waitForEvent(BrowserContext.EventType.PAGE);
+    Deferred<Event<BrowserContext.EventType>> popup = context.futureEvent(BrowserContext.EventType.PAGE);
     page.click("a");
     popup.get();
 
@@ -103,7 +103,7 @@ public class TestPopup extends TestBase {
       .withHttpCredentials("user", "pass"));
     Page page = context.newPage();
     page.navigate(server.EMPTY_PAGE);
-    Deferred<Event<Page.EventType>> popupEvent = page.waitForEvent(POPUP);
+    Deferred<Event<Page.EventType>> popupEvent = page.futureEvent(POPUP);
     page.evaluate("url => window['_popup'] = window.open(url)", server.PREFIX + "/title.html");
     Page popup = (Page) popupEvent.get().data();
     popup.waitForLoadState(DOMCONTENTLOADED);
@@ -146,7 +146,7 @@ public class TestPopup extends TestBase {
       .withViewport(700, 700));
     Page page = context.newPage();
     page.navigate(server.EMPTY_PAGE);
-    Deferred<Event<Page.EventType>> popupEvent = page.waitForEvent(POPUP);
+    Deferred<Event<Page.EventType>> popupEvent = page.futureEvent(POPUP);
     Object size = page.evaluate("() => {\n" +
       "  const win = window.open(window.location.href, 'Title', 'toolbar=no,location=no,directories=no,status=no,menubar=no,scrollbars=yes,resizable=yes,width=600,height=300,top=0,left=0');\n" +
       "  return { width: win.innerWidth, height: win.innerHeight };\n" +
@@ -170,7 +170,7 @@ public class TestPopup extends TestBase {
       route.continue_();
       intercepted[0] = true;
     });
-    Deferred<Event<Page.EventType>> popupEvent = page.waitForEvent(POPUP);
+    Deferred<Event<Page.EventType>> popupEvent = page.futureEvent(POPUP);
     page.evaluate("url => window['__popup'] = window.open(url)", server.EMPTY_PAGE);
     popupEvent.get();
     assertTrue(intercepted[0]);
@@ -197,7 +197,7 @@ public class TestPopup extends TestBase {
     context.addInitScript("() => window['injected'] = 123");
     Page page = context.newPage();
     page.navigate(server.EMPTY_PAGE);
-    Deferred<Event<Page.EventType>> popupEvent = page.waitForEvent(POPUP);
+    Deferred<Event<Page.EventType>> popupEvent = page.futureEvent(POPUP);
     page.evaluate("url => window.open(url)", server.CROSS_PROCESS_PREFIX + "/title.html");
     Page popup = (Page) popupEvent.get().data();
     assertEquals(123, popup.evaluate("injected"));

--- a/playwright/src/test/java/com/microsoft/playwright/TestRequestContinue.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestRequestContinue.java
@@ -66,7 +66,7 @@ public class TestRequestContinue extends TestBase {
     page.route("**/foo", route -> {
       route.continue_(new Route.ContinueOverrides().withUrl(server.PREFIX + "/global-var.html"));
     });
-    Deferred<Event<Page.EventType>> responseEvent = page.waitForEvent(RESPONSE);
+    Deferred<Event<Page.EventType>> responseEvent = page.futureEvent(RESPONSE);
     page.navigate(server.PREFIX + "/foo");
     Response response = (Response) responseEvent.get().data();
     assertEquals(server.PREFIX + "/foo", response.url());

--- a/playwright/src/test/java/com/microsoft/playwright/TestRequestContinue.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestRequestContinue.java
@@ -44,17 +44,17 @@ public class TestRequestContinue extends TestBase {
       route.continue_(new Route.ContinueOverrides().withHeaders(headers));
     });
     page.navigate(server.EMPTY_PAGE);
-    Future<Server.Request> request = server.waitForRequest("/sleep.zzz");
+    Future<Server.Request> request = server.futureRequest("/sleep.zzz");
     page.evaluate("() => fetch('/sleep.zzz')");
     assertEquals(Arrays.asList("bar"), request.get().headers.get("foo"));
   }
 
   @Test
   void shouldAmendMethod() throws ExecutionException, InterruptedException {
-    Future<Server.Request> sRequest = server.waitForRequest("/sleep.zzz");
+    Future<Server.Request> sRequest = server.futureRequest("/sleep.zzz");
     page.navigate(server.EMPTY_PAGE);
     page.route("**/*", route -> route.continue_(new Route.ContinueOverrides().withMethod("POST")));
-    Future<Server.Request> request = server.waitForRequest("/sleep.zzz");
+    Future<Server.Request> request = server.futureRequest("/sleep.zzz");
     page.evaluate("() => fetch('/sleep.zzz')");
     assertEquals("POST", request.get().method);
     assertEquals("POST", sRequest.get().method);
@@ -62,7 +62,7 @@ public class TestRequestContinue extends TestBase {
 
   @Test
   void shouldOverrideRequestUrl() throws ExecutionException, InterruptedException {
-    Future<Server.Request> serverRequest = server.waitForRequest("/global-var.html");
+    Future<Server.Request> serverRequest = server.futureRequest("/global-var.html");
     page.route("**/foo", route -> {
       route.continue_(new Route.ContinueOverrides().withUrl(server.PREFIX + "/global-var.html"));
     });
@@ -92,7 +92,7 @@ public class TestRequestContinue extends TestBase {
 
   @Test
   void shouldOverrideMethodAlongWithUrl() throws ExecutionException, InterruptedException {
-    Future<Server.Request> serverRequest = server.waitForRequest("/empty.html");
+    Future<Server.Request> serverRequest = server.futureRequest("/empty.html");
     page.route("**/foo", route -> {
       route.continue_(new Route.ContinueOverrides().withUrl(server.EMPTY_PAGE).withMethod("POST"));
     });
@@ -102,7 +102,7 @@ public class TestRequestContinue extends TestBase {
 
   @Test
   void shouldAmendMethodOnMainRequest() throws ExecutionException, InterruptedException {
-    Future<Server.Request> request = server.waitForRequest("/empty.html");
+    Future<Server.Request> request = server.futureRequest("/empty.html");
     page.route("**/*", route -> route.continue_(new Route.ContinueOverrides().withMethod("POST")));
     page.navigate(server.EMPTY_PAGE);
     assertEquals("POST", request.get().method);
@@ -114,7 +114,7 @@ public class TestRequestContinue extends TestBase {
     page.route("**/*", route -> {
       route.continue_(new Route.ContinueOverrides().withPostData("doggo"));
     });
-    Future<Server.Request> serverRequest = server.waitForRequest("/sleep.zzz");
+    Future<Server.Request> serverRequest = server.futureRequest("/sleep.zzz");
     page.evaluate("() => fetch('/sleep.zzz', { method: 'POST', body: 'birdy' })");
     assertEquals("doggo", new String(serverRequest.get().postBody, UTF_8));
   }
@@ -125,7 +125,7 @@ public class TestRequestContinue extends TestBase {
     page.route("**/*", route -> {
       route.continue_(new Route.ContinueOverrides().withPostData("пушкин"));
     });
-    Future<Server.Request> serverRequest = server.waitForRequest("/sleep.zzz");
+    Future<Server.Request> serverRequest = server.futureRequest("/sleep.zzz");
     page.evaluate("() => fetch('/sleep.zzz', { method: 'POST', body: 'birdy' })");
     assertEquals("POST", serverRequest.get().method);
     assertEquals("пушкин", new String(serverRequest.get().postBody, UTF_8));
@@ -137,7 +137,7 @@ public class TestRequestContinue extends TestBase {
     page.route("**/*", route -> {
       route.continue_(new Route.ContinueOverrides().withPostData("doggo-is-longer-than-birdy"));
     });
-    Future<Server.Request> serverRequest = server.waitForRequest("/sleep.zzz");
+    Future<Server.Request> serverRequest = server.futureRequest("/sleep.zzz");
     page.evaluate("() => fetch('/sleep.zzz', { method: 'POST', body: 'birdy' })");
     assertEquals("POST", serverRequest.get().method);
     assertEquals("doggo-is-longer-than-birdy", new String(serverRequest.get().postBody, UTF_8));
@@ -153,7 +153,7 @@ public class TestRequestContinue extends TestBase {
     page.route("**/*", route -> {
       route.continue_(new Route.ContinueOverrides().withPostData(arr));
     });
-    Future<Server.Request> serverRequest = server.waitForRequest("/sleep.zzz");
+    Future<Server.Request> serverRequest = server.futureRequest("/sleep.zzz");
     page.evaluate("() => fetch('/sleep.zzz', { method: 'POST', body: 'birdy' })");
     assertEquals("POST", serverRequest.get().method);
     byte[] buffer = serverRequest.get().postBody;

--- a/playwright/src/test/java/com/microsoft/playwright/TestWebSocket.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestWebSocket.java
@@ -201,7 +201,7 @@ public class TestWebSocket extends TestBase {
 
   @Test
   void shouldNotHaveStrayErrorEvents() {
-    Deferred<Event<Page.EventType>> wsEvent = page.waitForEvent(WEBSOCKET);
+    Deferred<Event<Page.EventType>> wsEvent = page.futureEvent(WEBSOCKET);
     page.evaluate("port => {\n" +
       "  window.ws = new WebSocket('ws://localhost:' + port + '/ws');\n" +
       "}", webSocketServer.getPort());
@@ -209,22 +209,22 @@ public class TestWebSocket extends TestBase {
     com.microsoft.playwright.WebSocket ws = (com.microsoft.playwright.WebSocket) wsEvent.get().data();
     boolean[] error = {false};
     ws.addListener(SOCKETERROR, e -> error[0] = true);
-    Deferred<Event<com.microsoft.playwright.WebSocket.EventType>> frameReceivedEvent = ws.waitForEvent(FRAMERECEIVED);
+    Deferred<Event<com.microsoft.playwright.WebSocket.EventType>> frameReceivedEvent = ws.futureEvent(FRAMERECEIVED);
     frameReceivedEvent.get();
     page.evaluate("window.ws.close()");
     assertFalse(error[0]);
   }
 
   @Test
-  void shouldRejectWaitForEventOnSocketClose() {
-    Deferred<Event<Page.EventType>> wsEvent = page.waitForEvent(WEBSOCKET);
+  void shouldRejectFutureEventOnSocketClose() {
+    Deferred<Event<Page.EventType>> wsEvent = page.futureEvent(WEBSOCKET);
     page.evaluate("port => {\n" +
       "  window.ws = new WebSocket('ws://localhost:' + port + '/ws');\n" +
       "}", webSocketServer.getPort());
 
     com.microsoft.playwright.WebSocket ws = (com.microsoft.playwright.WebSocket) wsEvent.get().data();
-    ws.waitForEvent(FRAMERECEIVED).get();
-    Deferred<Event<com.microsoft.playwright.WebSocket.EventType>> frameSentEvent = ws.waitForEvent(FRAMESENT);
+    ws.futureEvent(FRAMERECEIVED).get();
+    Deferred<Event<com.microsoft.playwright.WebSocket.EventType>> frameSentEvent = ws.futureEvent(FRAMESENT);
     page.evaluate("window.ws.close()");
     try {
       frameSentEvent.get();
@@ -235,15 +235,15 @@ public class TestWebSocket extends TestBase {
   }
 
   @Test
-  void shouldRejectWaitForEventOnPageClose() {
-    Deferred<Event<Page.EventType>> wsEvent = page.waitForEvent(WEBSOCKET);
+  void shouldRejectFutureEventOnPageClose() {
+    Deferred<Event<Page.EventType>> wsEvent = page.futureEvent(WEBSOCKET);
     page.evaluate("port => {\n" +
       "  window.ws = new WebSocket('ws://localhost:' + port + '/ws');\n" +
       "}", webSocketServer.getPort());
 
     com.microsoft.playwright.WebSocket ws = (com.microsoft.playwright.WebSocket) wsEvent.get().data();
-    ws.waitForEvent(FRAMERECEIVED).get();
-    Deferred<Event<com.microsoft.playwright.WebSocket.EventType>> frameSentEvent = ws.waitForEvent(FRAMESENT);
+    ws.futureEvent(FRAMERECEIVED).get();
+    Deferred<Event<com.microsoft.playwright.WebSocket.EventType>> frameSentEvent = ws.futureEvent(FRAMESENT);
     page.close();
     try {
       frameSentEvent.get();

--- a/playwright/src/test/java/com/microsoft/playwright/TestWebSocket.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestWebSocket.java
@@ -83,7 +83,7 @@ public class TestWebSocket extends TestBase {
     assertEquals(1, condition.length);
     Instant start = Instant.now();
     while (!condition[0]) {
-      page.waitForTimeout(100).get();
+      page.waitForTimeout(100);
       assertTrue(Duration.between(start, Instant.now()).getSeconds() < 30, "Timed out");
     }
   }

--- a/playwright/src/test/java/com/microsoft/playwright/TestWorkers.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestWorkers.java
@@ -29,7 +29,7 @@ public class TestWorkers extends TestBase {
 
   @Test
   void pageWorkers() {
-    Deferred<Event<Page.EventType>> workerEvent = page.waitForEvent(WORKER);
+    Deferred<Event<Page.EventType>> workerEvent = page.futureEvent(WORKER);
     page.navigate(server.PREFIX + "/worker/worker.html");
     workerEvent.get();
     Worker worker = page.workers().get(0);
@@ -41,11 +41,11 @@ public class TestWorkers extends TestBase {
 
   @Test
   void shouldEmitCreatedAndDestroyedEvents() {
-    Deferred<Event<Page.EventType>> workerCreatedPromise = page.waitForEvent(WORKER);
+    Deferred<Event<Page.EventType>> workerCreatedPromise = page.futureEvent(WORKER);
     JSHandle workerObj = page.evaluateHandle("() => new Worker(URL.createObjectURL(new Blob(['1'], {type: 'application/javascript'})))");
     Worker worker = (Worker) workerCreatedPromise.get().data();
     JSHandle workerThisObj = worker.evaluateHandle("() => this");
-    Deferred<Event<Worker.EventType>> workerDestroyedPromise = worker.waitForEvent(Worker.EventType.CLOSE);
+    Deferred<Event<Worker.EventType>> workerDestroyedPromise = worker.futureEvent(Worker.EventType.CLOSE);
     page.evaluate("workerObj => workerObj.terminate()", workerObj);
     assertEquals(worker, workerDestroyedPromise.get().data());
     try {
@@ -57,14 +57,14 @@ public class TestWorkers extends TestBase {
 
   @Test
   void shouldReportConsoleLogs() {
-    Deferred<Event<Page.EventType>> consoleEvent = page.waitForEvent(CONSOLE);
+    Deferred<Event<Page.EventType>> consoleEvent = page.futureEvent(CONSOLE);
     page.evaluate("() => new Worker(URL.createObjectURL(new Blob(['console.log(1)'], {type: 'application/javascript'})))");
     assertEquals("1", ((ConsoleMessage) consoleEvent.get().data()).text());
   }
 
   @Test
   void shouldHaveJSHandlesForConsoleLogs() {
-    Deferred<Event<Page.EventType>> consoleEvent = page.waitForEvent(CONSOLE);
+    Deferred<Event<Page.EventType>> consoleEvent = page.futureEvent(CONSOLE);
     page.evaluate("() => new Worker(URL.createObjectURL(new Blob(['console.log(1,2,3,this)'], {type: 'application/javascript'})))");
     ConsoleMessage log = (ConsoleMessage) consoleEvent.get().data();
     assertEquals("1 2 3 JSHandle@object", log.text());
@@ -74,7 +74,7 @@ public class TestWorkers extends TestBase {
 
   @Test
   void shouldEvaluate() {
-    Deferred<Event<Page.EventType>> workerCreatedPromise = page.waitForEvent(WORKER);
+    Deferred<Event<Page.EventType>> workerCreatedPromise = page.futureEvent(WORKER);
     page.evaluate("() => new Worker(URL.createObjectURL(new Blob(['console.log(1)'], {type: 'application/javascript'})))");
     Worker worker = (Worker) workerCreatedPromise.get().data();
     assertEquals(2, worker.evaluate("1+1"));
@@ -82,7 +82,7 @@ public class TestWorkers extends TestBase {
 
   @Test
   void shouldReportErrors() {
-    Deferred<Event<Page.EventType>> errorPromise = page.waitForEvent(PAGEERROR);
+    Deferred<Event<Page.EventType>> errorPromise = page.futureEvent(PAGEERROR);
     page.evaluate("() => new Worker(URL.createObjectURL(new Blob([`\n" +
       "  setTimeout(() => {\n" +
       "    // Do a console.log just to check that we do not confuse it with an error.\n" +
@@ -98,7 +98,7 @@ public class TestWorkers extends TestBase {
   @DisabledIf(value="com.microsoft.playwright.TestBase#isFirefox", disabledReason="flaky upstream")
   void shouldClearUponNavigation() {
     page.navigate(server.EMPTY_PAGE);
-    Deferred<Event<Page.EventType>> workerCreatedPromise = page.waitForEvent(WORKER);
+    Deferred<Event<Page.EventType>> workerCreatedPromise = page.futureEvent(WORKER);
     page.evaluate("() => new Worker(URL.createObjectURL(new Blob(['console.log(1)'], {type: 'application/javascript'})))");
     Worker worker = (Worker) workerCreatedPromise.get().data();
     assertEquals(1, page.workers().size());
@@ -112,7 +112,7 @@ public class TestWorkers extends TestBase {
   @Test
   void shouldClearUponCrossProcessNavigation() {
     page.navigate(server.EMPTY_PAGE);
-    Deferred<Event<Page.EventType>> workerCreatedPromise = page.waitForEvent(WORKER);
+    Deferred<Event<Page.EventType>> workerCreatedPromise = page.futureEvent(WORKER);
     page.evaluate("() => new Worker(URL.createObjectURL(new Blob(['console.log(1)'], {type: 'application/javascript'})))");
     Worker worker = (Worker) workerCreatedPromise.get().data();
     assertEquals(1, page.workers().size());
@@ -127,7 +127,7 @@ public class TestWorkers extends TestBase {
   @EnabledIf(value="com.microsoft.playwright.TestBase#isWebKit", disabledReason="fixme")
   void shouldAttributeNetworkActivityForWorkerInsideIframeToTheIframe() {
     page.navigate(server.PREFIX + "/empty.html");
-    Deferred<Event<Page.EventType>> workerEvent = page.waitForEvent(WORKER);
+    Deferred<Event<Page.EventType>> workerEvent = page.futureEvent(WORKER);
     Frame frame = attachFrame(page, "frame1", server.PREFIX + "/worker/worker.html");
     String url = server.PREFIX + "/one-style.css";
     Deferred<Request> request = page.waitForRequest(url);
@@ -141,7 +141,7 @@ public class TestWorkers extends TestBase {
 
   @Test
   void shouldReportNetworkActivity() {
-    Deferred<Event<Page.EventType>> workerEvent = page.waitForEvent(WORKER);
+    Deferred<Event<Page.EventType>> workerEvent = page.futureEvent(WORKER);
     page.navigate(server.PREFIX + "/worker/worker.html");
     Worker worker = (Worker) workerEvent.get().data();
     String url = server.PREFIX + "/one-style.css";
@@ -177,7 +177,7 @@ public class TestWorkers extends TestBase {
     BrowserContext context = browser.newContext(new Browser.NewContextOptions().withLocale("ru-RU"));
     Page page = context.newPage();
     page.navigate(server.EMPTY_PAGE);
-    Deferred<Event<Page.EventType>> workerEvent = page.waitForEvent(WORKER);
+    Deferred<Event<Page.EventType>> workerEvent = page.futureEvent(WORKER);
     page.evaluate("() => new Worker(URL.createObjectURL(new Blob(['console.log(1)'], {type: 'application/javascript'})))");
     Worker worker = (Worker) workerEvent.get().data();
     assertEquals("10\u00A0000,2", worker.evaluate("() => (10000.20).toLocaleString()"));

--- a/playwright/src/test/java/com/microsoft/playwright/TestWorkers.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestWorkers.java
@@ -130,7 +130,7 @@ public class TestWorkers extends TestBase {
     Deferred<Event<Page.EventType>> workerEvent = page.futureEvent(WORKER);
     Frame frame = attachFrame(page, "frame1", server.PREFIX + "/worker/worker.html");
     String url = server.PREFIX + "/one-style.css";
-    Deferred<Request> request = page.waitForRequest(url);
+    Deferred<Request> request = page.futureRequest(url);
     Worker worker = (Worker) workerEvent.get().data();
 
     worker.evaluate("url => fetch(url).then(response => response.text()).then(console.log)", url);
@@ -145,8 +145,8 @@ public class TestWorkers extends TestBase {
     page.navigate(server.PREFIX + "/worker/worker.html");
     Worker worker = (Worker) workerEvent.get().data();
     String url = server.PREFIX + "/one-style.css";
-    Deferred<Request> requestPromise = page.waitForRequest(url);
-    Deferred<Response> responsePromise = page.waitForResponse(url);
+    Deferred<Request> requestPromise = page.futureRequest(url);
+    Deferred<Response> responsePromise = page.futureResponse(url);
     worker.evaluate("url => fetch(url).then(response => response.text()).then(console.log)", url);
     Request request = requestPromise.get();
     Response response = responsePromise.get();
@@ -160,8 +160,8 @@ public class TestWorkers extends TestBase {
     // Chromium needs waitForDebugger enabled for this one.
     page.navigate(server.EMPTY_PAGE);
     String url = server.PREFIX + "/one-style.css";
-    Deferred<Request> requestPromise = page.waitForRequest(url);
-    Deferred<Response> responsePromise = page.waitForResponse(url);
+    Deferred<Request> requestPromise = page.futureRequest(url);
+    Deferred<Response> responsePromise = page.futureResponse(url);
     page.evaluate("url => new Worker(URL.createObjectURL(new Blob([`\n" +
       "  fetch('${url}').then(response => response.text()).then(console.log);\n" +
       "`], {type: 'application/javascript'})))", url);

--- a/tools/api-generator/src/main/java/com/microsoft/playwright/tools/ApiGenerator.java
+++ b/tools/api-generator/src/main/java/com/microsoft/playwright/tools/ApiGenerator.java
@@ -371,20 +371,20 @@ class Method extends Element {
     customSignature.put("WebSocket.waitForEvent", waitForEvent);
 
     customSignature.put("Page.waitForRequest", new String[] {
-      "default Deferred<Request> waitForRequest(String urlGlob) { return waitForRequest(urlGlob, null); }",
-      "default Deferred<Request> waitForRequest(Pattern urlPattern) { return waitForRequest(urlPattern, null); }",
-      "default Deferred<Request> waitForRequest(Predicate<String> urlPredicate) { return waitForRequest(urlPredicate, null); }",
-      "Deferred<Request> waitForRequest(String urlGlob, WaitForRequestOptions options);",
-      "Deferred<Request> waitForRequest(Pattern urlPattern, WaitForRequestOptions options);",
-      "Deferred<Request> waitForRequest(Predicate<String> urlPredicate, WaitForRequestOptions options);"
+      "default Deferred<Request> futureRequest(String urlGlob) { return futureRequest(urlGlob, null); }",
+      "default Deferred<Request> futureRequest(Pattern urlPattern) { return futureRequest(urlPattern, null); }",
+      "default Deferred<Request> futureRequest(Predicate<String> urlPredicate) { return futureRequest(urlPredicate, null); }",
+      "Deferred<Request> futureRequest(String urlGlob, FutureRequestOptions options);",
+      "Deferred<Request> futureRequest(Pattern urlPattern, FutureRequestOptions options);",
+      "Deferred<Request> futureRequest(Predicate<String> urlPredicate, FutureRequestOptions options);"
     });
     customSignature.put("Page.waitForResponse", new String[] {
-      "default Deferred<Response> waitForResponse(String urlGlob) { return waitForResponse(urlGlob, null); }",
-      "default Deferred<Response> waitForResponse(Pattern urlPattern) { return waitForResponse(urlPattern, null); }",
-      "default Deferred<Response> waitForResponse(Predicate<String> urlPredicate) { return waitForResponse(urlPredicate, null); }",
-      "Deferred<Response> waitForResponse(String urlGlob, WaitForResponseOptions options);",
-      "Deferred<Response> waitForResponse(Pattern urlPattern, WaitForResponseOptions options);",
-      "Deferred<Response> waitForResponse(Predicate<String> urlPredicate, WaitForResponseOptions options);"
+      "default Deferred<Response> futureResponse(String urlGlob) { return futureResponse(urlGlob, null); }",
+      "default Deferred<Response> futureResponse(Pattern urlPattern) { return futureResponse(urlPattern, null); }",
+      "default Deferred<Response> futureResponse(Predicate<String> urlPredicate) { return futureResponse(urlPredicate, null); }",
+      "Deferred<Response> futureResponse(String urlGlob, FutureResponseOptions options);",
+      "Deferred<Response> futureResponse(Pattern urlPattern, FutureResponseOptions options);",
+      "Deferred<Response> futureResponse(Predicate<String> urlPredicate, FutureResponseOptions options);"
     });
 
     String[] selectOption = {

--- a/tools/api-generator/src/main/java/com/microsoft/playwright/tools/ApiGenerator.java
+++ b/tools/api-generator/src/main/java/com/microsoft/playwright/tools/ApiGenerator.java
@@ -355,15 +355,15 @@ class Method extends Element {
     customSignature.put("Frame.setInputFiles", setInputFilesWithSelector);
 
     String[] waitForEvent = {
-      "default Deferred<Event<EventType>> waitForEvent(EventType event) {",
-      "  return waitForEvent(event, (WaitForEventOptions) null);",
+      "default Deferred<Event<EventType>> futureEvent(EventType event) {",
+      "  return futureEvent(event, (FutureEventOptions) null);",
       "}",
-      "default Deferred<Event<EventType>> waitForEvent(EventType event, Predicate<Event<EventType>> predicate) {",
-      "  WaitForEventOptions options = new WaitForEventOptions();",
+      "default Deferred<Event<EventType>> futureEvent(EventType event, Predicate<Event<EventType>> predicate) {",
+      "  FutureEventOptions options = new FutureEventOptions();",
       "  options.predicate = predicate;",
-      "  return waitForEvent(event, options);",
+      "  return futureEvent(event, options);",
       "}",
-      "Deferred<Event<EventType>> waitForEvent(EventType event, WaitForEventOptions options);",
+      "Deferred<Event<EventType>> futureEvent(EventType event, FutureEventOptions options);",
     };
     customSignature.put("Page.waitForEvent", waitForEvent);
     customSignature.put("BrowserContext.waitForEvent", waitForEvent);
@@ -833,7 +833,7 @@ class Interface extends TypeDefinition {
       m.writeTo(output, offset);
     }
     if ("Worker".equals(jsonName)) {
-      output.add(offset + "Deferred<Event<EventType>> waitForEvent(EventType event);");
+      output.add(offset + "Deferred<Event<EventType>> futureEvent(EventType event);");
     }
     output.add("}");
     output.add("\n");
@@ -1052,15 +1052,15 @@ class Interface extends TypeDefinition {
       }
     }
     if (asList("Page", "BrowserContext", "WebSocket").contains(jsonName)){
-      output.add(offset + "class WaitForEventOptions {");
+      output.add(offset + "class FutureEventOptions {");
       output.add(offset + "  public Integer timeout;");
       output.add(offset + "  public Predicate<Event<EventType>> predicate;");
 
-      output.add(offset + "  public WaitForEventOptions withTimeout(int millis) {");
+      output.add(offset + "  public FutureEventOptions withTimeout(int millis) {");
       output.add(offset + "    timeout = millis;");
       output.add(offset + "    return this;");
       output.add(offset + "  }");
-      output.add(offset + "  public WaitForEventOptions withPredicate(Predicate<Event<EventType>> predicate) {");
+      output.add(offset + "  public FutureEventOptions withPredicate(Predicate<Event<EventType>> predicate) {");
       output.add(offset + "    this.predicate = predicate;");
       output.add(offset + "    return this;");
       output.add(offset + "  }");

--- a/tools/api-generator/src/main/java/com/microsoft/playwright/tools/ApiGenerator.java
+++ b/tools/api-generator/src/main/java/com/microsoft/playwright/tools/ApiGenerator.java
@@ -266,6 +266,7 @@ class Method extends Element {
     tsToJavaMethodName.put("$", "querySelector");
     tsToJavaMethodName.put("$$", "querySelectorAll");
     tsToJavaMethodName.put("goto", "navigate");
+    tsToJavaMethodName.put("waitForNavigation", "futureNavigation");
   }
 
   private static Map<String, String[]> customSignature = new HashMap<>();
@@ -636,15 +637,15 @@ class Field extends Element {
   void writeBuilderMethod(List<String> output, String offset, String parentClass) {
     if (asList("Frame.waitForNavigation.options.url",
                "Page.waitForNavigation.options.url").contains(jsonPath)) {
-      output.add(offset + "public WaitForNavigationOptions withUrl(String glob) {");
+      output.add(offset + "public FutureNavigationOptions withUrl(String glob) {");
       output.add(offset + "  this.glob = glob;");
       output.add(offset + "  return this;");
       output.add(offset + "}");
-      output.add(offset + "public WaitForNavigationOptions withUrl(Pattern pattern) {");
+      output.add(offset + "public FutureNavigationOptions withUrl(Pattern pattern) {");
       output.add(offset + "  this.pattern = pattern;");
       output.add(offset + "  return this;");
       output.add(offset + "}");
-      output.add(offset + "public WaitForNavigationOptions withUrl(Predicate<String> predicate) {");
+      output.add(offset + "public FutureNavigationOptions withUrl(Predicate<String> predicate) {");
       output.add(offset + "  this.predicate = predicate;");
       output.add(offset + "  return this;");
       output.add(offset + "}");

--- a/tools/api-generator/src/main/java/com/microsoft/playwright/tools/Types.java
+++ b/tools/api-generator/src/main/java/com/microsoft/playwright/tools/Types.java
@@ -212,17 +212,17 @@ class Types {
     add("Page.waitForResponse", "Promise<Response>", "Deferred<Response>");
     add("Page.waitForNavigation", "Promise<null|Response>", "Deferred<Response>");
     add("Frame.waitForNavigation", "Promise<null|Response>", "Deferred<Response>");
-    add("Page.waitForSelector", "Promise<null|ElementHandle>", "Deferred<ElementHandle>", new Empty());
-    add("Frame.waitForSelector", "Promise<null|ElementHandle>", "Deferred<ElementHandle>", new Empty());
-    add("ElementHandle.waitForSelector", "Promise<null|ElementHandle>", "Deferred<ElementHandle>", new Empty());
+    add("Page.waitForSelector", "Promise<null|ElementHandle>", "ElementHandle", new Empty());
+    add("Frame.waitForSelector", "Promise<null|ElementHandle>", "ElementHandle", new Empty());
+    add("ElementHandle.waitForSelector", "Promise<null|ElementHandle>", "ElementHandle", new Empty());
 
-    add("Frame.waitForLoadState", "Promise", "Deferred<Void>", new Empty());
-    add("Page.waitForLoadState", "Promise", "Deferred<Void>", new Empty());
-    add("Frame.waitForTimeout", "Promise", "Deferred<Void>", new Empty());
-    add("Page.waitForTimeout", "Promise", "Deferred<Void>", new Empty());
-    add("Frame.waitForFunction", "Promise<JSHandle>", "Deferred<JSHandle>", new Empty());
-    add("Page.waitForFunction", "Promise<JSHandle>", "Deferred<JSHandle>", new Empty());
-    add("ElementHandle.waitForElementState", "Promise", "Deferred<Void>", new Empty());
+    add("Frame.waitForLoadState", "Promise", "void", new Empty());
+    add("Page.waitForLoadState", "Promise", "void", new Empty());
+    add("Frame.waitForTimeout", "Promise", "void", new Empty());
+    add("Page.waitForTimeout", "Promise", "void", new Empty());
+    add("Frame.waitForFunction", "Promise<JSHandle>", "JSHandle", new Empty());
+    add("Page.waitForFunction", "Promise<JSHandle>", "JSHandle", new Empty());
+    add("ElementHandle.waitForElementState", "Promise", "void", new Empty());
 
     // Custom options
     add("Page.pdf.options.margin.top", "string|number", "String");

--- a/tools/api-generator/src/main/java/com/microsoft/playwright/tools/Types.java
+++ b/tools/api-generator/src/main/java/com/microsoft/playwright/tools/Types.java
@@ -259,7 +259,8 @@ class Types {
     add("BrowserContext.waitForEvent.event", "string", "EventType", new Empty());
     add("BrowserContext.waitForEvent.optionsOrPredicate", "Function|Object", "String");
     add("BrowserContext.waitForEvent", "Promise<Object>", "Deferred<Event<EventType>>", new Empty());
-    add("Page.waitForNavigation.options.url", "string|RegExp|Function", "String");
+    add("Page.waitForNavigation.options.url", "string|RegExp|Function", "Custom");
+    add("Page.waitForNavigation.options", "Object", "FutureNavigationOptions");
     add("Page.frame.options", "string|Object", "FrameOptions", new Empty());
     add("Page.route.url", "string|RegExp|function(URL):boolean", "String");
     add("Page.selectOption.values", "null|string|ElementHandle|Array<string>|Object|Array<ElementHandle>|Array<Object>", "String");
@@ -270,7 +271,8 @@ class Types {
     add("Page.waitForEvent", "Promise<Object>", "Deferred<Event<EventType>>", new Empty());
     add("Page.waitForRequest.urlOrPredicate", "string|RegExp|Function", "String");
     add("Page.waitForResponse.urlOrPredicate", "string|RegExp|function(Response):boolean", "String");
-    add("Frame.waitForNavigation.options.url", "string|RegExp|Function", "String");
+    add("Frame.waitForNavigation.options.url", "string|RegExp|Function", "Custom");
+    add("Frame.waitForNavigation.options", "Object", "FutureNavigationOptions");
     add("Frame.selectOption.values", "null|string|ElementHandle|Array<string>|Object|Array<ElementHandle>|Array<Object>", "String");
     add("Frame.setInputFiles.files", "string|Array<string>|Object|Array<Object>", "String");
     add("ElementHandle.selectOption.values", "null|string|ElementHandle|Array<string>|Object|Array<ElementHandle>|Array<Object>", "String");

--- a/tools/api-generator/src/main/java/com/microsoft/playwright/tools/Types.java
+++ b/tools/api-generator/src/main/java/com/microsoft/playwright/tools/Types.java
@@ -261,6 +261,8 @@ class Types {
     add("BrowserContext.waitForEvent", "Promise<Object>", "Deferred<Event<EventType>>", new Empty());
     add("Page.waitForNavigation.options.url", "string|RegExp|Function", "Custom");
     add("Page.waitForNavigation.options", "Object", "FutureNavigationOptions");
+    add("Page.waitForRequest.options", "Object", "FutureRequestOptions");
+    add("Page.waitForResponse.options", "Object", "FutureResponseOptions");
     add("Page.frame.options", "string|Object", "FrameOptions", new Empty());
     add("Page.route.url", "string|RegExp|function(URL):boolean", "String");
     add("Page.selectOption.values", "null|string|ElementHandle|Array<string>|Object|Array<ElementHandle>|Array<Object>", "String");


### PR DESCRIPTION
Current waitFor* methods are easy to misuse as they require calling `.get()` on the returned object which is easy to forget if you just want to wait for certain condition and don't use the result. The API is updated in the following way:

* The following methods keep their name (starting with `waitFor`) but become synchronous and have different return type. 
```java
waitForElementState => void waitForElementState
waitForFunction => JSHandle waitForFunction
waitForLoadState => void waitForLoadState
waitForSelector => ElementHandle waitForSelector
waitForTimeout => void waitForTimeout
```
* Some of the methods have been renamed and now start with `future` prefix. They are non-blocking and still return `Deferred<>` object:
```java
waitForEvent => futureEvent
waitForNavigation => futureNavigation
waitForRequest => futureRequest
waitForResponse => futureResponse
```
As before the client has to call `.get()` on the returned object in order to retrieve the result. `.get()` call is blocking. In the future we may add corresponding synchronous `waitFor*` methods for convenience if need be.

Change in the behavior of `waitForFunction` is probably the most controversial as now there is no way to create the function before doing some actions with the page. Again if that turns out to be a problem in practice we'll add `futureCondition` or something that would restore existing behavior.