### PR TITLE
fix(scripts): Dockerfile is outdated

### DIFF
--- a/Dockerfile.focal
+++ b/Dockerfile.focal
@@ -66,5 +66,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 RUN mkdir /tmp/pw-java
 COPY . /tmp/pw-java
-RUN cd /tmp/pw-java && ./scripts/download_driver.sh && mvn install -D skipTests --no-transfer-progress && \
+RUN cd /tmp/pw-java && ./scripts/download_driver_for_all_platforms.sh && \
+    mvn install -D skipTests --no-transfer-progress && \
     rm -rf /tmp/pw-java


### PR DESCRIPTION
Fix issue #190 

Hi, there is indeed a minor issue. Now the script file should be `./scripts/download_driver_for_all_platforms.sh`.