### PR TITLE
feat(logging): support DEBUG=pw:api

### DIFF
--- a/playwright/src/main/java/com/microsoft/playwright/impl/AccessibilityImpl.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/AccessibilityImpl.java
@@ -31,7 +31,7 @@ class AccessibilityImpl implements Accessibility {
 
   @Override
   public AccessibilityNode snapshot(SnapshotOptions options) {
-    return page.withLogging("Accessibility.snapshot", () -> snapshot(options));
+    return page.withLogging("Accessibility.snapshot", () -> snapshotImpl(options));
   }
 
   private AccessibilityNode snapshotImpl(SnapshotOptions options) {

--- a/playwright/src/main/java/com/microsoft/playwright/impl/AccessibilityImpl.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/AccessibilityImpl.java
@@ -31,6 +31,10 @@ class AccessibilityImpl implements Accessibility {
 
   @Override
   public AccessibilityNode snapshot(SnapshotOptions options) {
+    return page.withLogging("Accessibility.snapshot", () -> snapshot(options));
+  }
+
+  private AccessibilityNode snapshotImpl(SnapshotOptions options) {
     if (options == null) {
       options = new SnapshotOptions();
     }

--- a/playwright/src/main/java/com/microsoft/playwright/impl/BrowserImpl.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/BrowserImpl.java
@@ -53,6 +53,9 @@ class BrowserImpl extends ChannelOwner implements Browser {
 
   @Override
   public void close() {
+    withLogging("Browser.close", () -> closeImpl());
+  }
+  private void closeImpl() {
     try {
       sendMessage("close");
     } catch (PlaywrightException e) {
@@ -74,6 +77,10 @@ class BrowserImpl extends ChannelOwner implements Browser {
 
   @Override
   public BrowserContextImpl newContext(NewContextOptions options) {
+    return withLogging("Browser.newContext", () -> newContextImpl(options));
+  }
+
+  private BrowserContextImpl newContextImpl(NewContextOptions options) {
     if (options == null) {
       options = new NewContextOptions();
     }
@@ -97,6 +104,10 @@ class BrowserImpl extends ChannelOwner implements Browser {
 
   @Override
   public Page newPage(NewPageOptions options) {
+    return withLogging("Browser.newPage", () -> newPageImpl(options));
+  }
+
+  private Page newPageImpl(NewPageOptions options) {
     BrowserContextImpl context = newContext(convertViaJson(options, NewContextOptions.class));
     PageImpl page = context.newPage();
     page.ownedContext = context;

--- a/playwright/src/main/java/com/microsoft/playwright/impl/BrowserTypeImpl.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/BrowserTypeImpl.java
@@ -33,6 +33,10 @@ class BrowserTypeImpl extends ChannelOwner implements BrowserType {
 
   @Override
   public BrowserImpl launch(LaunchOptions options) {
+    return withLogging("BrowserType.launch", () -> launchImpl(options));
+  }
+
+  private BrowserImpl launchImpl(LaunchOptions options) {
     if (options == null) {
       options = new LaunchOptions();
     }
@@ -45,9 +49,13 @@ class BrowserTypeImpl extends ChannelOwner implements BrowserType {
     return initializer.get("executablePath").getAsString();
   }
 
-
   @Override
   public BrowserContextImpl launchPersistentContext(Path userDataDir, LaunchPersistentContextOptions options) {
+    return withLogging("BrowserType.launchPersistentContext",
+      () -> launchPersistentContextImpl(userDataDir, options));
+  }
+
+  private BrowserContextImpl launchPersistentContextImpl(Path userDataDir, LaunchPersistentContextOptions options) {
     if (options == null) {
       options = new LaunchPersistentContextOptions();
     }

--- a/playwright/src/main/java/com/microsoft/playwright/impl/ChannelOwner.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/ChannelOwner.java
@@ -24,7 +24,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 
-class ChannelOwner {
+class ChannelOwner extends LoggingSupport {
   final Connection connection;
   private final ChannelOwner parent;
   private final Map<String, ChannelOwner> objects = new HashMap<>();
@@ -78,14 +78,6 @@ class ChannelOwner {
 
   JsonElement sendMessage(String method, JsonObject params) {
     return connection.sendMessage(guid, method, params);
-  }
-
-  void sendMessageNoWait(String method) {
-    sendMessageNoWait(method, new JsonObject());
-  }
-
-  void sendMessageNoWait(String method, JsonObject params) {
-    connection.sendMessageNoWait(guid, method, params);
   }
 
   @SuppressWarnings("unchecked")

--- a/playwright/src/main/java/com/microsoft/playwright/impl/Connection.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/Connection.java
@@ -72,15 +72,11 @@ public class Connection {
   }
 
   public JsonElement sendMessage(String guid, String method, JsonObject params) {
-    return (JsonElement) root.toDeferred(sendMessageAsync(guid, method, params)).get();
+    return root.toDeferred(sendMessageAsync(guid, method, params)).get();
   }
 
   public WaitableResult<JsonElement> sendMessageAsync(String guid, String method, JsonObject params) {
     return internalSendMessage(guid, method, params);
-  }
-
-  public void sendMessageNoWait(String guid, String method, JsonObject params) {
-    internalSendMessage(guid, method, params);
   }
 
   private WaitableResult<JsonElement> internalSendMessage(String guid, String method, JsonObject params) {

--- a/playwright/src/main/java/com/microsoft/playwright/impl/DialogImpl.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/DialogImpl.java
@@ -20,7 +20,7 @@ import com.google.gson.JsonObject;
 import com.microsoft.playwright.Dialog;
 import com.microsoft.playwright.PlaywrightException;
 
-public class DialogImpl extends ChannelOwner implements Dialog {
+class DialogImpl extends ChannelOwner implements Dialog {
   private boolean handled;
   DialogImpl(ChannelOwner parent, String type, String guid, JsonObject initializer) {
     super(parent, type, guid, initializer);
@@ -28,17 +28,21 @@ public class DialogImpl extends ChannelOwner implements Dialog {
 
   @Override
   public void accept(String promptText) {
-    handled = true;
-    JsonObject params = new JsonObject();
-    if (promptText != null)
-      params.addProperty("promptText", promptText);
-    sendMessageNoWait("accept", params);
+    withLogging("Dialog.accept", () -> {
+      handled = true;
+      JsonObject params = new JsonObject();
+      if (promptText != null)
+        params.addProperty("promptText", promptText);
+      sendMessage("accept", params);
+    });
   }
 
   @Override
   public void dismiss() {
-    handled = true;
-    sendMessageNoWait("dismiss");
+    withLogging("Dialog.dismiss", () -> {
+      handled = true;
+      sendMessage("dismiss");
+    });
   }
 
   @Override

--- a/playwright/src/main/java/com/microsoft/playwright/impl/DownloadImpl.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/DownloadImpl.java
@@ -40,38 +40,48 @@ public class DownloadImpl extends ChannelOwner implements Download {
 
   @Override
   public InputStream createReadStream() {
-    JsonObject result = sendMessage("stream").getAsJsonObject();
-    if (!result.has("stream")) {
-      return null;
-    }
-    Stream stream = connection.getExistingObject(result.getAsJsonObject("stream").get("guid").getAsString());
-    return stream.stream();
+    return withLogging("Download.createReadStream", () -> {
+      JsonObject result = sendMessage("stream").getAsJsonObject();
+      if (!result.has("stream")) {
+        return null;
+      }
+      Stream stream = connection.getExistingObject(result.getAsJsonObject("stream").get("guid").getAsString());
+      return stream.stream();
+    });
   }
 
   @Override
   public void delete() {
-    sendMessage("delete");
+    withLogging("Download.delete", () -> {
+      sendMessage("delete");
+    });
   }
 
   @Override
   public String failure() {
-    JsonObject result = sendMessage("failure").getAsJsonObject();
-    if (result.has("error")) {
-      return result.get("error").getAsString();
-    }
-    return null;
+    return withLogging("Download.failure", () -> {
+      JsonObject result = sendMessage("failure").getAsJsonObject();
+      if (result.has("error")) {
+        return result.get("error").getAsString();
+      }
+      return null;
+    });
   }
 
   @Override
   public Path path() {
-    JsonObject json = sendMessage("path").getAsJsonObject();
-    return FileSystems.getDefault().getPath(json.get("value").getAsString());
+    return withLogging("Download.path", () -> {
+      JsonObject json = sendMessage("path").getAsJsonObject();
+      return FileSystems.getDefault().getPath(json.get("value").getAsString());
+    });
   }
 
   @Override
   public void saveAs(Path path) {
-    JsonObject params = new JsonObject();
-    params.addProperty("path", path.toString());
-    sendMessage("saveAs", params);
+    withLogging("Download.saveAs", () -> {
+      JsonObject params = new JsonObject();
+      params.addProperty("path", path.toString());
+      sendMessage("saveAs", params);
+    });
   }
 }

--- a/playwright/src/main/java/com/microsoft/playwright/impl/ElementHandleImpl.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/ElementHandleImpl.java
@@ -46,67 +46,81 @@ public class ElementHandleImpl extends JSHandleImpl implements ElementHandle {
 
   @Override
   public ElementHandle querySelector(String selector) {
-    JsonObject params = new JsonObject();
-    params.addProperty("selector", selector);
-    JsonElement json = sendMessage("querySelector", params);
-    JsonObject element = json.getAsJsonObject().getAsJsonObject("element");
-    if (element == null) {
-      return null;
-    }
-    return connection.getExistingObject(element.get("guid").getAsString());
+    return withLogging("ElementHandle.querySelector", () -> {
+      JsonObject params = new JsonObject();
+      params.addProperty("selector", selector);
+      JsonElement json = sendMessage("querySelector", params);
+      JsonObject element = json.getAsJsonObject().getAsJsonObject("element");
+      if (element == null) {
+        return null;
+      }
+      return connection.getExistingObject(element.get("guid").getAsString());
+    });
   }
 
   @Override
   public List<ElementHandle> querySelectorAll(String selector) {
-    JsonObject params = new JsonObject();
-    params.addProperty("selector", selector);
-    JsonElement json = sendMessage("querySelectorAll", params);
-    JsonArray elements = json.getAsJsonObject().getAsJsonArray("elements");
-    if (elements == null) {
-      return null;
-    }
-    List<ElementHandle> handles = new ArrayList<>();
-    for (JsonElement item : elements) {
-      handles.add(connection.getExistingObject(item.getAsJsonObject().get("guid").getAsString()));
-    }
-    return handles;
+    return withLogging("ElementHandle.<", () -> {
+      JsonObject params = new JsonObject();
+      params.addProperty("selector", selector);
+      JsonElement json = sendMessage("querySelectorAll", params);
+      JsonArray elements = json.getAsJsonObject().getAsJsonArray("elements");
+      if (elements == null) {
+        return null;
+      }
+      List<ElementHandle> handles = new ArrayList<>();
+      for (JsonElement item : elements) {
+        handles.add(connection.getExistingObject(item.getAsJsonObject().get("guid").getAsString()));
+      }
+      return handles;
+    });
   }
 
   @Override
   public Object evalOnSelector(String selector, String pageFunction, Object arg) {
-    JsonObject params = new JsonObject();
-    params.addProperty("selector", selector);
-    params.addProperty("expression", pageFunction);
-    params.addProperty("isFunction", isFunctionBody(pageFunction));
-    params.add("arg", gson().toJsonTree(serializeArgument(arg)));
-    JsonElement json = sendMessage("evalOnSelector", params);
-    SerializedValue value = gson().fromJson(json.getAsJsonObject().get("value"), SerializedValue.class);
-    return deserialize(value);
+    return withLogging("ElementHandle.evalOnSelector", () -> {
+      JsonObject params = new JsonObject();
+      params.addProperty("selector", selector);
+      params.addProperty("expression", pageFunction);
+      params.addProperty("isFunction", isFunctionBody(pageFunction));
+      params.add("arg", gson().toJsonTree(serializeArgument(arg)));
+      JsonElement json = sendMessage("evalOnSelector", params);
+      SerializedValue value = gson().fromJson(json.getAsJsonObject().get("value"), SerializedValue.class);
+      return deserialize(value);
+    });
   }
 
   @Override
   public Object evalOnSelectorAll(String selector, String pageFunction, Object arg) {
-    JsonObject params = new JsonObject();
-    params.addProperty("selector", selector);
-    params.addProperty("expression", pageFunction);
-    params.addProperty("isFunction", isFunctionBody(pageFunction));
-    params.add("arg", gson().toJsonTree(serializeArgument(arg)));
-    JsonElement json = sendMessage("evalOnSelectorAll", params);
-    SerializedValue value = gson().fromJson(json.getAsJsonObject().get("value"), SerializedValue.class);
-    return deserialize(value);
+    return withLogging("ElementHandle.evalOnSelectorAll", () -> {
+      JsonObject params = new JsonObject();
+      params.addProperty("selector", selector);
+      params.addProperty("expression", pageFunction);
+      params.addProperty("isFunction", isFunctionBody(pageFunction));
+      params.add("arg", gson().toJsonTree(serializeArgument(arg)));
+      JsonElement json = sendMessage("evalOnSelectorAll", params);
+      SerializedValue value = gson().fromJson(json.getAsJsonObject().get("value"), SerializedValue.class);
+      return deserialize(value);
+    });
   }
 
   @Override
   public BoundingBox boundingBox() {
-    JsonObject json = sendMessage("boundingBox").getAsJsonObject();
-    if (!json.has("value")) {
-      return null;
-    }
-    return gson().fromJson(json.get("value"), BoundingBox.class);
+    return withLogging("ElementHandle.boundingBox", () -> {
+      JsonObject json = sendMessage("boundingBox").getAsJsonObject();
+      if (!json.has("value")) {
+        return null;
+      }
+      return gson().fromJson(json.get("value"), BoundingBox.class);
+    });
   }
 
   @Override
   public void check(CheckOptions options) {
+    withLogging("ElementHandle.check", () -> checkImpl(options));
+  }
+
+  private void checkImpl(CheckOptions options) {
     if (options == null) {
       options = new CheckOptions();
     }
@@ -116,6 +130,10 @@ public class ElementHandleImpl extends JSHandleImpl implements ElementHandle {
 
   @Override
   public void click(ClickOptions options) {
+    withLogging("ElementHandle.click", () -> clickImpl(options));
+  }
+
+  private void clickImpl(ClickOptions options) {
     if (options == null) {
       options = new ClickOptions();
     }
@@ -135,6 +153,10 @@ public class ElementHandleImpl extends JSHandleImpl implements ElementHandle {
 
   @Override
   public Frame contentFrame() {
+    return withLogging("ElementHandle.contentFrame", () -> contentFrameImpl());
+  }
+
+  private Frame contentFrameImpl() {
     JsonObject json = sendMessage("contentFrame").getAsJsonObject();
     if (!json.has("frame")) {
       return null;
@@ -144,6 +166,10 @@ public class ElementHandleImpl extends JSHandleImpl implements ElementHandle {
 
   @Override
   public void dblclick(DblclickOptions options) {
+    withLogging("ElementHandle.dblclick", () -> dblclickImpl(options));
+  }
+
+  private void dblclickImpl(DblclickOptions options) {
     if (options == null) {
       options = new DblclickOptions();
     }
@@ -163,14 +189,20 @@ public class ElementHandleImpl extends JSHandleImpl implements ElementHandle {
 
   @Override
   public void dispatchEvent(String type, Object eventInit) {
-    JsonObject params = new JsonObject();
-    params.addProperty("type", type);
-    params.add("eventInit", gson().toJsonTree(serializeArgument(eventInit)));
-    sendMessage("dispatchEvent", params);
+    withLogging("ElementHandle.dispatchEvent", () -> {
+      JsonObject params = new JsonObject();
+      params.addProperty("type", type);
+      params.add("eventInit", gson().toJsonTree(serializeArgument(eventInit)));
+      sendMessage("dispatchEvent", params);
+    });
   }
 
   @Override
   public void fill(String value, FillOptions options) {
+    withLogging("ElementHandle.fill", () -> fillImpl(value, options));
+  }
+
+  private void fillImpl(String value, FillOptions options) {
     if (options == null) {
       options = new FillOptions();
     }
@@ -181,50 +213,63 @@ public class ElementHandleImpl extends JSHandleImpl implements ElementHandle {
 
   @Override
   public void focus() {
-    sendMessage("focus");
+    withLogging("ElementHandle.focus", () -> sendMessage("focus"));
   }
 
   @Override
   public String getAttribute(String name) {
-    JsonObject params = new JsonObject();
-    params.addProperty("name", name);
-    JsonObject json = sendMessage("getAttribute", params).getAsJsonObject();
-    return json.has("value") ? json.get("value").getAsString() : null;
+    return withLogging("ElementHandle.getAttribute", () -> {
+      JsonObject params = new JsonObject();
+      params.addProperty("name", name);
+      JsonObject json = sendMessage("getAttribute", params).getAsJsonObject();
+      return json.has("value") ? json.get("value").getAsString() : null;
+    });
   }
 
   @Override
   public void hover(HoverOptions options) {
-    JsonObject params = gson().toJsonTree(options).getAsJsonObject();
-    params.remove("modifiers");
-    if (options.modifiers != null) {
-      params.add("modifiers", Serialization.toProtocol(options.modifiers));
-    }
-    sendMessage("hover", params);
+    withLogging("ElementHandle.hover", () -> {
+      JsonObject params = gson().toJsonTree(options).getAsJsonObject();
+      params.remove("modifiers");
+      if (options.modifiers != null) {
+        params.add("modifiers", Serialization.toProtocol(options.modifiers));
+      }
+      sendMessage("hover", params);
+    });
   }
 
   @Override
   public String innerHTML() {
-    JsonObject json = sendMessage("innerHTML").getAsJsonObject();
-    return json.get("value").getAsString();
+    return withLogging("ElementHandle.innerHTML", () -> {
+      JsonObject json = sendMessage("innerHTML").getAsJsonObject();
+      return json.get("value").getAsString();
+    });
   }
 
   @Override
   public String innerText() {
-    JsonObject json = sendMessage("innerText").getAsJsonObject();
-    return json.get("value").getAsString();
+    return withLogging("ElementHandle.innerText", () -> {
+      JsonObject json = sendMessage("innerText").getAsJsonObject();
+      return json.get("value").getAsString();
+    });
   }
 
   @Override
   public Frame ownerFrame() {
-    JsonObject json = sendMessage("ownerFrame").getAsJsonObject();
-    if (!json.has("frame")) {
-      return null;
-    }
-    return connection.getExistingObject(json.getAsJsonObject("frame").get("guid").getAsString());
+    return withLogging("ElementHandle.ownerFrame", () -> {
+      JsonObject json = sendMessage("ownerFrame").getAsJsonObject();
+      if (!json.has("frame")) {
+        return null;
+      }
+      return connection.getExistingObject(json.getAsJsonObject("frame").get("guid").getAsString());
+    });
   }
 
   @Override
   public void press(String key, PressOptions options) {
+    withLogging("ElementHandle.press", () -> pressImpl(key, options));
+  }
+  private void pressImpl(String key, PressOptions options) {
     if (options == null) {
       options = new PressOptions();
     }
@@ -239,6 +284,10 @@ public class ElementHandleImpl extends JSHandleImpl implements ElementHandle {
 
   @Override
   public byte[] screenshot(ScreenshotOptions options) {
+    return withLogging("ElementHandle.screenshot", () -> screenshotImpl(options));
+  }
+
+  private byte[] screenshotImpl(ScreenshotOptions options) {
     if (options == null) {
       options = new ScreenshotOptions();
     }
@@ -270,6 +319,10 @@ public class ElementHandleImpl extends JSHandleImpl implements ElementHandle {
 
   @Override
   public void scrollIntoViewIfNeeded(ScrollIntoViewIfNeededOptions options) {
+    withLogging("ElementHandle.scrollIntoViewIfNeeded", () -> scrollIntoViewIfNeededImpl(options));
+  }
+
+  private void scrollIntoViewIfNeededImpl(ScrollIntoViewIfNeededOptions options) {
     if (options == null) {
       options = new ScrollIntoViewIfNeededOptions();
     }
@@ -302,12 +355,18 @@ public class ElementHandleImpl extends JSHandleImpl implements ElementHandle {
   }
 
   private List<String> selectOption(JsonObject params) {
-    JsonObject json = sendMessage("selectOption", params).getAsJsonObject();
-    return parseStringList(json.getAsJsonArray("values"));
+    return withLogging("ElementHandle.selectOption", () -> {
+      JsonObject json = sendMessage("selectOption", params).getAsJsonObject();
+      return parseStringList(json.getAsJsonArray("values"));
+    });
   }
 
   @Override
   public void selectText(SelectTextOptions options) {
+    withLogging("ElementHandle.selectText", () -> selectTextImpl(options));
+  }
+
+  private void selectTextImpl(SelectTextOptions options) {
     if (options == null) {
       options = new SelectTextOptions();
     }
@@ -322,6 +381,10 @@ public class ElementHandleImpl extends JSHandleImpl implements ElementHandle {
 
   @Override
   public void setInputFiles(FileChooser.FilePayload[] files, SetInputFilesOptions options) {
+    withLogging("ElementHandle.setInputFiles", () -> setInputFilesImpl(files, options));
+  }
+
+  void setInputFilesImpl(FileChooser.FilePayload[] files, SetInputFilesOptions options) {
     if (options == null) {
       options = new SetInputFilesOptions();
     }
@@ -332,17 +395,39 @@ public class ElementHandleImpl extends JSHandleImpl implements ElementHandle {
 
   @Override
   public void tap(TapOptions options) {
+    withLogging("ElementHandle.tap", () -> tapImpl(options));
+  }
 
+  private void tapImpl(TapOptions options) {
+    if (options == null) {
+      options = new TapOptions();
+    }
+    JsonObject params = gson().toJsonTree(options).getAsJsonObject();
+    if (options.modifiers != null) {
+      params.remove("modifiers");
+      params.add("modifiers", Serialization.toProtocol(options.modifiers));
+    }
+    sendMessage("tap", params);
   }
 
   @Override
   public String textContent() {
-    JsonObject json = sendMessage("textContent").getAsJsonObject();
-    return json.has("value") ? json.get("value").getAsString() : null;
+    return withLogging("ElementHandle.textContent", () -> textContentImpl());
+  }
+
+  private String textContentImpl() {
+    return withLogging("ElementHandle.textContent", () -> {
+      JsonObject json = sendMessage("textContent").getAsJsonObject();
+      return json.has("value") ? json.get("value").getAsString() : null;
+    });
   }
 
   @Override
   public void type(String text, TypeOptions options) {
+    withLogging("ElementHandle.type", () -> typeImpl(text, options));
+  }
+
+  private void typeImpl(String text, TypeOptions options) {
     if (options == null) {
       options = new TypeOptions();
     }
@@ -353,6 +438,10 @@ public class ElementHandleImpl extends JSHandleImpl implements ElementHandle {
 
   @Override
   public void uncheck(UncheckOptions options) {
+    withLogging("ElementHandle.uncheck", () -> uncheckImpl(options));
+  }
+
+  private void uncheckImpl(UncheckOptions options) {
     if (options == null) {
       options = new UncheckOptions();
     }
@@ -362,6 +451,10 @@ public class ElementHandleImpl extends JSHandleImpl implements ElementHandle {
 
   @Override
   public void waitForElementState(ElementState state, WaitForElementStateOptions options) {
+    withLogging("ElementHandle.waitForElementState", () -> waitForElementStateImpl(state, options));
+  }
+
+  private void waitForElementStateImpl(ElementState state, WaitForElementStateOptions options) {
     if (options == null) {
       options = new WaitForElementStateOptions();
     }
@@ -379,6 +472,10 @@ public class ElementHandleImpl extends JSHandleImpl implements ElementHandle {
 
   @Override
   public ElementHandle waitForSelector(String selector, WaitForSelectorOptions options) {
+    return withLogging("ElementHandle.waitForSelector", () -> waitForSelectorImpl(selector, options));
+  }
+
+  private ElementHandle waitForSelectorImpl(String selector, WaitForSelectorOptions options) {
     if (options == null) {
       options = new WaitForSelectorOptions();
     }
@@ -392,16 +489,6 @@ public class ElementHandleImpl extends JSHandleImpl implements ElementHandle {
       return null;
     }
     return connection.getExistingObject(element.get("guid").getAsString());
-  }
-
-  public String createSelectorForTest(String name) {
-    JsonObject params = new JsonObject();
-    params.addProperty("name", name);
-    JsonObject json = sendMessage("createSelectorForTest", params).getAsJsonObject();
-    if (json.has("value")) {
-      return json.get("value").getAsString();
-    }
-    return null;
   }
 
   private static String toProtocol(WaitForSelectorOptions.State state) {

--- a/playwright/src/main/java/com/microsoft/playwright/impl/FileChooserImpl.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/FileChooserImpl.java
@@ -16,23 +16,20 @@
 
 package com.microsoft.playwright.impl;
 
-import com.google.gson.Gson;
-import com.google.gson.JsonObject;
 import com.microsoft.playwright.ElementHandle;
 import com.microsoft.playwright.FileChooser;
 import com.microsoft.playwright.Page;
 
-import java.io.File;
 import java.nio.file.Path;
 
 import static com.microsoft.playwright.impl.Utils.convertViaJson;
 
 class FileChooserImpl implements FileChooser {
   private final PageImpl page;
-  private final ElementHandle element;
+  private final ElementHandleImpl element;
   private final boolean isMultiple;
 
-  FileChooserImpl(PageImpl page, ElementHandle element, boolean isMultiple) {
+  FileChooserImpl(PageImpl page, ElementHandleImpl element, boolean isMultiple) {
     this.page = page;
     this.element = element;
     this.isMultiple = isMultiple;
@@ -60,6 +57,7 @@ class FileChooserImpl implements FileChooser {
 
   @Override
   public void setFiles(FilePayload[] files, SetFilesOptions options) {
-    element.setInputFiles(files, convertViaJson(options, ElementHandle.SetInputFilesOptions.class));
+    page.withLogging("FileChooser.setInputFiles",
+      () -> element.setInputFilesImpl(files, convertViaJson(options, ElementHandle.SetInputFilesOptions.class)));
   }
 }

--- a/playwright/src/main/java/com/microsoft/playwright/impl/FrameImpl.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/FrameImpl.java
@@ -69,6 +69,10 @@ public class FrameImpl extends ChannelOwner implements Frame {
 
   @Override
   public ElementHandle querySelector(String selector) {
+    return withLogging("Frame.querySelector", () -> querySelectorImpl(selector));
+  }
+
+  ElementHandleImpl querySelectorImpl(String selector) {
     JsonObject params = new JsonObject();
     params.addProperty("selector", selector);
     JsonElement json = sendMessage("querySelector", params);
@@ -81,6 +85,10 @@ public class FrameImpl extends ChannelOwner implements Frame {
 
   @Override
   public List<ElementHandle> querySelectorAll(String selector) {
+    return withLogging("Frame.querySelectorAll", () -> querySelectorAllImpl(selector));
+  }
+
+  List<ElementHandle> querySelectorAllImpl(String selector) {
     JsonObject params = new JsonObject();
     params.addProperty("selector", selector);
     JsonElement json = sendMessage("querySelectorAll", params);
@@ -97,6 +105,10 @@ public class FrameImpl extends ChannelOwner implements Frame {
 
   @Override
   public Object evalOnSelector(String selector, String pageFunction, Object arg) {
+    return withLogging("Frame.evalOnSelector", () -> evalOnSelectorImpl(selector, pageFunction, arg));
+  }
+
+  Object evalOnSelectorImpl(String selector, String pageFunction, Object arg) {
     JsonObject params = new JsonObject();
     params.addProperty("selector", selector);
     params.addProperty("expression", pageFunction);
@@ -109,6 +121,10 @@ public class FrameImpl extends ChannelOwner implements Frame {
 
   @Override
   public Object evalOnSelectorAll(String selector, String pageFunction, Object arg) {
+    return withLogging("Frame.evalOnSelectorAll", () -> evalOnSelectorAllImpl(selector, pageFunction, arg));
+  }
+
+  Object evalOnSelectorAllImpl(String selector, String pageFunction, Object arg) {
     JsonObject params = new JsonObject();
     params.addProperty("selector", selector);
     params.addProperty("expression", pageFunction);
@@ -120,7 +136,11 @@ public class FrameImpl extends ChannelOwner implements Frame {
   }
 
   @Override
-  public ElementHandle addScriptTag(AddScriptTagParams params) {
+  public ElementHandle addScriptTag(AddScriptTagParams params){
+    return withLogging("Frame.addScriptTag", () -> addScriptTagImpl(params));
+  }
+
+  ElementHandle addScriptTagImpl(AddScriptTagParams params) {
     if (params == null) {
       params = new AddScriptTagParams();
     }
@@ -142,7 +162,11 @@ public class FrameImpl extends ChannelOwner implements Frame {
   }
 
   @Override
-  public ElementHandle addStyleTag(AddStyleTagParams params) {
+  public ElementHandle addStyleTag(AddStyleTagParams params){
+    return withLogging("Frame.addStyleTag", () -> addStyleTagImpl(params));
+  }
+
+  ElementHandle addStyleTagImpl(AddStyleTagParams params) {
     if (params == null) {
       params = new AddStyleTagParams();
     }
@@ -164,7 +188,11 @@ public class FrameImpl extends ChannelOwner implements Frame {
   }
 
   @Override
-  public void check(String selector, CheckOptions options) {
+  public void check(String selector, CheckOptions options){
+    withLogging("Frame.check", () -> checkImpl(selector, options));
+  }
+
+  void checkImpl(String selector, CheckOptions options) {
     if (options == null) {
       options = new CheckOptions();
     }
@@ -180,6 +208,10 @@ public class FrameImpl extends ChannelOwner implements Frame {
 
   @Override
   public void click(String selector, ClickOptions options) {
+    withLogging("Frame.click", () -> clickImpl(selector, options));
+  }
+
+  void clickImpl(String selector, ClickOptions options) {
     if (options == null) {
       options = new ClickOptions();
     }
@@ -201,11 +233,19 @@ public class FrameImpl extends ChannelOwner implements Frame {
 
   @Override
   public String content() {
+    return withLogging("Frame.content", () -> contentImpl());
+  }
+
+  String contentImpl() {
     return sendMessage("content").getAsJsonObject().get("value").getAsString();
   }
 
   @Override
   public void dblclick(String selector, DblclickOptions options) {
+    withLogging("Frame.dblclick", () -> dblclickImpl(selector, options));
+  }
+
+  void dblclickImpl(String selector, DblclickOptions options) {
     if (options == null) {
       options = new DblclickOptions();
     }
@@ -227,6 +267,10 @@ public class FrameImpl extends ChannelOwner implements Frame {
 
   @Override
   public void dispatchEvent(String selector, String type, Object eventInit, DispatchEventOptions options) {
+    withLogging("Frame.dispatchEvent", () -> dispatchEventImpl(selector, type, eventInit, options));
+  }
+
+  void dispatchEventImpl(String selector, String type, Object eventInit, DispatchEventOptions options) {
     if (options == null) {
       options = new DispatchEventOptions();
     }
@@ -239,6 +283,10 @@ public class FrameImpl extends ChannelOwner implements Frame {
 
   @Override
   public Object evaluate(String expression, Object arg) {
+    return withLogging("Frame.evaluate", () -> evaluateImpl(expression, arg));
+  }
+
+  Object evaluateImpl(String expression, Object arg) {
     JsonObject params = new JsonObject();
     params.addProperty("expression", expression);
     params.addProperty("world", "main");
@@ -251,6 +299,10 @@ public class FrameImpl extends ChannelOwner implements Frame {
 
   @Override
   public JSHandle evaluateHandle(String pageFunction, Object arg) {
+    return withLogging("Frame.evaluateHandle", () -> evaluateHandleImpl(pageFunction, arg));
+  }
+
+  JSHandle evaluateHandleImpl(String pageFunction, Object arg) {
     JsonObject params = new JsonObject();
     params.addProperty("expression", pageFunction);
     params.addProperty("world", "main");
@@ -262,6 +314,10 @@ public class FrameImpl extends ChannelOwner implements Frame {
 
   @Override
   public void fill(String selector, String value, FillOptions options) {
+    withLogging("Frame.fill", () -> fillImpl(selector, value, options));
+  }
+
+  void fillImpl(String selector, String value, FillOptions options) {
     if (options == null) {
       options = new FillOptions();
     }
@@ -273,6 +329,10 @@ public class FrameImpl extends ChannelOwner implements Frame {
 
   @Override
   public void focus(String selector, FocusOptions options) {
+    withLogging("Frame.focus", () -> focusImpl(selector, options));
+  }
+
+  void focusImpl(String selector, FocusOptions options) {
     if (options == null) {
       options = new FocusOptions();
     }
@@ -283,12 +343,21 @@ public class FrameImpl extends ChannelOwner implements Frame {
 
   @Override
   public ElementHandle frameElement() {
+    return withLogging("Frame.frameElement", () -> frameElementImpl());
+
+  }
+
+  ElementHandle frameElementImpl() {
     JsonObject json = sendMessage("frameElement").getAsJsonObject();
     return connection.getExistingObject(json.getAsJsonObject("element").get("guid").getAsString());
   }
 
   @Override
   public String getAttribute(String selector, String name, GetAttributeOptions options) {
+    return withLogging("Frame.getAttribute", () -> getAttributeImpl(selector, name, options));
+  }
+
+  String getAttributeImpl(String selector, String name, GetAttributeOptions options) {
     if (options == null) {
       options = new GetAttributeOptions();
     }
@@ -304,6 +373,10 @@ public class FrameImpl extends ChannelOwner implements Frame {
 
   @Override
   public ResponseImpl navigate(String url, NavigateOptions options) {
+    return withLogging("Page.navigate", () -> navigateImpl(url, options));
+  }
+
+  ResponseImpl navigateImpl(String url, NavigateOptions options) {
     if (options == null) {
       options = new NavigateOptions();
     }
@@ -323,6 +396,10 @@ public class FrameImpl extends ChannelOwner implements Frame {
 
   @Override
   public void hover(String selector, HoverOptions options) {
+    withLogging("Frame.hover", () -> hoverImpl(selector, options));
+  }
+
+  void hoverImpl(String selector, HoverOptions options) {
     if (options == null) {
       options = new HoverOptions();
     }
@@ -333,6 +410,10 @@ public class FrameImpl extends ChannelOwner implements Frame {
 
   @Override
   public String innerHTML(String selector, InnerHTMLOptions options) {
+    return withLogging("Frame.innerHTML", () -> innerHTMLImpl(selector, options));
+  }
+
+  String innerHTMLImpl(String selector, InnerHTMLOptions options) {
     if (options == null) {
       options = new InnerHTMLOptions();
     }
@@ -344,6 +425,10 @@ public class FrameImpl extends ChannelOwner implements Frame {
 
   @Override
   public String innerText(String selector, InnerTextOptions options) {
+    return withLogging("Frame.innerText", () -> innerTextImpl(selector, options));
+  }
+
+  String innerTextImpl(String selector, InnerTextOptions options) {
     if (options == null) {
       options = new InnerTextOptions();
     }
@@ -375,6 +460,10 @@ public class FrameImpl extends ChannelOwner implements Frame {
 
   @Override
   public void press(String selector, String key, PressOptions options) {
+    withLogging("Frame.press", () -> pressImpl(selector, key, options));
+  }
+
+  void pressImpl(String selector, String key, PressOptions options) {
     if (options == null) {
       options = new PressOptions();
     }
@@ -386,6 +475,10 @@ public class FrameImpl extends ChannelOwner implements Frame {
 
   @Override
   public List<String> selectOption(String selector, ElementHandle.SelectOption[] values, SelectOptionOptions options) {
+    return withLogging("Frame.selectOption", () -> selectOptionImpl(selector, values, options));
+  }
+
+  List<String> selectOptionImpl(String selector, ElementHandle.SelectOption[] values, SelectOptionOptions options) {
     if (options == null) {
       options = new SelectOptionOptions();
     }
@@ -399,6 +492,10 @@ public class FrameImpl extends ChannelOwner implements Frame {
 
   @Override
   public List<String> selectOption(String selector, ElementHandle[] values, SelectOptionOptions options) {
+    return withLogging("Frame.selectOption", () -> selectOptionImpl(selector, values, options));
+  }
+
+  List<String> selectOptionImpl(String selector, ElementHandle[] values, SelectOptionOptions options) {
     if (options == null) {
       options = new SelectOptionOptions();
     }
@@ -429,6 +526,10 @@ public class FrameImpl extends ChannelOwner implements Frame {
 
   @Override
   public void setContent(String html, SetContentOptions options) {
+    withLogging("Frame.setContent", () -> setContentImpl(html, options));
+  }
+
+  void setContentImpl(String html, SetContentOptions options) {
     if (options == null) {
       options = new SetContentOptions();
     }
@@ -441,11 +542,19 @@ public class FrameImpl extends ChannelOwner implements Frame {
 
   @Override
   public void setInputFiles(String selector, Path[] files, SetInputFilesOptions options) {
+    withLogging("Frame.setInputFiles", () -> setInputFilesImpl(selector, files, options));
+  }
+
+  void setInputFilesImpl(String selector, Path[] files, SetInputFilesOptions options) {
     setInputFiles(selector, Utils.toFilePayloads(files), options);
   }
 
   @Override
   public void setInputFiles(String selector, FileChooser.FilePayload[] files, SetInputFilesOptions options) {
+    withLogging("Frame.setInputFiles", () -> setInputFilesImpl(selector, files, options));
+  }
+
+  void setInputFilesImpl(String selector, FileChooser.FilePayload[] files, SetInputFilesOptions options) {
     if (options == null) {
       options = new SetInputFilesOptions();
     }
@@ -457,6 +566,9 @@ public class FrameImpl extends ChannelOwner implements Frame {
 
   @Override
   public void tap(String selector, TapOptions options) {
+    withLogging("Frame.tap", () -> tapImpl(selector, options));
+  }
+  void tapImpl(String selector, TapOptions options) {
     if (options == null) {
       options = new TapOptions();
     }
@@ -471,6 +583,10 @@ public class FrameImpl extends ChannelOwner implements Frame {
 
   @Override
   public String textContent(String selector, TextContentOptions options) {
+    return withLogging("Frame.textContent", () -> textContentImpl(selector, options));
+  }
+
+  String textContentImpl(String selector, TextContentOptions options) {
     if (options == null) {
       options = new TextContentOptions();
     }
@@ -481,12 +597,20 @@ public class FrameImpl extends ChannelOwner implements Frame {
 
   @Override
   public String title() {
+    return withLogging("Frame.title", () -> titleImpl());
+  }
+
+  String titleImpl() {
     JsonElement json = sendMessage("title");
     return json.getAsJsonObject().get("value").getAsString();
   }
 
   @Override
   public void type(String selector, String text, TypeOptions options) {
+    withLogging("Frame.type", () -> typeImpl(selector, text, options));
+  }
+
+  void typeImpl(String selector, String text, TypeOptions options) {
     if (options == null) {
       options = new TypeOptions();
     }
@@ -498,6 +622,10 @@ public class FrameImpl extends ChannelOwner implements Frame {
 
   @Override
   public void uncheck(String selector, UncheckOptions options) {
+    withLogging("Frame.uncheck", () -> uncheckImpl(selector, options));
+  }
+
+  void uncheckImpl(String selector, UncheckOptions options) {
     if (options == null) {
       options = new UncheckOptions();
     }
@@ -513,6 +641,10 @@ public class FrameImpl extends ChannelOwner implements Frame {
 
   @Override
   public JSHandle waitForFunction(String pageFunction, Object arg, WaitForFunctionOptions options) {
+    return withLogging("Frame.waitForFunction", () -> waitForFunctionImpl(pageFunction, arg, options));
+  }
+
+  JSHandle waitForFunctionImpl(String pageFunction, Object arg, WaitForFunctionOptions options) {
     if (options == null) {
       options = new WaitForFunctionOptions();
     }
@@ -527,6 +659,10 @@ public class FrameImpl extends ChannelOwner implements Frame {
 
   @Override
   public void waitForLoadState(LoadState state, WaitForLoadStateOptions options) {
+    withLogging("Frame.waitForLoadState", () -> waitForLoadStateImpl(state, options));
+  }
+
+  void waitForLoadStateImpl(LoadState state, WaitForLoadStateOptions options) {
     if (options == null) {
       options = new WaitForLoadStateOptions();
     }
@@ -645,6 +781,10 @@ public class FrameImpl extends ChannelOwner implements Frame {
 
   @Override
   public Deferred<Response> futureNavigation(FutureNavigationOptions options) {
+    return withLoggingDeferred("Frame.futureNavigation", () -> futureNavigationImpl(options));
+  }
+
+  Deferred<Response> futureNavigationImpl(FutureNavigationOptions options) {
     if (options == null) {
       options = new FutureNavigationOptions();
     }
@@ -667,6 +807,10 @@ public class FrameImpl extends ChannelOwner implements Frame {
 
   @Override
   public ElementHandle waitForSelector(String selector, WaitForSelectorOptions options) {
+    return withLogging("Frame.waitForSelector", () -> waitForSelectorImpl(selector, options));
+  }
+
+  ElementHandle waitForSelectorImpl(String selector, WaitForSelectorOptions options) {
     if (options == null) {
       options = new WaitForSelectorOptions();
     }
@@ -686,6 +830,10 @@ public class FrameImpl extends ChannelOwner implements Frame {
 
   @Override
   public void waitForTimeout(int timeout) {
+    withLogging("Frame.waitForTimeout", () -> waitForTimeoutImpl(timeout));
+  }
+
+  void waitForTimeoutImpl(int timeout) {
     toDeferred(new WaitableTimeout<Void>(timeout) {
       @Override
       public Void get() {

--- a/playwright/src/main/java/com/microsoft/playwright/impl/KeyboardImpl.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/KeyboardImpl.java
@@ -19,7 +19,7 @@ package com.microsoft.playwright.impl;
 import com.google.gson.JsonObject;
 import com.microsoft.playwright.Keyboard;
 
-class KeyboardImpl implements Keyboard {
+class KeyboardImpl extends LoggingSupport implements Keyboard {
   private final ChannelOwner page;
 
   KeyboardImpl(ChannelOwner page) {
@@ -28,42 +28,52 @@ class KeyboardImpl implements Keyboard {
 
   @Override
   public void down(String key) {
-    JsonObject params = new JsonObject();
-    params.addProperty("key", key);
-    page.sendMessage("keyboardDown", params);
+    withLogging("Keyboard.down", () -> {
+      JsonObject params = new JsonObject();
+      params.addProperty("key", key);
+      page.sendMessage("keyboardDown", params);
+    });
   }
 
   @Override
   public void insertText(String text) {
-    JsonObject params = new JsonObject();
-    params.addProperty("text", text);
-    page.sendMessage("keyboardInsertText", params);
+    withLogging("Keyboard.insertText", () -> {
+      JsonObject params = new JsonObject();
+      params.addProperty("text", text);
+      page.sendMessage("keyboardInsertText", params);
+    });
   }
 
   @Override
   public void press(String key, int delay) {
-    JsonObject params = new JsonObject();
-    params.addProperty("key", key);
-    if (delay != 0) {
-      params.addProperty("delay", delay);
-    }
-    page.sendMessage("keyboardPress", params);
+    withLogging("Keyboard.press", () -> {
+      JsonObject params = new JsonObject();
+      params.addProperty("key", key);
+      if (delay != 0) {
+        params.addProperty("delay", delay);
+      }
+      page.sendMessage("keyboardPress", params);
+    });
   }
 
   @Override
   public void type(String text, int delay) {
-    JsonObject params = new JsonObject();
-    params.addProperty("text", text);
-    if (delay != 0) {
-      params.addProperty("delay", delay);
-    }
-    page.sendMessage("keyboardType", params);
+    withLogging("Keyboard.type", () -> {
+      JsonObject params = new JsonObject();
+      params.addProperty("text", text);
+      if (delay != 0) {
+        params.addProperty("delay", delay);
+      }
+      page.sendMessage("keyboardType", params);
+    });
   }
 
   @Override
   public void up(String key) {
-    JsonObject params = new JsonObject();
-    params.addProperty("key", key);
-    page.sendMessage("keyboardUp", params);
+    withLogging("Keyboard.up", () -> {
+      JsonObject params = new JsonObject();
+      params.addProperty("key", key);
+      page.sendMessage("keyboardUp", params);
+    });
   }
 }

--- a/playwright/src/main/java/com/microsoft/playwright/impl/LoggingSupport.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/LoggingSupport.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.microsoft.playwright.impl;
+
+import com.microsoft.playwright.Deferred;
+
+import java.util.function.Supplier;
+
+class LoggingSupport {
+  private static boolean isEnabled;
+  {
+    String debug = System.getenv("DEBUG");
+    isEnabled = (debug != null) && debug.contains("pw:api");
+  }
+
+  void withLogging(String apiName, Runnable code) {
+    withLogging(apiName, () -> {
+      code.run();
+      return null;
+    });
+  }
+
+  <T> T withLogging(String apiName, Supplier<T> code) {
+    if (isEnabled) {
+      logApi("=> " + apiName + " started");
+    }
+    boolean success = false;
+    try {
+      T result = code.get();
+      success = true;
+      return result;
+    } finally {
+      if (isEnabled) {
+        logApi("<= " + apiName + (success ? " succeeded" : " failed"));
+      }
+    }
+  }
+
+  <T> Deferred<T> withLoggingDeferred(String apiName, Supplier<Deferred<T>> code) {
+    if (isEnabled) {
+      logApi("=> " + apiName + " started");
+    }
+    Deferred<T> deferred = code.get();
+    return () -> {
+      boolean success = false;
+      try {
+        T result = deferred.get();
+        success = true;
+        return result;
+      } finally {
+        if (isEnabled) {
+          logApi("<= " + apiName + (success ? " succeeded" : " failed"));
+        }
+      }
+    };
+  }
+
+  private void logApi(String message) {
+    System.err.println(message);
+  }
+}

--- a/playwright/src/main/java/com/microsoft/playwright/impl/MouseImpl.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/MouseImpl.java
@@ -33,6 +33,10 @@ class MouseImpl implements Mouse {
 
   @Override
   public void click(int x, int y, ClickOptions options) {
+    page.withLogging("Mouse.click", () -> clickImpl(x, y, options));
+  }
+
+  private void clickImpl(int x, int y, ClickOptions options) {
     if (options == null) {
       options = new ClickOptions();
     }
@@ -48,6 +52,10 @@ class MouseImpl implements Mouse {
 
   @Override
   public void dblclick(int x, int y, DblclickOptions options) {
+    page.withLogging("Mouse.dblclick", () -> dblclickImpl(x, y, options));
+  }
+
+  private void dblclickImpl(int x, int y, DblclickOptions options) {
     ClickOptions clickOptions;
     if (options == null) {
       clickOptions = new ClickOptions();
@@ -60,6 +68,10 @@ class MouseImpl implements Mouse {
 
   @Override
   public void down(DownOptions options) {
+    page.withLogging("Mouse.down", () -> downImpl(options));
+  }
+
+  private void downImpl(DownOptions options) {
     if (options == null) {
       options = new DownOptions();
     }
@@ -69,6 +81,10 @@ class MouseImpl implements Mouse {
 
   @Override
   public void move(int x, int y, MoveOptions options) {
+    page.withLogging("Mouse.move", () -> moveImpl(x, y, options));
+  }
+
+  private void moveImpl(int x, int y, MoveOptions options) {
     if (options == null) {
       options = new MoveOptions();
     }
@@ -80,6 +96,10 @@ class MouseImpl implements Mouse {
 
   @Override
   public void up(UpOptions options) {
+    page.withLogging("Mouse.up", () -> upImpl(options));
+  }
+
+  private void upImpl(UpOptions options) {
     if (options == null) {
       options = new UpOptions();
     }

--- a/playwright/src/main/java/com/microsoft/playwright/impl/PageImpl.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/PageImpl.java
@@ -26,6 +26,7 @@ import java.util.*;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 import java.util.regex.Pattern;
 
 import static com.microsoft.playwright.impl.Serialization.gson;
@@ -102,7 +103,7 @@ public class PageImpl extends ChannelOwner implements Page {
       listeners.notify(EventType.DOWNLOAD, download);
     } else if ("fileChooser".equals(event)) {
       String guid = params.getAsJsonObject("element").get("guid").getAsString();
-      ElementHandle elementHandle = connection.getExistingObject(guid);
+      ElementHandleImpl elementHandle = connection.getExistingObject(guid);
       FileChooser fileChooser = new FileChooserImpl(this, elementHandle, params.get("isMultiple").getAsBoolean());
       listeners.notify(EventType.FILECHOOSER, fileChooser);
     } else if ("bindingCall".equals(event)) {
@@ -237,22 +238,22 @@ public class PageImpl extends ChannelOwner implements Page {
 
   @Override
   public ElementHandle querySelector(String selector) {
-    return mainFrame.querySelector(selector);
+    return withLogging("Page.querySelector", () -> mainFrame.querySelectorImpl(selector));
   }
 
   @Override
   public List<ElementHandle> querySelectorAll(String selector) {
-    return mainFrame.querySelectorAll(selector);
+    return withLogging("Page.querySelectorAll", () -> mainFrame.querySelectorAllImpl(selector));
   }
 
   @Override
   public Object evalOnSelector(String selector, String pageFunction, Object arg) {
-    return mainFrame.evalOnSelector(selector, pageFunction, arg);
+    return withLogging("Page.evalOnSelector", () -> mainFrame.evalOnSelectorImpl(selector, pageFunction, arg));
   }
 
   @Override
   public Object evalOnSelectorAll(String selector, String pageFunction, Object arg) {
-    return mainFrame.evalOnSelectorAll(selector, pageFunction, arg);
+    return withLogging("Page.evalOnSelectorAll", () -> mainFrame.evalOnSelectorAllImpl(selector, pageFunction, arg));
   }
 
   @Override
@@ -262,40 +263,46 @@ public class PageImpl extends ChannelOwner implements Page {
 
   @Override
   public void addInitScript(String script, Object arg) {
-    JsonObject params = new JsonObject();
-    // TODO: support or drop arg
-    params.addProperty("source", script);
-    sendMessage("addInitScript", params);
+    withLogging("Page.addInitScript", () -> {
+      JsonObject params = new JsonObject();
+      // TODO: support or drop arg
+      params.addProperty("source", script);
+      sendMessage("addInitScript", params);
+    });
   }
 
   @Override
   public ElementHandle addScriptTag(AddScriptTagParams params) {
-    return mainFrame.addScriptTag(convertViaJson(params, Frame.AddScriptTagParams.class));
+    return withLogging("Page.addScriptTag",
+      () -> mainFrame.addScriptTagImpl(convertViaJson(params, Frame.AddScriptTagParams.class)));
   }
 
   @Override
   public ElementHandle addStyleTag(AddStyleTagParams params) {
-    return mainFrame.addStyleTag(convertViaJson(params, Frame.AddStyleTagParams.class));
+    return withLogging("Page.addStyleTag",
+      () -> mainFrame.addStyleTagImpl(convertViaJson(params, Frame.AddStyleTagParams.class)));
   }
 
   @Override
   public void bringToFront() {
-    sendMessage("bringToFront");
+    withLogging("Page.bringToFront", () -> sendMessage("bringToFront"));
   }
 
   @Override
   public void check(String selector, CheckOptions options) {
-    mainFrame.check(selector, convertViaJson(options, Frame.CheckOptions.class));
+    withLogging("Page.check",
+      () -> mainFrame.checkImpl(selector, convertViaJson(options, Frame.CheckOptions.class)));
   }
 
   @Override
   public void click(String selector, ClickOptions options) {
-    mainFrame.click(selector, convertViaJson(options, Frame.ClickOptions.class));
+    withLogging("Page.click",
+      () -> mainFrame.clickImpl(selector, convertViaJson(options, Frame.ClickOptions.class)));
   }
 
   @Override
   public String content() {
-    return mainFrame.content();
+    return withLogging("Page.content", () -> mainFrame.contentImpl());
   }
 
   @Override
@@ -305,16 +312,22 @@ public class PageImpl extends ChannelOwner implements Page {
 
   @Override
   public void dblclick(String selector, DblclickOptions options) {
-    mainFrame.dblclick(selector, convertViaJson(options, Frame.DblclickOptions.class));
+    withLogging("Page.dblclick",
+      () -> mainFrame.dblclickImpl(selector, convertViaJson(options, Frame.DblclickOptions.class)));
   }
 
   @Override
   public void dispatchEvent(String selector, String type, Object eventInit, DispatchEventOptions options) {
-    mainFrame.dispatchEvent(selector, type, eventInit, convertViaJson(options, Frame.DispatchEventOptions.class));
+    withLogging("Page.dispatchEvent",
+      () -> mainFrame.dispatchEventImpl(selector, type, eventInit, convertViaJson(options, Frame.DispatchEventOptions.class)));
   }
 
   @Override
   public void emulateMedia(EmulateMediaParams options) {
+    withLogging("Page.emulateMedia", () -> emulateMediaImpl(options));
+  }
+
+  private void emulateMediaImpl(EmulateMediaParams options) {
     if (options == null) {
       options = new EmulateMediaParams();
     }
@@ -324,16 +337,20 @@ public class PageImpl extends ChannelOwner implements Page {
 
   @Override
   public Object evaluate(String expression, Object arg) {
-    return mainFrame.evaluate(expression, arg);
+    return withLogging("Page.evaluate", () -> mainFrame.evaluateImpl(expression, arg));
   }
 
   @Override
   public JSHandle evaluateHandle(String pageFunction, Object arg) {
-    return mainFrame.evaluateHandle(pageFunction, arg);
+    return withLogging("Page.evaluateHandle", () -> mainFrame.evaluateHandleImpl(pageFunction, arg));
   }
 
   @Override
   public void exposeBinding(String name, Binding playwrightBinding, ExposeBindingOptions options) {
+    withLogging("Page.exposeBinding", () -> exposeBindingImpl(name, playwrightBinding, options));
+  }
+
+  private void exposeBindingImpl(String name, Binding playwrightBinding, ExposeBindingOptions options) {
     if (bindings.containsKey(name)) {
       throw new PlaywrightException("Function \"" + name + "\" has been already registered");
     }
@@ -352,17 +369,20 @@ public class PageImpl extends ChannelOwner implements Page {
 
   @Override
   public void exposeFunction(String name, Function playwrightFunction) {
-    exposeBinding(name, (Binding.Source source, Object... args) -> playwrightFunction.call(args));
+    withLogging("Page.exposeFunction",
+      () -> exposeBindingImpl(name, (Binding.Source source, Object... args) -> playwrightFunction.call(args), null));
   }
 
   @Override
   public void fill(String selector, String value, FillOptions options) {
-    mainFrame.fill(selector, value, convertViaJson(options, Frame.FillOptions.class));
+    withLogging("Page.fill",
+      () -> mainFrame.fillImpl(selector, value, convertViaJson(options, Frame.FillOptions.class)));
   }
 
   @Override
   public void focus(String selector, FocusOptions options) {
-    mainFrame.focus(selector, convertViaJson(options, Frame.FocusOptions.class));
+    withLogging("Page.focus",
+      () -> mainFrame.focusImpl(selector, convertViaJson(options, Frame.FocusOptions.class)));
   }
 
   @Override
@@ -406,11 +426,16 @@ public class PageImpl extends ChannelOwner implements Page {
 
   @Override
   public String getAttribute(String selector, String name, GetAttributeOptions options) {
-    return mainFrame.getAttribute(selector, name, convertViaJson(options, Frame.GetAttributeOptions.class));
+    return withLogging("Page.getAttribute",
+      () -> mainFrame.getAttributeImpl(selector, name, convertViaJson(options, Frame.GetAttributeOptions.class)));
   }
 
   @Override
   public Response goBack(GoBackOptions options) {
+    return withLogging("Page.goBack", () -> goBackImpl(options));
+  }
+
+  Response goBackImpl(GoBackOptions options) {
     if (options == null) {
       options = new GoBackOptions();
     }
@@ -426,6 +451,10 @@ public class PageImpl extends ChannelOwner implements Page {
 
   @Override
   public Response goForward(GoForwardOptions options) {
+    return withLogging("Page.goForward", () -> goForwardImpl(options));
+  }
+
+  Response goForwardImpl(GoForwardOptions options) {
     if (options == null) {
       options = new GoForwardOptions();
     }
@@ -441,22 +470,26 @@ public class PageImpl extends ChannelOwner implements Page {
 
   @Override
   public ResponseImpl navigate(String url, NavigateOptions options) {
-    return mainFrame.navigate(url, convertViaJson(options, Frame.NavigateOptions.class));
+    return withLogging("Page.navigate", () ->
+      mainFrame.navigateImpl(url, convertViaJson(options, Frame.NavigateOptions.class)));
   }
 
   @Override
   public void hover(String selector, HoverOptions options) {
-    mainFrame.hover(selector, convertViaJson(options, Frame.HoverOptions.class));
+    withLogging("Page.hover", () ->
+      mainFrame.hoverImpl(selector, convertViaJson(options, Frame.HoverOptions.class)));
   }
 
   @Override
   public String innerHTML(String selector, InnerHTMLOptions options) {
-    return mainFrame.innerHTML(selector, convertViaJson(options, Frame.InnerHTMLOptions.class));
+    return withLogging("Page.innerHTML",
+      () -> mainFrame.innerHTMLImpl(selector, convertViaJson(options, Frame.InnerHTMLOptions.class)));
   }
 
   @Override
   public String innerText(String selector, InnerTextOptions options) {
-    return mainFrame.innerText(selector, convertViaJson(options, Frame.InnerTextOptions.class));
+    return withLogging("Page.innerText",
+      () -> mainFrame.innerTextImpl(selector, convertViaJson(options, Frame.InnerTextOptions.class)));
   }
 
   @Override
@@ -481,15 +514,21 @@ public class PageImpl extends ChannelOwner implements Page {
 
   @Override
   public Page opener() {
-    JsonObject result = sendMessage("opener").getAsJsonObject();
-    if (!result.has("page")) {
-      return null;
-    }
-    return connection.getExistingObject(result.getAsJsonObject("page").get("guid").getAsString());
+    return withLogging("Page.opener", () -> {
+      JsonObject result = sendMessage("opener").getAsJsonObject();
+      if (!result.has("page")) {
+        return null;
+      }
+      return connection.getExistingObject(result.getAsJsonObject("page").get("guid").getAsString());
+    });
   }
 
   @Override
   public byte[] pdf(PdfOptions options) {
+    return withLogging("Page.pdf", () -> pdfImpl(options));
+  }
+
+  private byte[] pdfImpl(PdfOptions options) {
     if (!browserContext.browser().isChromium()) {
       throw new PlaywrightException("Page.pdf only supported in headless Chromium");
     }
@@ -508,11 +547,16 @@ public class PageImpl extends ChannelOwner implements Page {
 
   @Override
   public void press(String selector, String key, PressOptions options) {
-    mainFrame.press(selector, key, convertViaJson(options, Frame.PressOptions.class));
+    withLogging("Page.press",
+      () -> mainFrame.pressImpl(selector, key, convertViaJson(options, Frame.PressOptions.class)));
   }
 
   @Override
   public Response reload(ReloadOptions options) {
+    return withLogging("Page.reload", () -> reloadImpl(options));
+  }
+
+  private Response reloadImpl(ReloadOptions options) {
     if (options == null) {
       options = new ReloadOptions();
     }
@@ -542,12 +586,14 @@ public class PageImpl extends ChannelOwner implements Page {
   }
 
   private void route(UrlMatcher matcher, Consumer<Route> handler) {
-    routes.add(matcher, handler);
-    if (routes.size() == 1) {
-      JsonObject params = new JsonObject();
-      params.addProperty("enabled", true);
-      sendMessage("setNetworkInterceptionEnabled", params);
-    }
+    withLogging("Page.route", () -> {
+      routes.add(matcher, handler);
+      if (routes.size() == 1) {
+        JsonObject params = new JsonObject();
+        params.addProperty("enabled", true);
+        sendMessage("setNetworkInterceptionEnabled", params);
+      }
+    });
   }
 
   private static String toProtocol(ScreenshotOptions.Type type) {
@@ -556,6 +602,10 @@ public class PageImpl extends ChannelOwner implements Page {
 
   @Override
   public byte[] screenshot(ScreenshotOptions options) {
+    return withLogging("Page.screenshot", () -> screenshotImpl(options));
+  }
+
+  private byte[] screenshotImpl(ScreenshotOptions options) {
     if (options == null) {
       options = new ScreenshotOptions();
     }
@@ -587,80 +637,95 @@ public class PageImpl extends ChannelOwner implements Page {
 
   @Override
   public List<String> selectOption(String selector, ElementHandle.SelectOption[] values, SelectOptionOptions options) {
-    return mainFrame.selectOption(selector, values, convertViaJson(options, Frame.SelectOptionOptions.class));
+    return withLogging("Page.selectOption",
+      () -> mainFrame.selectOptionImpl(selector, values, convertViaJson(options, Frame.SelectOptionOptions.class)));
   }
 
   @Override
   public List<String> selectOption(String selector, ElementHandle[] values, SelectOptionOptions options) {
-    return mainFrame.selectOption(selector, values, convertViaJson(options, Frame.SelectOptionOptions.class));
+    return withLogging("Page.selectOption",
+      () -> mainFrame.selectOptionImpl(selector, values, convertViaJson(options, Frame.SelectOptionOptions.class)));
   }
 
   @Override
   public void setContent(String html, SetContentOptions options) {
-    mainFrame.setContent(html, convertViaJson(options, Frame.SetContentOptions.class));
+    withLogging("Page.setContent",
+      () -> mainFrame.setContentImpl(html, convertViaJson(options, Frame.SetContentOptions.class)));
   }
 
   @Override
   public void setDefaultNavigationTimeout(int timeout) {
-    timeoutSettings.setDefaultNavigationTimeout(timeout);
-    JsonObject params = new JsonObject();
-    params.addProperty("timeout", timeout);
-    sendMessage("setDefaultNavigationTimeoutNoReply", params);
+    withLogging("Page.setDefaultNavigationTimeout", () -> {
+      timeoutSettings.setDefaultNavigationTimeout(timeout);
+      JsonObject params = new JsonObject();
+      params.addProperty("timeout", timeout);
+      sendMessage("setDefaultNavigationTimeoutNoReply", params);
+    });
   }
 
   @Override
   public void setDefaultTimeout(int timeout) {
-    timeoutSettings.setDefaultTimeout(timeout);
-    JsonObject params = new JsonObject();
-    params.addProperty("timeout", timeout);
-    sendMessage("setDefaultTimeoutNoReply", params);
+    withLogging("Page.setDefaultTimeout", () -> {
+      timeoutSettings.setDefaultTimeout(timeout);
+      JsonObject params = new JsonObject();
+      params.addProperty("timeout", timeout);
+      sendMessage("setDefaultTimeoutNoReply", params);
+    });
   }
 
   @Override
   public void setExtraHTTPHeaders(Map<String, String> headers) {
-    JsonObject params = new JsonObject();
-    JsonArray jsonHeaders = new JsonArray();
-    for (Map.Entry<String, String> e : headers.entrySet()) {
-      JsonObject header = new JsonObject();
-      header.addProperty("name", e.getKey());
-      header.addProperty("value", e.getValue());
-      jsonHeaders.add(header);
-    }
-    params.add("headers", jsonHeaders);
-    sendMessage("setExtraHTTPHeaders", params);
+    withLogging("Page.setExtraHTTPHeaders", () -> {
+      JsonObject params = new JsonObject();
+      JsonArray jsonHeaders = new JsonArray();
+      for (Map.Entry<String, String> e : headers.entrySet()) {
+        JsonObject header = new JsonObject();
+        header.addProperty("name", e.getKey());
+        header.addProperty("value", e.getValue());
+        jsonHeaders.add(header);
+      }
+      params.add("headers", jsonHeaders);
+      sendMessage("setExtraHTTPHeaders", params);
+    });
   }
 
   @Override
   public void setInputFiles(String selector, Path[] files, SetInputFilesOptions options) {
-    mainFrame.setInputFiles(selector, files, convertViaJson(options, Frame.SetInputFilesOptions.class));
+    withLogging("Page.setInputFiles",
+      () -> mainFrame.setInputFilesImpl(selector, files, convertViaJson(options, Frame.SetInputFilesOptions.class)));
   }
 
   @Override
   public void setInputFiles(String selector, FileChooser.FilePayload[] files, SetInputFilesOptions options) {
-    mainFrame.setInputFiles(selector, files, convertViaJson(options, Frame.SetInputFilesOptions.class));
+    withLogging("Page.setInputFiles",
+      () -> mainFrame.setInputFilesImpl(selector, files, convertViaJson(options, Frame.SetInputFilesOptions.class)));
   }
 
   @Override
   public void setViewportSize(int width, int height) {
-    viewport = new Viewport(width, height);
-    JsonObject params = new JsonObject();
-    params.add("viewportSize", gson().toJsonTree(viewport));
-    sendMessage("setViewportSize", params);
+    withLogging("Page.setViewportSize", () -> {
+      viewport = new Viewport(width, height);
+      JsonObject params = new JsonObject();
+      params.add("viewportSize", gson().toJsonTree(viewport));
+      sendMessage("setViewportSize", params);
+    });
   }
 
   @Override
   public void tap(String selector, TapOptions options) {
-    mainFrame.tap(selector, convertViaJson(options, Frame.TapOptions.class));
+    withLogging("Page.tap",
+      () -> mainFrame.tapImpl(selector, convertViaJson(options, Frame.TapOptions.class)));
   }
 
   @Override
   public String textContent(String selector, TextContentOptions options) {
-    return mainFrame.textContent(selector, convertViaJson(options, Frame.TextContentOptions.class));
+    return withLogging("Page.textContent",
+      () -> mainFrame.textContentImpl(selector, convertViaJson(options, Frame.TextContentOptions.class)));
   }
 
   @Override
   public String title() {
-    return mainFrame.title();
+    return withLogging("Page.title", () -> mainFrame.titleImpl());
   }
 
   @Override
@@ -670,12 +735,14 @@ public class PageImpl extends ChannelOwner implements Page {
 
   @Override
   public void type(String selector, String text, TypeOptions options) {
-    mainFrame.type(selector, text, convertViaJson(options, Frame.TypeOptions.class));
+    withLogging("Page.type",
+      () -> mainFrame.typeImpl(selector, text, convertViaJson(options, Frame.TypeOptions.class)));
   }
 
   @Override
   public void uncheck(String selector, UncheckOptions options) {
-    mainFrame.uncheck(selector, convertViaJson(options, Frame.UncheckOptions.class));
+    withLogging("Page.uncheck",
+      () -> mainFrame.uncheckImpl(selector, convertViaJson(options, Frame.UncheckOptions.class)));
   }
 
   @Override
@@ -694,12 +761,14 @@ public class PageImpl extends ChannelOwner implements Page {
   }
 
   private void unroute(UrlMatcher matcher, Consumer<Route> handler) {
-    routes.remove(matcher, handler);
-    if (routes.size() == 0) {
-      JsonObject params = new JsonObject();
-      params.addProperty("enabled", false);
-      sendMessage("setNetworkInterceptionEnabled", params);
-    }
+    withLogging("Page.unroute", () -> {
+      routes.remove(matcher, handler);
+      if (routes.size() == 0) {
+        JsonObject params = new JsonObject();
+        params.addProperty("enabled", false);
+        sendMessage("setNetworkInterceptionEnabled", params);
+      }
+    });
   }
 
   @Override
@@ -738,6 +807,10 @@ public class PageImpl extends ChannelOwner implements Page {
 
   @Override
   public Deferred<Event<EventType>> futureEvent(EventType event, FutureEventOptions options) {
+    return withLogging("Page.futureEvent", () -> futureEventImpl(event, options));
+  }
+
+  private Deferred<Event<EventType>> futureEventImpl(EventType event, FutureEventOptions options) {
     if (options == null) {
       options = new FutureEventOptions();
     }
@@ -760,16 +833,22 @@ public class PageImpl extends ChannelOwner implements Page {
 
   @Override
   public JSHandle waitForFunction(String pageFunction, Object arg, WaitForFunctionOptions options) {
-    return mainFrame.waitForFunction(pageFunction, arg, convertViaJson(options, Frame.WaitForFunctionOptions.class));
+    return withLogging("Page.waitForFunction",
+      () -> mainFrame.waitForFunctionImpl(pageFunction, arg, convertViaJson(options, Frame.WaitForFunctionOptions.class)));
   }
 
   @Override
   public void waitForLoadState(LoadState state, WaitForLoadStateOptions options) {
-    mainFrame.waitForLoadState(convertViaJson(state, Frame.LoadState.class), convertViaJson(options, Frame.WaitForLoadStateOptions.class));
+    withLogging("Page.waitForLoadState",
+      () -> mainFrame.waitForLoadStateImpl(convertViaJson(state, Frame.LoadState.class), convertViaJson(options, Frame.WaitForLoadStateOptions.class)));
   }
 
   @Override
   public Deferred<Response> futureNavigation(FutureNavigationOptions options) {
+    return withLoggingDeferred("Page.futureNavigation", () -> futureNavigationImpl(options));
+  }
+
+  Deferred<Response> futureNavigationImpl(FutureNavigationOptions options) {
     Frame.FutureNavigationOptions frameOptions = new Frame.FutureNavigationOptions();
     if (options != null) {
       frameOptions.timeout = options.timeout;
@@ -778,7 +857,7 @@ public class PageImpl extends ChannelOwner implements Page {
       frameOptions.pattern = options.pattern;
       frameOptions.predicate = options.predicate;
     }
-    return mainFrame.futureNavigation(frameOptions);
+    return mainFrame.futureNavigationImpl(frameOptions);
   }
 
   void frameNavigated(FrameImpl frame) {
@@ -886,6 +965,10 @@ public class PageImpl extends ChannelOwner implements Page {
   }
 
   private Deferred<Request> futureRequest(UrlMatcher matcher, FutureRequestOptions options) {
+    return withLoggingDeferred("Page.futureRequest", () -> futureRequestImpl(matcher, options));
+  }
+
+  private Deferred<Request> futureRequestImpl(UrlMatcher matcher, FutureRequestOptions options) {
     if (options == null) {
       options = new FutureRequestOptions();
     }
@@ -913,6 +996,10 @@ public class PageImpl extends ChannelOwner implements Page {
   }
 
   private Deferred<Response> futureResponse(UrlMatcher matcher, FutureResponseOptions options) {
+    return withLoggingDeferred("Page.futureResponse", () -> futureResponse(matcher, options));
+  }
+
+  private Deferred<Response> futureResponseImpl(UrlMatcher matcher, FutureResponseOptions options) {
     if (options == null) {
       options = new FutureResponseOptions();
     }
@@ -926,12 +1013,13 @@ public class PageImpl extends ChannelOwner implements Page {
 
   @Override
   public ElementHandle waitForSelector(String selector, WaitForSelectorOptions options) {
-    return mainFrame.waitForSelector(selector, convertViaJson(options, Frame.WaitForSelectorOptions.class));
+    return withLogging("Page.waitForSelector",
+      () -> mainFrame.waitForSelectorImpl(selector, convertViaJson(options, Frame.WaitForSelectorOptions.class)));
   }
 
   @Override
   public void waitForTimeout(int timeout) {
-    mainFrame.waitForTimeout(timeout);
+    withLogging("Page.waitForTimeout", () -> mainFrame.waitForTimeoutImpl(timeout));
   }
 
   @Override

--- a/playwright/src/main/java/com/microsoft/playwright/impl/PageImpl.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/PageImpl.java
@@ -996,7 +996,7 @@ public class PageImpl extends ChannelOwner implements Page {
   }
 
   private Deferred<Response> futureResponse(UrlMatcher matcher, FutureResponseOptions options) {
-    return withLoggingDeferred("Page.futureResponse", () -> futureResponse(matcher, options));
+    return withLoggingDeferred("Page.futureResponse", () -> futureResponseImpl(matcher, options));
   }
 
   private Deferred<Response> futureResponseImpl(UrlMatcher matcher, FutureResponseOptions options) {

--- a/playwright/src/main/java/com/microsoft/playwright/impl/RequestImpl.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/RequestImpl.java
@@ -33,6 +33,7 @@ public class RequestImpl extends ChannelOwner implements Request {
   private RequestImpl redirectedTo;
   final Map<String, String> headers = new HashMap<>();
   RequestFailure failure;
+  RequestTiming timing;
 
   RequestImpl(ChannelOwner parent, String type, String guid, JsonObject initializer) {
     super(parent, type, guid, initializer);
@@ -107,11 +108,13 @@ public class RequestImpl extends ChannelOwner implements Request {
 
   @Override
   public Response response() {
-    JsonObject result = sendMessage("response").getAsJsonObject();
-    if (!result.has("response")) {
-      return null;
-    }
-    return connection.getExistingObject(result.getAsJsonObject("response").get("guid").getAsString());
+    return withLogging("Request.response", () -> {
+      JsonObject result = sendMessage("response").getAsJsonObject();
+      if (!result.has("response")) {
+        return null;
+      }
+      return connection.getExistingObject(result.getAsJsonObject("response").get("guid").getAsString());
+    });
   }
 
   @Override

--- a/playwright/src/main/java/com/microsoft/playwright/impl/ResponseImpl.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/ResponseImpl.java
@@ -45,21 +45,26 @@ public class ResponseImpl extends ChannelOwner implements Response {
       JsonObject item = e.getAsJsonObject();
       request.headers.put(item.get("name").getAsString().toLowerCase(), item.get("value").getAsString());
     }
+    request.timing = Serialization.gson().fromJson(initializer.get("timing"), Request.RequestTiming.class);
   }
 
   @Override
   public byte[] body() {
-    JsonObject json = sendMessage("body").getAsJsonObject();
-    return Base64.getDecoder().decode(json.get("binary").getAsString());
+    return withLogging("Response.body", () -> {
+      JsonObject json = sendMessage("body").getAsJsonObject();
+      return Base64.getDecoder().decode(json.get("binary").getAsString());
+    });
   }
 
   @Override
   public String finished() {
-    JsonObject json = sendMessage("finished").getAsJsonObject();
-    if (json.has("error")) {
-      return json.get("error").getAsString();
-    }
-    return null;
+    return withLogging("Response.finished", () -> {
+      JsonObject json = sendMessage("finished").getAsJsonObject();
+      if (json.has("error")) {
+        return json.get("error").getAsString();
+      }
+      return null;
+    });
   }
 
   @Override

--- a/playwright/src/main/java/com/microsoft/playwright/impl/RouteImpl.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/RouteImpl.java
@@ -36,13 +36,19 @@ public class RouteImpl extends ChannelOwner implements Route {
 
   @Override
   public void abort(String errorCode) {
-    JsonObject params = new JsonObject();
-    params.addProperty("errorCode", errorCode);
-    sendMessage("abort", params);
+    withLogging("Route.abort", () -> {
+      JsonObject params = new JsonObject();
+      params.addProperty("errorCode", errorCode);
+      sendMessage("abort", params);
+    });
   }
 
   @Override
   public void continue_(ContinueOverrides overrides) {
+    withLogging("Route.continue", () -> continueImpl(overrides));
+  }
+
+  private void continueImpl(ContinueOverrides overrides) {
     if (overrides == null) {
       overrides = new ContinueOverrides();
     }
@@ -65,6 +71,10 @@ public class RouteImpl extends ChannelOwner implements Route {
 
   @Override
   public void fulfill(FulfillResponse response) {
+    withLogging("Route.fulfill", () -> fulfillImpl(response));
+  }
+
+  private void fulfillImpl(FulfillResponse response) {
     if (response == null) {
       response = new FulfillResponse();
     }

--- a/playwright/src/main/java/com/microsoft/playwright/impl/SelectorsImpl.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/SelectorsImpl.java
@@ -34,6 +34,10 @@ class SelectorsImpl extends ChannelOwner implements Selectors {
 
   @Override
   public void register(String name, String script, RegisterOptions options) {
+    withLogging("Selectors.register", () -> registerImpl(name, script, options));
+  }
+
+  private void registerImpl(String name, String script, RegisterOptions options) {
     if (options == null) {
       options = new RegisterOptions();
     }

--- a/playwright/src/main/java/com/microsoft/playwright/impl/TouchscreenImpl.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/TouchscreenImpl.java
@@ -28,9 +28,11 @@ class TouchscreenImpl implements Touchscreen {
 
   @Override
   public void tap(int x, int y) {
-    JsonObject params = new JsonObject();
-    params.addProperty("x", x);
-    params.addProperty("y", y);
-    page.sendMessage("touchscreenTap", params);
+    page.withLogging("Touchscreen.tap", () -> {
+      JsonObject params = new JsonObject();
+      params.addProperty("x", x);
+      params.addProperty("y", y);
+      page.sendMessage("touchscreenTap", params);
+    });
   }
 }

--- a/playwright/src/main/java/com/microsoft/playwright/impl/WebSocketImpl.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/WebSocketImpl.java
@@ -98,6 +98,10 @@ class WebSocketImpl extends ChannelOwner implements WebSocket {
 
   @Override
   public Deferred<Event<EventType>> futureEvent(EventType event, FutureEventOptions options) {
+    return withLoggingDeferred("WebSocket.futureEvent", () -> futureEventImpl(event, options));
+  }
+
+  private Deferred<Event<EventType>> futureEventImpl(EventType event, FutureEventOptions options) {
     if (options == null) {
       options = new FutureEventOptions();
     }

--- a/playwright/src/main/java/com/microsoft/playwright/impl/WorkerImpl.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/WorkerImpl.java
@@ -44,23 +44,27 @@ class WorkerImpl extends ChannelOwner implements Worker {
 
   @Override
   public Object evaluate(String pageFunction, Object arg) {
-    JsonObject params = new JsonObject();
-    params.addProperty("expression", pageFunction);
-    params.addProperty("isFunction", isFunctionBody(pageFunction));
-    params.add("arg", gson().toJsonTree(serializeArgument(arg)));
-    JsonElement json = sendMessage("evaluateExpression", params);
-    SerializedValue value = gson().fromJson(json.getAsJsonObject().get("value"), SerializedValue.class);
-    return deserialize(value);
+    return withLogging("Worker.evaluate", () -> {
+      JsonObject params = new JsonObject();
+      params.addProperty("expression", pageFunction);
+      params.addProperty("isFunction", isFunctionBody(pageFunction));
+      params.add("arg", gson().toJsonTree(serializeArgument(arg)));
+      JsonElement json = sendMessage("evaluateExpression", params);
+      SerializedValue value = gson().fromJson(json.getAsJsonObject().get("value"), SerializedValue.class);
+      return deserialize(value);
+    });
   }
 
   @Override
   public JSHandle evaluateHandle(String pageFunction, Object arg) {
-    JsonObject params = new JsonObject();
-    params.addProperty("expression", pageFunction);
-    params.addProperty("isFunction", isFunctionBody(pageFunction));
-    params.add("arg", gson().toJsonTree(serializeArgument(arg)));
-    JsonElement json = sendMessage("evaluateExpressionHandle", params);
-    return connection.getExistingObject(json.getAsJsonObject().getAsJsonObject("handle").get("guid").getAsString());
+    return withLogging("Worker.evaluateHandle", () -> {
+      JsonObject params = new JsonObject();
+      params.addProperty("expression", pageFunction);
+      params.addProperty("isFunction", isFunctionBody(pageFunction));
+      params.add("arg", gson().toJsonTree(serializeArgument(arg)));
+      JsonElement json = sendMessage("evaluateExpressionHandle", params);
+      return connection.getExistingObject(json.getAsJsonObject().getAsJsonObject("handle").get("guid").getAsString());
+    });
   }
 
   @Override


### PR DESCRIPTION
Methods that go to the backend over rpc are wrapped into logging scopes. This somewhat bloats the implementation classes but still feels better than wrapping each public class into a logging decorator (tried that in https://github.com/yury-s/playwright-java/tree/generate-logging-wrappers and it seemed more verbose and harder to maintain).