### PR TITLE
fix: do not dismiss dialogs automatically

### DIFF
--- a/playwright/src/main/java/com/microsoft/playwright/impl/DialogImpl.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/DialogImpl.java
@@ -21,7 +21,6 @@ import com.microsoft.playwright.Dialog;
 import com.microsoft.playwright.PlaywrightException;
 
 class DialogImpl extends ChannelOwner implements Dialog {
-  private boolean handled;
   DialogImpl(ChannelOwner parent, String type, String guid, JsonObject initializer) {
     super(parent, type, guid, initializer);
   }
@@ -29,20 +28,17 @@ class DialogImpl extends ChannelOwner implements Dialog {
   @Override
   public void accept(String promptText) {
     withLogging("Dialog.accept", () -> {
-      handled = true;
       JsonObject params = new JsonObject();
-      if (promptText != null)
+      if (promptText != null) {
         params.addProperty("promptText", promptText);
+      }
       sendMessage("accept", params);
     });
   }
 
   @Override
   public void dismiss() {
-    withLogging("Dialog.dismiss", () -> {
-      handled = true;
-      sendMessage("dismiss");
-    });
+    withLogging("Dialog.dismiss", () -> sendMessage("dismiss"));
   }
 
   @Override
@@ -64,9 +60,5 @@ class DialogImpl extends ChannelOwner implements Dialog {
       case "prompt": return Type.PROMPT;
       default: throw new PlaywrightException("Unexpected dialog type: " + initializer.get("type").getAsString());
     }
-  }
-
-  boolean isHandled() {
-    return handled;
   }
 }

--- a/playwright/src/main/java/com/microsoft/playwright/impl/PageImpl.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/PageImpl.java
@@ -74,11 +74,10 @@ public class PageImpl extends ChannelOwner implements Page {
     if ("dialog".equals(event)) {
       String guid = params.getAsJsonObject("dialog").get("guid").getAsString();
       DialogImpl dialog = connection.getExistingObject(guid);
+      // If no action taken the dialog will stay open and execution will hang. We
+      // could automatically dismiss the dialog if there are no listeners but we want
+      // the behavior to match upstream one.
       listeners.notify(EventType.DIALOG, dialog);
-      // If no action taken dismiss dialog to not hang.
-      if (!dialog.isHandled()) {
-        dialog.dismiss();
-      }
     } else if ("popup".equals(event)) {
       String guid = params.getAsJsonObject("page").get("guid").getAsString();
       PageImpl popup = connection.getExistingObject(guid);

--- a/playwright/src/test/java/com/microsoft/playwright/TestPageBasic.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestPageBasic.java
@@ -59,24 +59,19 @@ public class TestPageBasic extends TestBase {
     // We have to interact with a page so that "beforeunload" handlers
     // fire.
     newPage.click("body");
-    boolean[] didShowDialog = {false};
-    newPage.addListener(DIALOG, event -> {
-      didShowDialog[0] = true;
-      Dialog dialog = (Dialog) event.data();
-      assertEquals(Dialog.Type.BEFOREUNLOAD, dialog.type());
-      assertEquals("", dialog.defaultValue());
-      if (isChromium()) {
-        assertEquals("", dialog.message());
-      } else if (isWebKit()) {
-        assertEquals("Leave?", dialog.message());
-      } else {
-        assertEquals("This page is asking you to confirm that you want to leave - data you have entered may not be saved.", dialog.message());
-      }
-      dialog.accept();
-    });
+    Deferred<Event<Page.EventType>> event = newPage.futureEvent(DIALOG);
     newPage.close(new Page.CloseOptions().withRunBeforeUnload(true));
-    // TODO: uncomment once https://github.com/microsoft/playwright/pull/4070 is committed.
-//    assertTrue(didShowDialog[0]);
+    Dialog dialog = (Dialog) event.get().data();
+    assertEquals(Dialog.Type.BEFOREUNLOAD, dialog.type());
+    assertEquals("", dialog.defaultValue());
+    if (isChromium()) {
+      assertEquals("", dialog.message());
+    } else if (isWebKit()) {
+      assertEquals("Leave?", dialog.message());
+    } else {
+      assertEquals("This page is asking you to confirm that you want to leave - data you have entered may not be saved.", dialog.message());
+    }
+    dialog.accept();
   }
 
   @Test


### PR DESCRIPTION
This should fix flakiness in `TestPageBasic.shouldRunBeforeunloadIfAskedFor` (see [this run](https://github.com/microsoft/playwright-java/pull/196/checks?check_run_id=1663558029) for example).