### PR TITLE
test: add new test 'Element Handle Select Text', Fixed webkit windows…

### DIFF
--- a/playwright/src/test/java/com/microsoft/playwright/TestElementHandleSelectText.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestElementHandleSelectText.java
@@ -1,0 +1,65 @@
+package com.microsoft.playwright;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class TestElementHandleSelectText extends TestBase {
+
+  @Test
+  void shouldSelectTextarea() {
+    page.navigate(server.PREFIX + "/input/textarea.html");
+    ElementHandle textarea = page.querySelector("textarea");
+    textarea.evaluate("textarea => textarea.value = 'some value'");
+    textarea.selectText();
+    if (isFirefox()) {
+      assertEquals(0, textarea.evaluate("el => el.selectionStart"));
+      assertEquals(10, textarea.evaluate("el => el.selectionEnd"));
+    } else {
+      assertEquals("some value", page.evaluate("() => window.getSelection().toString()"));
+    }
+  }
+
+  @Test
+  void shouldSelectInput() {
+    page.navigate(server.PREFIX + "/input/textarea.html");
+    ElementHandle input = page.querySelector("input");
+    input.evaluate("input => input.value = 'some value'");
+    input.selectText();
+    if (isFirefox()) {
+      assertEquals(0, input.evaluate("el => el.selectionStart"));
+      assertEquals(10, input.evaluate("el => el.selectionEnd"));
+    } else {
+      assertEquals("some value", page.evaluate("() => window.getSelection().toString()"));
+    }
+  }
+
+  @Test
+  void shouldSelectPlainDiv() {
+    page.navigate(server.PREFIX + "/input/textarea.html");
+    ElementHandle div = page.querySelector("div.plain");
+    div.selectText();
+    assertEquals("Plain div", page.evaluate("() => window.getSelection().toString()"));
+  }
+
+  @Test
+  void shouldTimeoutWaitingForInvisibleElement() {
+    page.navigate(server.PREFIX + "/input/textarea.html");
+    ElementHandle textarea = page.querySelector("textarea");
+    textarea.evaluate("e => e.style.display = 'none'");
+    try {
+      textarea.selectText(new ElementHandle.SelectTextOptions().withTimeout(3000));
+      fail("did not throw");
+    } catch (PlaywrightException e) {
+      assertTrue(e.getMessage().contains("element is not visible"));
+    }
+  }
+
+//  @Test
+  void shouldWaitForVisible() {
+    // TODO Wait for Async API implementation
+  }
+}

--- a/playwright/src/test/java/com/microsoft/playwright/TestPageWaitForNavigation.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestPageWaitForNavigation.java
@@ -20,11 +20,12 @@ import org.junit.jupiter.api.Test;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.Arrays;
+import java.util.List;
 import java.util.regex.Pattern;
 
 import static com.microsoft.playwright.Page.EventType.FRAMENAVIGATED;
-import static com.microsoft.playwright.Utils.expectedSSLError;
-import static com.microsoft.playwright.Utils.getOS;
+import static com.microsoft.playwright.Utils.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class TestPageWaitForNavigation extends TestBase {
@@ -67,6 +68,10 @@ public class TestPageWaitForNavigation extends TestBase {
     assertEquals(server.EMPTY_PAGE + "#foobar", page.url());
   }
 
+  private boolean checkSSLErrorMessage(String exceptionMessage, List<String> possibleErrorMessages) {
+    return possibleErrorMessages.stream().anyMatch(exceptionMessage::contains);
+  }
+
   @Test
   void shouldWorkWithClickingOnLinksWhichDoNotCommitNavigation() throws InterruptedException {
     page.navigate(server.EMPTY_PAGE);
@@ -78,9 +83,8 @@ public class TestPageWaitForNavigation extends TestBase {
       fail("did not throw");
     } catch (PlaywrightException e) {
       // TODO: figure out why it is inconsistent on Linux WebKit.
-      assertTrue(e.getMessage().contains(expectedSSLError(browserType.name())) ||
-          (isWebKit() && getOS() == Utils.OS.LINUX && "Server required TLS certificate".equals(e.getMessage())),
-        "Unexpected exception: '" + e.getMessage() + "'");
+      List<String> possibleErrorMessages = expectedSSLError(browserType.name());
+      assertTrue(checkSSLErrorMessage(e.getMessage(), possibleErrorMessages), "Unexpected exception: '" + e.getMessage() + "' check message(s): " + String.join(",", possibleErrorMessages));
     }
   }
 

--- a/playwright/src/test/java/com/microsoft/playwright/Utils.java
+++ b/playwright/src/test/java/com/microsoft/playwright/Utils.java
@@ -23,7 +23,10 @@ import com.google.gson.JsonParser;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.lang.reflect.Array;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -78,27 +81,27 @@ class Utils {
     return OS.UNKNOWN;
   }
 
-  static String expectedSSLError(String browserName) {
+  static List<String> expectedSSLError(String browserName) {
     switch (browserName) {
       case "chromium":
         switch (getOS()) {
           case MAC:
-            return "net::ERR_CERT_INVALID";
+            return Arrays.asList("net::ERR_CERT_INVALID");
           default:
-            return "net::ERR_CERT_AUTHORITY_INVALID";
+            return Arrays.asList("net::ERR_CERT_AUTHORITY_INVALID");
         }
       case "webkit": {
         switch (getOS()) {
           case MAC:
-            return "The certificate for this server is invalid";
+            return Arrays.asList("The certificate for this server is invalid");
           case WINDOWS:
-            return "SSL peer certificate or SSH remote key was not OK";
+            return Arrays.asList("SSL peer certificate or SSH remote key was not OK", "SSL connect error");
           default:
-            return "Unacceptable TLS certificate";
+            return Arrays.asList("Unacceptable TLS certificate", "Server required TLS certificate");
         }
       }
       default:
-        return "SSL_ERROR_UNKNOWN";
+        return Arrays.asList("SSL_ERROR_UNKNOWN");
     }
   }
 }


### PR DESCRIPTION
1. add new test - Test Element Handle Select Text scenarios
2. Fixed webkit windows platform check SSL Error message with regular expression in TestPageWaitForNavigation.shouldWorkWithClickingOnLinksWhichDoNotCommitNavigation()