### PR TITLE
fix(scripts): 'generate_api.sh' does not work on macOS

### DIFF
--- a/scripts/generate_api.sh
+++ b/scripts/generate_api.sh
@@ -3,10 +3,19 @@
 set -e
 set +x
 
-trap "cd $(pwd -P)" EXIT
-cd "$(dirname $0)/.."
+trap 'cd $(pwd -P)' EXIT
+cd "$(dirname "$0")/.."
 
-PLAYWRIGHT_CLI=./driver-bundle/src/main/resources/driver/linux/playwright.sh
+DRIVER_PATH=./driver-bundle/src/main/resources/driver
+case $(uname) in
+Darwin)
+  PLAYWRIGHT_CLI=$DRIVER_PATH/mac/playwright.sh
+  ;;
+Linux|MINGW32*|MINGW64*)
+  PLAYWRIGHT_CLI=$DRIVER_PATH/linux/playwright.sh
+  ;;
+esac
+
 echo "Updating api.json from $($PLAYWRIGHT_CLI --version)"
 
 $PLAYWRIGHT_CLI print-api-json > ./tools/api-generator/src/main/resources/api.json
@@ -14,4 +23,4 @@ $PLAYWRIGHT_CLI print-api-json > ./tools/api-generator/src/main/resources/api.js
 mvn compile -f ./tools/api-generator --no-transfer-progress
 
 echo "Regenerating Java interfaces"
-mvn exec:java --f ./tools/api-generator -Dexec.mainClass=com.microsoft.playwright.tools.ApiGenerator
+mvn exec:java --f ./tools/api-generator -D exec.mainClass=com.microsoft.playwright.tools.ApiGenerator

--- a/scripts/generate_api.sh
+++ b/scripts/generate_api.sh
@@ -6,13 +6,23 @@ set +x
 trap 'cd $(pwd -P)' EXIT
 cd "$(dirname "$0")/.."
 
-DRIVER_PATH=./driver-bundle/src/main/resources/driver
+PLAYWRIGHT_CLI="unknown"
 case $(uname) in
 Darwin)
-  PLAYWRIGHT_CLI=$DRIVER_PATH/mac/playwright.sh
+  PLAYWRIGHT_CLI=./driver-bundle/src/main/resources/driver/mac/playwright.sh
   ;;
-Linux|MINGW32*|MINGW64*)
-  PLAYWRIGHT_CLI=$DRIVER_PATH/linux/playwright.sh
+Linux)
+  PLAYWRIGHT_CLI=./driver-bundle/src/main/resources/driver/linux/playwright.sh
+  ;;
+MINGW32*)
+  PLAYWRIGHT_CLI=./driver-bundle/src/main/resources/driver/win32/playwright.sh
+  ;;
+MINGW64*)
+  PLAYWRIGHT_CLI=./driver-bundle/src/main/resources/driver/win32_x64/playwright.sh
+  ;;
+*)
+  echo "Unknown platform '$(uname)'"
+  exit 1;
   ;;
 esac
 

--- a/scripts/generate_api.sh
+++ b/scripts/generate_api.sh
@@ -15,10 +15,10 @@ Linux)
   PLAYWRIGHT_CLI=./driver-bundle/src/main/resources/driver/linux/playwright.sh
   ;;
 MINGW32*)
-  PLAYWRIGHT_CLI=./driver-bundle/src/main/resources/driver/win32/playwright.sh
+  PLAYWRIGHT_CLI=./driver-bundle/src/main/resources/driver/win32/playwright.cmd
   ;;
 MINGW64*)
-  PLAYWRIGHT_CLI=./driver-bundle/src/main/resources/driver/win32_x64/playwright.sh
+  PLAYWRIGHT_CLI=./driver-bundle/src/main/resources/driver/win32_x64/playwright.cmd
   ;;
 *)
   echo "Unknown platform '$(uname)'"


### PR DESCRIPTION
Got a prompt message like this `playwright-java/driver-bundle/src/main/resources/driver/linux/node: cannot execute binary file` when I was executing `./scripts/generate_api.sh` on my `macOS Big Sur 11.1`, guess that is caused by different platform, so maybe we need to consider distinguishing the path of `playwright.sh` by platform.