### PR TITLE
fix(api): remove Listener interface from public API

### DIFF
--- a/playwright/src/main/java/com/microsoft/playwright/Browser.java
+++ b/playwright/src/main/java/com/microsoft/playwright/Browser.java
@@ -48,12 +48,6 @@ public interface Browser {
     }
   }
 
-  enum EventType {
-    DISCONNECTED,
-  }
-
-  void addListener(EventType type, Listener<EventType> listener);
-  void removeListener(EventType type, Listener<EventType> listener);
 
   void onDisconnected(Runnable handler);
   void offDisconnected(Runnable handler);

--- a/playwright/src/main/java/com/microsoft/playwright/BrowserContext.java
+++ b/playwright/src/main/java/com/microsoft/playwright/BrowserContext.java
@@ -94,13 +94,6 @@ public interface BrowserContext {
     }
   }
 
-  enum EventType {
-    CLOSE,
-    PAGE,
-  }
-
-  void addListener(EventType type, Listener<EventType> listener);
-  void removeListener(EventType type, Listener<EventType> listener);
 
   void onClose(Runnable handler);
   void offClose(Runnable handler);

--- a/playwright/src/main/java/com/microsoft/playwright/Page.java
+++ b/playwright/src/main/java/com/microsoft/playwright/Page.java
@@ -74,30 +74,6 @@ public interface Page {
     String stack();
   }
 
-  enum EventType {
-    CLOSE,
-    CONSOLE,
-    CRASH,
-    DIALOG,
-    DOMCONTENTLOADED,
-    DOWNLOAD,
-    FILECHOOSER,
-    FRAMEATTACHED,
-    FRAMEDETACHED,
-    FRAMENAVIGATED,
-    LOAD,
-    PAGEERROR,
-    POPUP,
-    REQUEST,
-    REQUESTFAILED,
-    REQUESTFINISHED,
-    RESPONSE,
-    WEBSOCKET,
-    WORKER,
-  }
-
-  void addListener(EventType type, Listener<EventType> listener);
-  void removeListener(EventType type, Listener<EventType> listener);
 
   void onClose(Runnable handler);
   void offClose(Runnable handler);

--- a/playwright/src/main/java/com/microsoft/playwright/WebSocket.java
+++ b/playwright/src/main/java/com/microsoft/playwright/WebSocket.java
@@ -29,15 +29,6 @@ public interface WebSocket {
     String text();
   }
 
-  enum EventType {
-    CLOSE,
-    FRAMERECEIVED,
-    FRAMESENT,
-    SOCKETERROR,
-  }
-
-  void addListener(EventType type, Listener<EventType> listener);
-  void removeListener(EventType type, Listener<EventType> listener);
 
   void onClose(Runnable handler);
   void offClose(Runnable handler);

--- a/playwright/src/main/java/com/microsoft/playwright/Worker.java
+++ b/playwright/src/main/java/com/microsoft/playwright/Worker.java
@@ -25,12 +25,6 @@ import java.util.function.Consumer;
  * worker is gone.
  */
 public interface Worker {
-  enum EventType {
-    CLOSE,
-  }
-
-  void addListener(EventType type, Listener<EventType> listener);
-  void removeListener(EventType type, Listener<EventType> listener);
 
   void onClose(Consumer<Worker> handler);
   void offClose(Consumer<Worker> handler);

--- a/playwright/src/main/java/com/microsoft/playwright/impl/BrowserContextImpl.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/BrowserContextImpl.java
@@ -21,7 +21,6 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.microsoft.playwright.*;
 
-import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -46,6 +45,11 @@ class BrowserContextImpl extends ChannelOwner implements BrowserContext {
   final TimeoutSettings timeoutSettings = new TimeoutSettings();
   Path videosDir;
 
+  enum EventType {
+    CLOSE,
+    PAGE,
+  }
+
   BrowserContextImpl(ChannelOwner parent, String type, String guid, JsonObject initializer) {
     super(parent, type, guid, initializer);
     if (parent instanceof BrowserImpl) {
@@ -53,16 +57,6 @@ class BrowserContextImpl extends ChannelOwner implements BrowserContext {
     } else {
       browser = null;
     }
-  }
-
-  @Override
-  public void addListener(EventType type, Listener<EventType> listener) {
-    listeners.add(type, listener);
-  }
-
-  @Override
-  public void removeListener(EventType type, Listener<EventType> listener) {
-    listeners.remove(type, listener);
   }
 
   @Override
@@ -359,7 +353,7 @@ class BrowserContextImpl extends ChannelOwner implements BrowserContext {
     private String errorMessage;
 
     WaitableContextClose() {
-      addListener(EventType.CLOSE, this);
+      listeners.add(EventType.CLOSE, this);
     }
 
     @Override
@@ -384,7 +378,7 @@ class BrowserContextImpl extends ChannelOwner implements BrowserContext {
 
     @Override
     public void dispose() {
-      removeListener(EventType.CLOSE, this);
+      listeners.remove(EventType.CLOSE, this);
     }
   }
 

--- a/playwright/src/main/java/com/microsoft/playwright/impl/BrowserImpl.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/BrowserImpl.java
@@ -37,18 +37,12 @@ class BrowserImpl extends ChannelOwner implements Browser {
   private final ListenerCollection<EventType> listeners = new ListenerCollection<>();
   private boolean isConnected = true;
 
+  enum EventType {
+    DISCONNECTED,
+  }
+
   BrowserImpl(ChannelOwner parent, String type, String guid, JsonObject initializer) {
     super(parent, type, guid, initializer);
-  }
-
-  @Override
-  public void addListener(EventType type, Listener<EventType> listener) {
-    listeners.add(type, listener);
-  }
-
-  @Override
-  public void removeListener(EventType type, Listener<EventType> listener) {
-    listeners.remove(type, listener);
   }
 
   @Override

--- a/playwright/src/main/java/com/microsoft/playwright/impl/Listener.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/Listener.java
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 
-package com.microsoft.playwright;
+package com.microsoft.playwright.impl;
+
+import com.microsoft.playwright.Event;
 
 public interface Listener<EventType> {
   void handle(Event<EventType> event);

--- a/playwright/src/main/java/com/microsoft/playwright/impl/ListenerCollection.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/ListenerCollection.java
@@ -17,7 +17,6 @@
 package com.microsoft.playwright.impl;
 
 import com.microsoft.playwright.Event;
-import com.microsoft.playwright.Listener;
 
 import java.util.*;
 import java.util.function.Consumer;
@@ -89,7 +88,7 @@ class ListenerCollection <EventType> {
     public boolean equals(Object o) {
       if (this == o) return true;
       if (o == null || getClass() != o.getClass()) return false;
-      RunnableWrapper<?> that = (RunnableWrapper<?>) o;
+      ConsumerWrapper<?> that = (ConsumerWrapper<?>) o;
       return Objects.equals(callback, that.callback);
     }
 

--- a/playwright/src/main/java/com/microsoft/playwright/impl/WaitableEvent.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/WaitableEvent.java
@@ -17,8 +17,6 @@
 package com.microsoft.playwright.impl;
 
 import com.microsoft.playwright.Event;
-import com.microsoft.playwright.Listener;
-import com.microsoft.playwright.Page;
 
 import java.util.function.Predicate;
 

--- a/playwright/src/main/java/com/microsoft/playwright/impl/WebSocketImpl.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/WebSocketImpl.java
@@ -31,19 +31,16 @@ class WebSocketImpl extends ChannelOwner implements WebSocket {
   private final PageImpl page;
   private boolean isClosed;
 
-  public WebSocketImpl(ChannelOwner parent, String type, String guid, JsonObject initializer) {
+  enum EventType {
+    CLOSE,
+    FRAMERECEIVED,
+    FRAMESENT,
+    SOCKETERROR,
+  }
+
+  WebSocketImpl(ChannelOwner parent, String type, String guid, JsonObject initializer) {
     super(parent, type, guid, initializer);
     page = (PageImpl) parent;
-  }
-
-  @Override
-  public void addListener(EventType type, Listener<EventType> listener) {
-    listeners.add(type, listener);
-  }
-
-  @Override
-  public void removeListener(EventType type, Listener<EventType> listener) {
-    listeners.remove(type, listener);
   }
 
   @Override
@@ -127,7 +124,7 @@ class WebSocketImpl extends ChannelOwner implements WebSocket {
     WaitableWebSocketError() {
       subscribedEvents = Arrays.asList(EventType.CLOSE, EventType.SOCKETERROR);
       for (EventType e : subscribedEvents) {
-        addListener(e, this);
+        listeners.add(e, this);
       }
     }
 
@@ -156,7 +153,7 @@ class WebSocketImpl extends ChannelOwner implements WebSocket {
     @Override
     public void dispose() {
       for (EventType e : subscribedEvents) {
-        removeListener(e, this);
+        listeners.remove(e, this);
       }
     }
   }

--- a/playwright/src/main/java/com/microsoft/playwright/impl/WorkerImpl.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/WorkerImpl.java
@@ -32,18 +32,12 @@ class WorkerImpl extends ChannelOwner implements Worker {
   private final ListenerCollection<EventType> listeners = new ListenerCollection<>();
   PageImpl page;
 
+  enum EventType {
+    CLOSE,
+  }
+
   WorkerImpl(ChannelOwner parent, String type, String guid, JsonObject initializer) {
     super(parent, type, guid, initializer);
-  }
-
-  @Override
-  public void addListener(EventType type, Listener<EventType> listener) {
-    listeners.add(type, listener);
-  }
-
-  @Override
-  public void removeListener(EventType type, Listener<EventType> listener) {
-    listeners.remove(type, listener);
   }
 
   @Override

--- a/playwright/src/test/java/com/microsoft/playwright/TestBase.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestBase.java
@@ -16,7 +16,10 @@
 
 package com.microsoft.playwright;
 
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 
 import java.io.IOException;
 

--- a/playwright/src/test/java/com/microsoft/playwright/TestBrowserContextBasic.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestBrowserContextBasic.java
@@ -22,8 +22,6 @@ import org.junit.jupiter.api.Test;
 import java.io.OutputStreamWriter;
 import java.util.List;
 
-import static com.microsoft.playwright.BrowserContext.EventType.PAGE;
-import static com.microsoft.playwright.Page.EventType.POPUP;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class TestBrowserContextBasic extends TestBase {
@@ -181,7 +179,7 @@ public class TestBrowserContextBasic extends TestBase {
       }
     });
     Page[] popup = {null};
-    context.addListener(PAGE, event -> popup[0] = (Page) event.data());
+    context.onPage(page1 -> popup[0] = page1);
     page.navigate(server.EMPTY_PAGE);
     page.click("'Click me'");
     context.close();

--- a/playwright/src/test/java/com/microsoft/playwright/TestBrowserContextCredentials.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestBrowserContextCredentials.java
@@ -19,7 +19,6 @@ package com.microsoft.playwright;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIf;
 
-import static com.microsoft.playwright.Utils.getOS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 

--- a/playwright/src/test/java/com/microsoft/playwright/TestBrowserContextRoute.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestBrowserContextRoute.java
@@ -20,7 +20,6 @@ import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
 import static java.util.Arrays.asList;

--- a/playwright/src/test/java/com/microsoft/playwright/TestClick.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestClick.java
@@ -23,11 +23,9 @@ import org.junit.jupiter.api.condition.EnabledIf;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.function.Consumer;
 
 import static com.microsoft.playwright.Keyboard.Modifier.SHIFT;
 import static com.microsoft.playwright.Mouse.Button.RIGHT;
-import static com.microsoft.playwright.Page.EventType.CONSOLE;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class TestClick extends TestBase {
@@ -141,7 +139,7 @@ public class TestClick extends TestBase {
   void shouldClickOffscreenButtons() {
     page.navigate(server.PREFIX + "/offscreenbuttons.html");
     List<String> messages = new ArrayList<>();
-    page.addListener(CONSOLE, event -> messages.add(((ConsoleMessage) event.data()).text()));
+    page.onConsole(message -> messages.add(message.text()));
     for (int i = 0; i < 11; ++i) {
       // We might've scrolled to click a button - reset to (0, 0).
       page.evaluate("() => window.scrollTo(0, 0)");

--- a/playwright/src/test/java/com/microsoft/playwright/TestDefaultBrowserContext2.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestDefaultBrowserContext2.java
@@ -223,7 +223,7 @@ public class TestDefaultBrowserContext2 extends TestBase {
   void shouldFireCloseEventForAPersistentContext() {
     launchPersistent();
     boolean[] closed = {false};
-    persistentContext.addListener(BrowserContext.EventType.CLOSE, event -> closed[0] = true);
+    persistentContext.onClose(() -> closed[0] = true);
     closePersistentContext();
     assertTrue(closed[0]);
   }

--- a/playwright/src/test/java/com/microsoft/playwright/TestDialog.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestDialog.java
@@ -18,11 +18,9 @@ package com.microsoft.playwright;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIf;
-import org.junit.jupiter.api.condition.EnabledIf;
 
 import static com.microsoft.playwright.Dialog.Type.ALERT;
 import static com.microsoft.playwright.Dialog.Type.PROMPT;
-import static com.microsoft.playwright.Page.EventType.DIALOG;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
@@ -30,8 +28,7 @@ public class TestDialog extends TestBase {
 
   @Test
   void shouldFire() {
-    page.addListener(DIALOG, event -> {
-      Dialog dialog = (Dialog) event.data();
+    page.onDialog(dialog -> {
       assertEquals(ALERT, dialog.type());
       assertEquals( "", dialog.defaultValue());
       assertEquals( "yo", dialog.message());
@@ -42,8 +39,7 @@ public class TestDialog extends TestBase {
 
   @Test
   void shouldAllowAcceptingPrompts() {
-    page.addListener(DIALOG, event -> {
-      Dialog dialog = (Dialog) event.data();
+    page.onDialog(dialog -> {
       assertEquals(PROMPT, dialog.type());
       assertEquals("yes.", dialog.defaultValue());
       assertEquals("question?", dialog.message());
@@ -55,8 +51,7 @@ public class TestDialog extends TestBase {
 
   @Test
   void shouldDismissThePrompt() {
-    page.addListener(DIALOG, event -> {
-      Dialog dialog = (Dialog) event.data();
+    page.onDialog(dialog -> {
       dialog.dismiss();
     });
     Object result = page.evaluate("() => prompt('question?')");
@@ -65,8 +60,7 @@ public class TestDialog extends TestBase {
 
   @Test
   void shouldAcceptTheConfirmPrompt() {
-    page.addListener(DIALOG, event -> {
-      Dialog dialog = (Dialog) event.data();
+    page.onDialog(dialog -> {
       dialog.accept();
     });
     Object result = page.evaluate("() => confirm('boolean?')");
@@ -75,8 +69,7 @@ public class TestDialog extends TestBase {
 
   @Test
   void shouldDismissTheConfirmPrompt() {
-    page.addListener(DIALOG, event -> {
-      Dialog dialog = (Dialog) event.data();
+    page.onDialog(dialog -> {
       dialog.dismiss();
     });
     Object result = page.evaluate("() => confirm('boolean?')");

--- a/playwright/src/test/java/com/microsoft/playwright/TestDispatchEvent.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestDispatchEvent.java
@@ -19,7 +19,8 @@ package com.microsoft.playwright;
 import org.junit.jupiter.api.Test;
 
 import static com.microsoft.playwright.Utils.mapOf;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class TestDispatchEvent extends TestBase {
 

--- a/playwright/src/test/java/com/microsoft/playwright/TestElementHandleSelectText.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestElementHandleSelectText.java
@@ -2,9 +2,6 @@ package com.microsoft.playwright;
 
 import org.junit.jupiter.api.Test;
 
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.atomic.AtomicBoolean;
-
 import static org.junit.jupiter.api.Assertions.*;
 
 public class TestElementHandleSelectText extends TestBase {

--- a/playwright/src/test/java/com/microsoft/playwright/TestGeolocation.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestGeolocation.java
@@ -21,8 +21,6 @@ import org.junit.jupiter.api.Test;
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.microsoft.playwright.Page.EventType.CONSOLE;
-import static com.microsoft.playwright.Page.EventType.POPUP;
 import static com.microsoft.playwright.Utils.mapOf;
 import static java.util.Arrays.asList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -111,7 +109,7 @@ public class TestGeolocation extends TestBase {
     context.grantPermissions(asList("geolocation"));
     page.navigate(server.EMPTY_PAGE);
     List<String> messages = new ArrayList<>();
-    page.addListener(CONSOLE, event -> messages.add(((ConsoleMessage) event.data()).text()));
+    page.onConsole(message -> messages.add(message.text()));
     context.setGeolocation(new Geolocation());
     page.evaluate("() => {\n" +
       "  navigator.geolocation.watchPosition(pos => {\n" +

--- a/playwright/src/test/java/com/microsoft/playwright/TestHar.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestHar.java
@@ -19,12 +19,10 @@ package com.microsoft.playwright;
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-import com.google.gson.stream.JsonReader;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.IOException;
 import java.io.Reader;

--- a/playwright/src/test/java/com/microsoft/playwright/TestNetworkResponse.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestNetworkResponse.java
@@ -24,12 +24,8 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
 import java.util.concurrent.Semaphore;
-import java.util.regex.Pattern;
 
-import static com.microsoft.playwright.Page.EventType.REQUESTFINISHED;
-import static com.microsoft.playwright.Page.EventType.RESPONSE;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class TestNetworkResponse extends TestBase {
@@ -102,8 +98,8 @@ public class TestNetworkResponse extends TestBase {
     });
     // Setup page to trap response.
     boolean[] requestFinished = {false};
-    page.addListener(REQUESTFINISHED, event -> {
-      requestFinished[0] |= ((Request) event.data()).url().contains("/get");
+    page.onRequestFinished(request -> {
+      requestFinished[0] |= request.url().contains("/get");
     });
     // send request and wait for server response
     Response pageResponse = page.waitForResponse(() -> page.evaluate("() => fetch('./get', { method: 'GET'})"));

--- a/playwright/src/test/java/com/microsoft/playwright/TestPageBasic.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestPageBasic.java
@@ -25,7 +25,6 @@ import java.util.List;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import static com.microsoft.playwright.Page.EventType.*;
 import static com.microsoft.playwright.Page.LoadState.DOMCONTENTLOADED;
 import static com.microsoft.playwright.Page.LoadState.LOAD;
 import static org.junit.jupiter.api.Assertions.*;
@@ -91,7 +90,7 @@ public class TestPageBasic extends TestBase {
     // fire.
     newPage.click("body");
     boolean[] didShowDialog = {false};
-    newPage.addListener(DIALOG, event -> didShowDialog[0] = true);
+    newPage.onDialog(dialog -> didShowDialog[0] = true);
     newPage.close();
     assertFalse(didShowDialog[0]);
   }
@@ -265,7 +264,7 @@ public class TestPageBasic extends TestBase {
   void pagePressShouldWorkForEnter() {
     page.setContent("<input onkeypress='console.log(\"press\")'></input>");
     List<ConsoleMessage> messages = new ArrayList<>();
-    page.addListener(CONSOLE, event ->  messages.add((ConsoleMessage) event.data()));
+    page.onConsole(message ->  messages.add(message));
     page.press("input", "Enter");
     assertEquals("press", messages.get(0).text());
   }

--- a/playwright/src/test/java/com/microsoft/playwright/TestPageEmulateMedia.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestPageEmulateMedia.java
@@ -23,7 +23,6 @@ import java.util.function.Supplier;
 import static com.microsoft.playwright.ColorScheme.DARK;
 import static com.microsoft.playwright.ColorScheme.LIGHT;
 import static com.microsoft.playwright.Page.EmulateMediaParams.Media.PRINT;
-import static com.microsoft.playwright.Page.EventType.POPUP;
 import static com.microsoft.playwright.Utils.attachFrame;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 

--- a/playwright/src/test/java/com/microsoft/playwright/TestPageEvaluate.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestPageEvaluate.java
@@ -18,11 +18,9 @@ package com.microsoft.playwright;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIf;
-import org.junit.jupiter.api.condition.EnabledIf;
 
 import java.util.Map;
 
-import static com.microsoft.playwright.Page.EventType.FRAMENAVIGATED;
 import static com.microsoft.playwright.Utils.mapOf;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyMap;
@@ -174,8 +172,7 @@ public class TestPageEvaluate extends TestBase {
   @Test
   void shouldWorkRightAfterFramenavigated() {
     Object[] frameEvaluation = {null};
-    page.addListener(FRAMENAVIGATED, event -> {
-      Frame frame = (Frame) event.data();
+    page.onFrameNavigated(frame -> {
       frameEvaluation[0] = frame.evaluate("() => 6 * 7");
     });
     page.navigate(server.EMPTY_PAGE);
@@ -186,8 +183,7 @@ public class TestPageEvaluate extends TestBase {
   void shouldWorkRightAfterACrossOriginNavigation() {
     page.navigate(server.EMPTY_PAGE);
     Object[] frameEvaluation = {null};
-    page.addListener(FRAMENAVIGATED, event -> {
-      Frame frame = (Frame) event.data();
+    page.onFrameNavigated(frame -> {
       frameEvaluation[0] = frame.evaluate("() => 6 * 7");
     });
     page.navigate(server.CROSS_PROCESS_PREFIX + "/empty.html");

--- a/playwright/src/test/java/com/microsoft/playwright/TestPageSelectOption.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestPageSelectOption.java
@@ -18,7 +18,6 @@ package com.microsoft.playwright;
 
 import org.junit.jupiter.api.Test;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 

--- a/playwright/src/test/java/com/microsoft/playwright/TestPageWaitForNavigation.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestPageWaitForNavigation.java
@@ -20,12 +20,10 @@ import org.junit.jupiter.api.Test;
 
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.Arrays;
 import java.util.List;
 import java.util.regex.Pattern;
 
-import static com.microsoft.playwright.Page.EventType.FRAMENAVIGATED;
-import static com.microsoft.playwright.Utils.*;
+import static com.microsoft.playwright.Utils.expectedSSLError;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class TestPageWaitForNavigation extends TestBase {
@@ -135,10 +133,9 @@ public class TestPageWaitForNavigation extends TestBase {
   void shouldWorkWhenSubframeIssuesWindowStop() {
     server.setRoute("/frames/style.css", exchange -> {});
     boolean[] frameWindowStopCalled = {false};
-    page.addListener(Page.EventType.FRAMEATTACHED, event -> {
-      Frame frame = (Frame) event.data();
-      page.addListener(FRAMENAVIGATED, event1 -> {
-        if (frame.equals(event1.data())) {
+    page.onFrameAttached(frame -> {
+      page.onFrameNavigated(frame1 -> {
+        if (frame.equals(frame1)) {
           frame.evaluate("window.stop()");
           frameWindowStopCalled[0] = true;
         }

--- a/playwright/src/test/java/com/microsoft/playwright/TestPageWaitForRequest.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestPageWaitForRequest.java
@@ -20,7 +20,6 @@ import org.junit.jupiter.api.Test;
 
 import java.util.regex.Pattern;
 
-import static com.microsoft.playwright.Page.EventType.REQUEST;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class TestPageWaitForRequest extends TestBase {

--- a/playwright/src/test/java/com/microsoft/playwright/TestPageWaitForResponse.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestPageWaitForResponse.java
@@ -18,8 +18,6 @@ package com.microsoft.playwright;
 
 import org.junit.jupiter.api.Test;
 
-import static com.microsoft.playwright.Page.EventType.REQUEST;
-import static com.microsoft.playwright.Page.EventType.RESPONSE;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class TestPageWaitForResponse extends TestBase {

--- a/playwright/src/test/java/com/microsoft/playwright/TestPdf.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestPdf.java
@@ -21,7 +21,6 @@ import org.junit.jupiter.api.condition.DisabledIf;
 import org.junit.jupiter.api.condition.EnabledIf;
 import org.junit.jupiter.api.io.TempDir;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;

--- a/playwright/src/test/java/com/microsoft/playwright/TestPopup.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestPopup.java
@@ -24,7 +24,6 @@ import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
-import static com.microsoft.playwright.Page.EventType.POPUP;
 import static com.microsoft.playwright.Page.LoadState.DOMCONTENTLOADED;
 import static com.microsoft.playwright.Utils.mapOf;
 import static org.junit.jupiter.api.Assertions.*;

--- a/playwright/src/test/java/com/microsoft/playwright/TestRequestContinue.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestRequestContinue.java
@@ -24,7 +24,6 @@ import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
-import static com.microsoft.playwright.Page.EventType.RESPONSE;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/playwright/src/test/java/com/microsoft/playwright/TestRequestFulfill.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestRequestFulfill.java
@@ -19,7 +19,6 @@ package com.microsoft.playwright;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIf;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;

--- a/playwright/src/test/java/com/microsoft/playwright/TestSelectorsRegister.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestSelectorsRegister.java
@@ -16,7 +16,6 @@
 
 package com.microsoft.playwright;
 
-import com.microsoft.playwright.impl.ElementHandleImpl;
 import org.junit.jupiter.api.Test;
 
 import java.nio.file.Paths;

--- a/playwright/src/test/java/com/microsoft/playwright/TestTap.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestTap.java
@@ -23,7 +23,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.Semaphore;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import static com.microsoft.playwright.Utils.mapOf;
 import static java.util.Arrays.asList;

--- a/playwright/src/test/java/com/microsoft/playwright/TestWaitForFunction.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestWaitForFunction.java
@@ -23,7 +23,6 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.microsoft.playwright.Page.EventType.CONSOLE;
 import static com.microsoft.playwright.Utils.mapOf;
 import static java.util.Arrays.asList;
 import static org.junit.jupiter.api.Assertions.*;
@@ -73,7 +72,7 @@ public class TestWaitForFunction extends TestBase {
   @Test
   void shouldAvoidSideEffectsAfterTimeout() {
     int[] counter = { 0 };
-    page.addListener(CONSOLE, event -> ++counter[0]);
+    page.onConsole(message -> ++counter[0]);
 
     try {
       JSHandle result = page.waitForFunction("() => {\n" +
@@ -239,8 +238,7 @@ public class TestWaitForFunction extends TestBase {
     void shouldNotBeCalledAfterFinishingSuccessfully() {
       page.navigate(server.EMPTY_PAGE);
       List<String> messages = new ArrayList<>();
-      page.addListener(CONSOLE, event -> {
-        ConsoleMessage msg = (ConsoleMessage) event.data();
+      page.onConsole(msg -> {
         if (msg.text().startsWith("waitForFunction")) {
           messages.add(msg.text());
         }
@@ -266,10 +264,10 @@ public class TestWaitForFunction extends TestBase {
   void shouldNotBeCalledAfterFinishingUnsuccessfully() {
     page.navigate(server.EMPTY_PAGE);
     List<String> messages = new ArrayList<>();
-    page.addListener(CONSOLE, event -> {
-      ConsoleMessage msg = (ConsoleMessage) event.data();
-      if (msg.text().startsWith("waitForFunction"))
+    page.onConsole(msg -> {
+      if (msg.text().startsWith("waitForFunction")) {
         messages.add(msg.text());
+      }
     });
     try {
       page.waitForFunction("() => {\n" +

--- a/playwright/src/test/java/com/microsoft/playwright/TestWorkers.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestWorkers.java
@@ -20,7 +20,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIf;
 import org.junit.jupiter.api.condition.EnabledIf;
 
-import static com.microsoft.playwright.Page.EventType.*;
 import static com.microsoft.playwright.Utils.attachFrame;
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -110,7 +109,7 @@ public class TestWorkers extends TestBase {
       "() => new Worker(URL.createObjectURL(new Blob(['console.log(1)'], {type: 'application/javascript'})))"));
     assertEquals(1, page.workers().size());
     boolean[] destroyed = {false};
-    worker.addListener(Worker.EventType.CLOSE, event -> destroyed[0] = true);
+    worker.onClose(worker1 -> destroyed[0] = true);
     page.navigate(server.CROSS_PROCESS_PREFIX + "/empty.html");
     assertTrue(destroyed[0]);
     assertEquals(0, page.workers().size());

--- a/playwright/src/test/java/com/microsoft/playwright/Utils.java
+++ b/playwright/src/test/java/com/microsoft/playwright/Utils.java
@@ -23,7 +23,6 @@ import com.google.gson.JsonParser;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.lang.reflect.Array;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;

--- a/tools/api-generator/src/main/java/com/microsoft/playwright/tools/ApiGenerator.java
+++ b/tools/api-generator/src/main/java/com/microsoft/playwright/tools/ApiGenerator.java
@@ -1075,16 +1075,6 @@ class Interface extends TypeDefinition {
     if (events.isEmpty()) {
       return;
     }
-    output.add(offset + "enum EventType {");
-    for (int i = 0; i < events.size(); i++) {
-      String comma = i == events.size() ? "" : ",";
-      output.add(offset + "  " + events.get(i).jsonName.toUpperCase() + comma);
-    }
-    output.add(offset + "}");
-    output.add("");
-    output.add(offset + "void addListener(EventType type, Listener<EventType> listener);");
-    output.add(offset + "void removeListener(EventType type, Listener<EventType> listener);");
-
     for (Event e : events) {
       output.add("");
       e.writeListenerMethods(output, offset);


### PR DESCRIPTION
Removed `addListener/removeListener` along with `Listener` interface and `EventType` enums from the public API. Instead of that there are pairs of `onFoo/offFoo` methods for subscribing to corresponding events. For some of them there is already `waitForFoo()` convenience methods. This results in a more concise and type-safe code.