### PR TITLE
fix(api): make Dialog.type() return string

### DIFF
--- a/playwright/src/main/java/com/microsoft/playwright/Dialog.java
+++ b/playwright/src/main/java/com/microsoft/playwright/Dialog.java
@@ -22,8 +22,6 @@ import java.util.*;
  * {@code Dialog} objects are dispatched by page via the [{@code event: Page.dialog}] event.
  */
 public interface Dialog {
-  enum Type { ALERT, BEFOREUNLOAD, CONFIRM, PROMPT }
-
   default void accept() {
     accept(null);
   }
@@ -48,6 +46,6 @@ public interface Dialog {
   /**
    * Returns dialog's type, can be one of {@code alert}, {@code beforeunload}, {@code confirm} or {@code prompt}.
    */
-  Type type();
+  String type();
 }
 

--- a/playwright/src/main/java/com/microsoft/playwright/impl/DialogImpl.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/DialogImpl.java
@@ -52,13 +52,7 @@ class DialogImpl extends ChannelOwner implements Dialog {
   }
 
   @Override
-  public Type type() {
-    switch (initializer.get("type").getAsString()) {
-      case "alert": return Type.ALERT;
-      case "beforeunload": return Type.BEFOREUNLOAD;
-      case "confirm": return Type.CONFIRM;
-      case "prompt": return Type.PROMPT;
-      default: throw new PlaywrightException("Unexpected dialog type: " + initializer.get("type").getAsString());
-    }
+  public String type() {
+    return initializer.get("type").getAsString();
   }
 }

--- a/playwright/src/test/java/com/microsoft/playwright/TestPageBasic.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestPageBasic.java
@@ -61,7 +61,7 @@ public class TestPageBasic extends TestBase {
     boolean[] didShowDialog = {false};
     newPage.onDialog(dialog -> {
       didShowDialog[0] = true;
-      assertEquals(Dialog.Type.BEFOREUNLOAD, dialog.type());
+      assertEquals("beforeunload", dialog.type());
       assertEquals("", dialog.defaultValue());
       if (isChromium()) {
         assertEquals("", dialog.message());

--- a/tools/api-generator/src/main/java/com/microsoft/playwright/tools/ApiGenerator.java
+++ b/tools/api-generator/src/main/java/com/microsoft/playwright/tools/ApiGenerator.java
@@ -1112,11 +1112,6 @@ class Interface extends TypeDefinition {
 
   private void writeSharedTypes(List<String> output, String offset) {
     switch (jsonName) {
-      case "Dialog": {
-        output.add(offset + "enum Type { ALERT, BEFOREUNLOAD, CONFIRM, PROMPT }");
-        output.add("");
-        break;
-      }
       case "Mouse": {
         output.add(offset + "enum Button { LEFT, MIDDLE, RIGHT }");
         output.add("");

--- a/tools/api-generator/src/main/java/com/microsoft/playwright/tools/Types.java
+++ b/tools/api-generator/src/main/java/com/microsoft/playwright/tools/Types.java
@@ -152,7 +152,6 @@ class Types {
     add("WebSocket.waitForEvent.optionsOrPredicate", "Function|Object", "String");
 
     // Return structures
-    add("Dialog.type", "string", "Type", new Empty());
     add("ConsoleMessage.location", "Object", "Location");
     add("ElementHandle.boundingBox", "Object|null", "BoundingBox", new Empty());
     add("Accessibility.snapshot", "Object|null", "AccessibilityNode", new Empty());


### PR DESCRIPTION
Unifying this with upstream. String allows to add new dialog types in the future should they emerge.