### PR TITLE
fix: avoid NPE when saving storage state

### DIFF
--- a/playwright/src/main/java/com/microsoft/playwright/impl/BrowserContextImpl.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/BrowserContextImpl.java
@@ -21,9 +21,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.microsoft.playwright.*;
 
-import java.io.FileWriter;
-import java.io.IOException;
-import java.nio.file.Files;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.*;
 import java.util.function.Consumer;
@@ -320,14 +318,7 @@ class BrowserContextImpl extends ChannelOwner implements BrowserContext {
       JsonElement json = sendMessage("storageState");
       StorageState storageState = gson().fromJson(json, StorageState.class);
       if (options != null && options.path != null) {
-        try {
-          Files.createDirectories(options.path.getParent());
-          try (FileWriter writer = new FileWriter(options.path.toFile())) {
-            writer.write(json.toString());
-          }
-        } catch (IOException e) {
-          throw new PlaywrightException("Failed to write storage state to file", e);
-        }
+        Utils.writeToFile(json.toString().getBytes(StandardCharsets.UTF_8), options.path);
       }
       return storageState;
     });

--- a/playwright/src/test/java/com/microsoft/playwright/TestBrowserContextStorageState.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestBrowserContextStorageState.java
@@ -21,8 +21,10 @@ import com.google.gson.JsonObject;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
-import java.io.FileReader;
+import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.Arrays;
 
@@ -112,7 +114,7 @@ public class TestBrowserContextStorageState extends TestBase {
       "        }]\n" +
       "    }]\n" +
       "}\n", JsonObject.class);
-    try (FileReader reader = new FileReader(path.toFile())) {
+    try (InputStreamReader reader = new InputStreamReader(new FileInputStream(path.toFile()), StandardCharsets.UTF_8)) {
       assertEquals(expected, new Gson().fromJson(reader, JsonObject.class));
     }
     BrowserContext context2 = browser.newContext(new Browser.NewContextOptions().withStorageState(path));


### PR DESCRIPTION
When the path chosen to write the storage state is a relative path to the current directory (such as `Paths.get("state.json")`), the code tried to create directories for the parent path, which is null, thus causing a NullPointerException.
Moreover, the code also used a FileWriter, which uses the platform default encoding, which might not be valid for JSON, and which might not be able to encode some of the characters. The encoding is now set explicitly to UTF-8.