### PR TITLE
fix: add snapshot repo to the examples project

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -31,4 +31,12 @@
       </plugin>
     </plugins>
   </build>
+  <repositories>
+    <repository>
+      <id>snapshots-repo</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+      <releases><enabled>false</enabled></releases>
+      <snapshots><enabled>true</enabled></snapshots>
+    </repository>
+  </repositories>
 </project>


### PR DESCRIPTION
Without this config maven fails to download `0.190.0-SNAPSHOT` version of Playwright.