### PR TITLE
tests: stop using waitFor* methods which will be removed

### DIFF
--- a/playwright/src/test/java/com/microsoft/playwright/TestPageEventNetwork.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestPageEventNetwork.java
@@ -78,13 +78,12 @@ public class TestPageEventNetwork extends TestBase {
 
   @Test
   void PageEventsRequestFinished() {
-    Response[] response = {null};
-    Request finishedRequest = page.waitForRequestFinished(() -> {
-      response[0] = page.navigate(server.EMPTY_PAGE);
-    });
-    assertNotNull(response[0]);
-    Request request = response[0].request();
-    assertEquals(request, finishedRequest);
+    Request[] requestRef = {null};
+    page.onRequestFinished(r -> requestRef[0] = r);
+    Response response = page.navigate(server.EMPTY_PAGE);
+    assertNotNull(response);
+    Request request = requestRef[0];
+    assertEquals(response.request(), request);
     assertEquals(server.EMPTY_PAGE, request.url());
     assertNotNull(request.response());
     assertEquals(page.mainFrame(), request.frame());

--- a/playwright/src/test/java/com/microsoft/playwright/TestPageEventNetwork.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestPageEventNetwork.java
@@ -81,6 +81,7 @@ public class TestPageEventNetwork extends TestBase {
     Request[] requestRef = {null};
     page.onRequestFinished(r -> requestRef[0] = r);
     Response response = page.navigate(server.EMPTY_PAGE);
+    assertNull(response.finished());
     assertNotNull(response);
     Request request = requestRef[0];
     assertEquals(response.request(), request);

--- a/playwright/src/test/java/com/microsoft/playwright/TestPageRoute.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestPageRoute.java
@@ -211,19 +211,20 @@ public class TestPageRoute extends TestBase {
   @Test
   void shouldBeAbortableWithCustomErrorCodes() {
     page.route("**/*", route -> route.abort("internetdisconnected"));
-    Request failedRequest = page.waitForRequestFailed(() -> {
-      try {
-        page.navigate(server.EMPTY_PAGE);
-      } catch (PlaywrightException e) {
-      }
-    });
-    assertNotNull(failedRequest);
-    if (isWebKit())
-      assertEquals("Request intercepted", failedRequest.failure());
-    else if (isFirefox())
-      assertEquals("NS_ERROR_OFFLINE", failedRequest.failure());
-    else
-      assertEquals("net::ERR_INTERNET_DISCONNECTED", failedRequest.failure());
+    Request[] failedRequest = {null};
+    page.onRequestFailed(r -> failedRequest[0] = r);
+    try {
+      page.navigate(server.EMPTY_PAGE);
+    } catch (PlaywrightException e) {
+    }
+    assertNotNull(failedRequest[0]);
+    if (isWebKit()) {
+      assertEquals("Request intercepted", failedRequest[0].failure());
+    } else if (isFirefox()) {
+      assertEquals("NS_ERROR_OFFLINE", failedRequest[0].failure());
+    } else {
+      assertEquals("net::ERR_INTERNET_DISCONNECTED", failedRequest[0].failure());
+    }
   }
 
   @Test


### PR DESCRIPTION
Removing some of the methods as per discussion in https://github.com/microsoft/playwright/pull/5315 We'll add them back in the future if need be.