### PR TITLE
chore: move enums and second level nested classes into options package

### DIFF
--- a/playwright/src/main/java/com/microsoft/playwright/Browser.java
+++ b/playwright/src/main/java/com/microsoft/playwright/Browser.java
@@ -16,6 +16,7 @@
 
 package com.microsoft.playwright;
 
+import com.microsoft.playwright.options.*;
 import java.nio.file.Path;
 import java.util.*;
 import java.util.function.Consumer;

--- a/playwright/src/main/java/com/microsoft/playwright/BrowserContext.java
+++ b/playwright/src/main/java/com/microsoft/playwright/BrowserContext.java
@@ -16,6 +16,7 @@
 
 package com.microsoft.playwright;
 
+import com.microsoft.playwright.options.*;
 import java.nio.file.Path;
 import java.util.*;
 import java.util.function.Consumer;

--- a/playwright/src/main/java/com/microsoft/playwright/BrowserType.java
+++ b/playwright/src/main/java/com/microsoft/playwright/BrowserType.java
@@ -16,6 +16,7 @@
 
 package com.microsoft.playwright;
 
+import com.microsoft.playwright.options.*;
 import java.nio.file.Path;
 import java.util.*;
 

--- a/playwright/src/main/java/com/microsoft/playwright/ElementHandle.java
+++ b/playwright/src/main/java/com/microsoft/playwright/ElementHandle.java
@@ -16,6 +16,7 @@
 
 package com.microsoft.playwright;
 
+import com.microsoft.playwright.options.*;
 import java.nio.file.Path;
 import java.util.*;
 

--- a/playwright/src/main/java/com/microsoft/playwright/Frame.java
+++ b/playwright/src/main/java/com/microsoft/playwright/Frame.java
@@ -16,6 +16,7 @@
 
 package com.microsoft.playwright;
 
+import com.microsoft.playwright.options.*;
 import java.nio.file.Path;
 import java.util.*;
 import java.util.function.Predicate;

--- a/playwright/src/main/java/com/microsoft/playwright/Keyboard.java
+++ b/playwright/src/main/java/com/microsoft/playwright/Keyboard.java
@@ -16,6 +16,7 @@
 
 package com.microsoft.playwright;
 
+import com.microsoft.playwright.options.*;
 import java.util.*;
 
 /**

--- a/playwright/src/main/java/com/microsoft/playwright/Mouse.java
+++ b/playwright/src/main/java/com/microsoft/playwright/Mouse.java
@@ -16,6 +16,7 @@
 
 package com.microsoft.playwright;
 
+import com.microsoft.playwright.options.*;
 import java.util.*;
 
 /**

--- a/playwright/src/main/java/com/microsoft/playwright/Page.java
+++ b/playwright/src/main/java/com/microsoft/playwright/Page.java
@@ -16,6 +16,7 @@
 
 package com.microsoft.playwright;
 
+import com.microsoft.playwright.options.*;
 import java.nio.file.Path;
 import java.util.*;
 import java.util.function.Consumer;

--- a/playwright/src/main/java/com/microsoft/playwright/impl/BrowserContextImpl.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/BrowserContextImpl.java
@@ -20,6 +20,7 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.microsoft.playwright.*;
+import com.microsoft.playwright.options.*;
 
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;

--- a/playwright/src/main/java/com/microsoft/playwright/impl/ElementHandleImpl.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/ElementHandleImpl.java
@@ -20,7 +20,7 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.microsoft.playwright.ElementHandle;
-import com.microsoft.playwright.ElementState;
+import com.microsoft.playwright.options.ElementState;
 import com.microsoft.playwright.FileChooser;
 import com.microsoft.playwright.Frame;
 
@@ -29,8 +29,8 @@ import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
 
-import static com.microsoft.playwright.ScreenshotType.JPEG;
-import static com.microsoft.playwright.ScreenshotType.PNG;
+import static com.microsoft.playwright.options.ScreenshotType.JPEG;
+import static com.microsoft.playwright.options.ScreenshotType.PNG;
 import static com.microsoft.playwright.impl.Serialization.*;
 
 public class ElementHandleImpl extends JSHandleImpl implements ElementHandle {

--- a/playwright/src/main/java/com/microsoft/playwright/impl/FrameImpl.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/FrameImpl.java
@@ -20,6 +20,7 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.microsoft.playwright.*;
+import com.microsoft.playwright.options.*;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -28,7 +29,7 @@ import java.nio.file.Path;
 import java.util.*;
 import java.util.function.Consumer;
 
-import static com.microsoft.playwright.LoadState.*;
+import static com.microsoft.playwright.options.LoadState.*;
 import static com.microsoft.playwright.impl.Serialization.*;
 import static com.microsoft.playwright.impl.Utils.convertViaJson;
 import static com.microsoft.playwright.impl.Utils.isFunctionBody;

--- a/playwright/src/main/java/com/microsoft/playwright/impl/PageImpl.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/PageImpl.java
@@ -19,6 +19,7 @@ package com.microsoft.playwright.impl;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.microsoft.playwright.*;
+import com.microsoft.playwright.options.*;
 
 import java.nio.file.Path;
 import java.util.*;
@@ -26,8 +27,8 @@ import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
-import static com.microsoft.playwright.ScreenshotType.JPEG;
-import static com.microsoft.playwright.ScreenshotType.PNG;
+import static com.microsoft.playwright.options.ScreenshotType.JPEG;
+import static com.microsoft.playwright.options.ScreenshotType.PNG;
 import static com.microsoft.playwright.impl.Serialization.gson;
 import static com.microsoft.playwright.impl.Utils.convertViaJson;
 import static com.microsoft.playwright.impl.Utils.isSafeCloseError;

--- a/playwright/src/main/java/com/microsoft/playwright/impl/Serialization.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/Serialization.java
@@ -20,6 +20,7 @@ import com.google.gson.*;
 import com.google.gson.reflect.TypeToken;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
+import com.microsoft.playwright.options.*;
 import com.microsoft.playwright.*;
 
 import java.io.ByteArrayOutputStream;

--- a/playwright/src/main/java/com/microsoft/playwright/options/ColorScheme.java
+++ b/playwright/src/main/java/com/microsoft/playwright/options/ColorScheme.java
@@ -14,13 +14,10 @@
  * limitations under the License.
  */
 
-package com.microsoft.playwright;
+package com.microsoft.playwright.options;
 
-public enum ElementState {
-  VISIBLE,
-  HIDDEN,
-  STABLE,
-  ENABLED,
-  DISABLED,
-  EDITABLE
+public enum ColorScheme {
+  LIGHT,
+  DARK,
+  NO_PREFERENCE
 }

--- a/playwright/src/main/java/com/microsoft/playwright/options/ElementState.java
+++ b/playwright/src/main/java/com/microsoft/playwright/options/ElementState.java
@@ -14,11 +14,13 @@
  * limitations under the License.
  */
 
-package com.microsoft.playwright;
+package com.microsoft.playwright.options;
 
-public enum WaitForSelectorState {
-  ATTACHED,
-  DETACHED,
+public enum ElementState {
   VISIBLE,
-  HIDDEN
+  HIDDEN,
+  STABLE,
+  ENABLED,
+  DISABLED,
+  EDITABLE
 }

--- a/playwright/src/main/java/com/microsoft/playwright/options/Geolocation.java
+++ b/playwright/src/main/java/com/microsoft/playwright/options/Geolocation.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.microsoft.playwright;
+package com.microsoft.playwright.options;
 
 public class Geolocation {
   public double latitude;

--- a/playwright/src/main/java/com/microsoft/playwright/options/KeyboardModifier.java
+++ b/playwright/src/main/java/com/microsoft/playwright/options/KeyboardModifier.java
@@ -14,9 +14,11 @@
  * limitations under the License.
  */
 
-package com.microsoft.playwright;
+package com.microsoft.playwright.options;
 
-public enum ScreenshotType {
-  PNG,
-  JPEG
+public enum KeyboardModifier {
+  ALT,
+  CONTROL,
+  META,
+  SHIFT
 }

--- a/playwright/src/main/java/com/microsoft/playwright/options/LoadState.java
+++ b/playwright/src/main/java/com/microsoft/playwright/options/LoadState.java
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-package com.microsoft.playwright;
+package com.microsoft.playwright.options;
 
-public enum SameSiteAttribute {
-  STRICT,
-  LAX,
-  NONE
+public enum LoadState {
+  LOAD,
+  DOMCONTENTLOADED,
+  NETWORKIDLE
 }

--- a/playwright/src/main/java/com/microsoft/playwright/options/Media.java
+++ b/playwright/src/main/java/com/microsoft/playwright/options/Media.java
@@ -14,26 +14,9 @@
  * limitations under the License.
  */
 
-package com.microsoft.playwright;
+package com.microsoft.playwright.options;
 
-public class Position {
-  public int x;
-  public int y;
-
-  public Position() {
-  }
-
-  public Position(int x, int y) {
-    this.x = x;
-    this.y = y;
-  }
-
-  public Position withX(int x) {
-    this.x = x;
-    return this;
-  }
-  public Position withY(int y) {
-    this.y = y;
-    return this;
-  }
+public enum Media {
+  SCREEN,
+  PRINT
 }

--- a/playwright/src/main/java/com/microsoft/playwright/options/MouseButton.java
+++ b/playwright/src/main/java/com/microsoft/playwright/options/MouseButton.java
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-package com.microsoft.playwright;
+package com.microsoft.playwright.options;
 
-public enum WaitUntilState {
-  LOAD,
-  DOMCONTENTLOADED,
-  NETWORKIDLE
+public enum MouseButton {
+  LEFT,
+  RIGHT,
+  MIDDLE
 }

--- a/playwright/src/main/java/com/microsoft/playwright/options/Position.java
+++ b/playwright/src/main/java/com/microsoft/playwright/options/Position.java
@@ -14,10 +14,26 @@
  * limitations under the License.
  */
 
-package com.microsoft.playwright;
+package com.microsoft.playwright.options;
 
-public enum LoadState {
-  LOAD,
-  DOMCONTENTLOADED,
-  NETWORKIDLE
+public class Position {
+  public int x;
+  public int y;
+
+  public Position() {
+  }
+
+  public Position(int x, int y) {
+    this.x = x;
+    this.y = y;
+  }
+
+  public Position withX(int x) {
+    this.x = x;
+    return this;
+  }
+  public Position withY(int y) {
+    this.y = y;
+    return this;
+  }
 }

--- a/playwright/src/main/java/com/microsoft/playwright/options/SameSiteAttribute.java
+++ b/playwright/src/main/java/com/microsoft/playwright/options/SameSiteAttribute.java
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
-package com.microsoft.playwright;
+package com.microsoft.playwright.options;
 
-public enum Media {
-  SCREEN,
-  PRINT
+public enum SameSiteAttribute {
+  STRICT,
+  LAX,
+  NONE
 }

--- a/playwright/src/main/java/com/microsoft/playwright/options/ScreenshotType.java
+++ b/playwright/src/main/java/com/microsoft/playwright/options/ScreenshotType.java
@@ -14,10 +14,9 @@
  * limitations under the License.
  */
 
-package com.microsoft.playwright;
+package com.microsoft.playwright.options;
 
-public enum ColorScheme {
-  LIGHT,
-  DARK,
-  NO_PREFERENCE
+public enum ScreenshotType {
+  PNG,
+  JPEG
 }

--- a/playwright/src/main/java/com/microsoft/playwright/options/WaitForSelectorState.java
+++ b/playwright/src/main/java/com/microsoft/playwright/options/WaitForSelectorState.java
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-package com.microsoft.playwright;
+package com.microsoft.playwright.options;
 
-public enum KeyboardModifier {
-  ALT,
-  CONTROL,
-  META,
-  SHIFT
+public enum WaitForSelectorState {
+  ATTACHED,
+  DETACHED,
+  VISIBLE,
+  HIDDEN
 }

--- a/playwright/src/main/java/com/microsoft/playwright/options/WaitUntilState.java
+++ b/playwright/src/main/java/com/microsoft/playwright/options/WaitUntilState.java
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-package com.microsoft.playwright;
+package com.microsoft.playwright.options;
 
-public enum MouseButton {
-  LEFT,
-  RIGHT,
-  MIDDLE
+public enum WaitUntilState {
+  LOAD,
+  DOMCONTENTLOADED,
+  NETWORKIDLE
 }

--- a/playwright/src/test/java/com/microsoft/playwright/TestBrowserContextCookies.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestBrowserContextCookies.java
@@ -16,6 +16,7 @@
 
 package com.microsoft.playwright;
 
+import com.microsoft.playwright.options.SameSiteAttribute;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIf;
 

--- a/playwright/src/test/java/com/microsoft/playwright/TestClick.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestClick.java
@@ -23,8 +23,8 @@ import org.junit.jupiter.api.condition.EnabledIf;
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.microsoft.playwright.KeyboardModifier.SHIFT;
-import static com.microsoft.playwright.MouseButton.RIGHT;
+import static com.microsoft.playwright.options.KeyboardModifier.SHIFT;
+import static com.microsoft.playwright.options.MouseButton.RIGHT;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static org.junit.jupiter.api.Assertions.*;

--- a/playwright/src/test/java/com/microsoft/playwright/TestDefaultBrowserContext2.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestDefaultBrowserContext2.java
@@ -1,5 +1,6 @@
 package com.microsoft.playwright;
 
+import com.microsoft.playwright.options.Geolocation;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIf;
@@ -12,7 +13,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.stream.Collectors;
 
-import static com.microsoft.playwright.ColorScheme.DARK;
+import static com.microsoft.playwright.options.ColorScheme.DARK;
 import static com.microsoft.playwright.Utils.mapOf;
 import static java.util.Arrays.asList;
 import static org.junit.jupiter.api.Assertions.*;

--- a/playwright/src/test/java/com/microsoft/playwright/TestDownload.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestDownload.java
@@ -31,7 +31,7 @@ import java.nio.file.Paths;
 import java.time.Duration;
 import java.time.Instant;
 
-import static com.microsoft.playwright.KeyboardModifier.ALT;
+import static com.microsoft.playwright.options.KeyboardModifier.ALT;
 import static com.microsoft.playwright.Utils.copy;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.nio.file.Files.readAllBytes;

--- a/playwright/src/test/java/com/microsoft/playwright/TestElementHandleOwnerFrame.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestElementHandleOwnerFrame.java
@@ -18,7 +18,7 @@ package com.microsoft.playwright;
 
 import org.junit.jupiter.api.Test;
 
-import static com.microsoft.playwright.LoadState.DOMCONTENTLOADED;
+import static com.microsoft.playwright.options.LoadState.DOMCONTENTLOADED;
 import static com.microsoft.playwright.Utils.attachFrame;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;

--- a/playwright/src/test/java/com/microsoft/playwright/TestElementHandleQuerySelector.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestElementHandleQuerySelector.java
@@ -6,7 +6,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import static com.microsoft.playwright.LoadState.DOMCONTENTLOADED;
+import static com.microsoft.playwright.options.LoadState.DOMCONTENTLOADED;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class TestElementHandleQuerySelector extends TestBase {

--- a/playwright/src/test/java/com/microsoft/playwright/TestElementHandleWaitForElementState.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestElementHandleWaitForElementState.java
@@ -19,7 +19,7 @@ package com.microsoft.playwright;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIf;
 
-import static com.microsoft.playwright.ElementState.*;
+import static com.microsoft.playwright.options.ElementState.*;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 

--- a/playwright/src/test/java/com/microsoft/playwright/TestFrameNavigate.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestFrameNavigate.java
@@ -18,7 +18,7 @@ package com.microsoft.playwright;
 
 import org.junit.jupiter.api.Test;
 
-import static com.microsoft.playwright.WaitUntilState.NETWORKIDLE;
+import static com.microsoft.playwright.options.WaitUntilState.NETWORKIDLE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 

--- a/playwright/src/test/java/com/microsoft/playwright/TestGeolocation.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestGeolocation.java
@@ -16,6 +16,7 @@
 
 package com.microsoft.playwright;
 
+import com.microsoft.playwright.options.Geolocation;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;

--- a/playwright/src/test/java/com/microsoft/playwright/TestHar.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestHar.java
@@ -29,7 +29,7 @@ import java.io.Reader;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-import static com.microsoft.playwright.LoadState.DOMCONTENTLOADED;
+import static com.microsoft.playwright.options.LoadState.DOMCONTENTLOADED;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class TestHar extends TestBase {

--- a/playwright/src/test/java/com/microsoft/playwright/TestPageBasic.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestPageBasic.java
@@ -25,8 +25,8 @@ import java.util.List;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import static com.microsoft.playwright.LoadState.DOMCONTENTLOADED;
-import static com.microsoft.playwright.LoadState.LOAD;
+import static com.microsoft.playwright.options.LoadState.DOMCONTENTLOADED;
+import static com.microsoft.playwright.options.LoadState.LOAD;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class TestPageBasic extends TestBase {

--- a/playwright/src/test/java/com/microsoft/playwright/TestPageEmulateMedia.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestPageEmulateMedia.java
@@ -20,9 +20,9 @@ import org.junit.jupiter.api.Test;
 
 import java.util.function.Supplier;
 
-import static com.microsoft.playwright.ColorScheme.DARK;
-import static com.microsoft.playwright.ColorScheme.LIGHT;
-import static com.microsoft.playwright.Media.PRINT;
+import static com.microsoft.playwright.options.ColorScheme.DARK;
+import static com.microsoft.playwright.options.ColorScheme.LIGHT;
+import static com.microsoft.playwright.options.Media.PRINT;
 import static com.microsoft.playwright.Utils.attachFrame;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 

--- a/playwright/src/test/java/com/microsoft/playwright/TestPageExposeFunction.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestPageExposeFunction.java
@@ -21,7 +21,7 @@ import org.junit.jupiter.api.Test;
 import java.util.Map;
 
 import static com.microsoft.playwright.Utils.mapOf;
-import static com.microsoft.playwright.WaitUntilState.LOAD;
+import static com.microsoft.playwright.options.WaitUntilState.LOAD;
 import static java.util.Arrays.asList;
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/playwright/src/test/java/com/microsoft/playwright/TestPageWaitForNavigation.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestPageWaitForNavigation.java
@@ -16,6 +16,7 @@
 
 package com.microsoft.playwright;
 
+import com.microsoft.playwright.options.WaitUntilState;
 import org.junit.jupiter.api.Test;
 
 import java.net.MalformedURLException;

--- a/playwright/src/test/java/com/microsoft/playwright/TestPopup.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestPopup.java
@@ -24,7 +24,7 @@ import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
-import static com.microsoft.playwright.LoadState.DOMCONTENTLOADED;
+import static com.microsoft.playwright.options.LoadState.DOMCONTENTLOADED;
 import static com.microsoft.playwright.Utils.mapOf;
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/playwright/src/test/java/com/microsoft/playwright/TestTap.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestTap.java
@@ -24,7 +24,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.Semaphore;
 
-import static com.microsoft.playwright.KeyboardModifier.ALT;
+import static com.microsoft.playwright.options.KeyboardModifier.ALT;
 import static com.microsoft.playwright.Utils.mapOf;
 import static java.util.Arrays.asList;
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/tools/api-generator/src/main/java/com/microsoft/playwright/tools/ApiGenerator.java
+++ b/tools/api-generator/src/main/java/com/microsoft/playwright/tools/ApiGenerator.java
@@ -925,6 +925,9 @@ class Interface extends TypeDefinition {
     if ("Playwright".equals(jsonName)) {
       output.add("import com.microsoft.playwright.impl.PlaywrightImpl;");
     }
+    if (asList("Page", "Frame", "ElementHandle", "Browser", "BrowserContext", "BrowserType", "Mouse", "Keyboard").contains(jsonName)) {
+      output.add("import com.microsoft.playwright.options.*;");
+    }
     if (jsonName.equals("Route")) {
       output.add("import java.nio.charset.StandardCharsets;");
     }
@@ -1265,9 +1268,10 @@ public class ApiGenerator {
         writer.write(text);
       }
     }
+    dir = new File(dir, "options");
     for (Enum e : enums.values()) {
       List<String> lines = new ArrayList<>();
-      lines.add(Interface.header);
+      lines.add(Interface.header.replace("package com.microsoft.playwright;", "package com.microsoft.playwright.options;"));
       e.writeTo(lines);
       String text = String.join("\n", lines);
       try (FileWriter writer = new FileWriter(new File(dir, e.jsonName + ".java"))) {


### PR DESCRIPTION
* All second level option classes (like Geolocation, RecordHar etc.) will reside in `com.microsoft.playwright.options` so that they could be shared between different classes in the API (Page, BrowserContext, Browser etc) without cluttering the main package.