### PR TITLE
docs: add code snippets from upstream

### DIFF
--- a/playwright/src/main/java/com/microsoft/playwright/Accessibility.java
+++ b/playwright/src/main/java/com/microsoft/playwright/Accessibility.java
@@ -57,8 +57,20 @@ public interface Accessibility {
    * Captures the current state of the accessibility tree. The returned object represents the root accessible node of the
    * page.
    *
-   * <p> <strong>NOTE:</strong> The Chromium accessibility tree contains nodes that go unused on most platforms and by most screen readers.
-   * Playwright will discard them as well for an easier to process tree, unless {@code interestingOnly} is set to {@code false}.
+   * <p> <strong>NOTE:</strong> The Chromium accessibility tree contains nodes that go unused on most platforms and by most screen readers. Playwright
+   * will discard them as well for an easier to process tree, unless {@code interestingOnly} is set to {@code false}.
+   *
+   * <p> An example of dumping the entire accessibility tree:
+   * <pre>{@code
+   * String snapshot = page.accessibility().snapshot();
+   * System.out.println(snapshot);
+   * }</pre>
+   *
+   * <p> An example of logging the focused node's name:
+   * <pre>{@code
+   * // FIXME
+   * String snapshot = page.accessibility().snapshot();
+   * }</pre>
    */
   default String snapshot() {
     return snapshot(null);
@@ -67,8 +79,20 @@ public interface Accessibility {
    * Captures the current state of the accessibility tree. The returned object represents the root accessible node of the
    * page.
    *
-   * <p> <strong>NOTE:</strong> The Chromium accessibility tree contains nodes that go unused on most platforms and by most screen readers.
-   * Playwright will discard them as well for an easier to process tree, unless {@code interestingOnly} is set to {@code false}.
+   * <p> <strong>NOTE:</strong> The Chromium accessibility tree contains nodes that go unused on most platforms and by most screen readers. Playwright
+   * will discard them as well for an easier to process tree, unless {@code interestingOnly} is set to {@code false}.
+   *
+   * <p> An example of dumping the entire accessibility tree:
+   * <pre>{@code
+   * String snapshot = page.accessibility().snapshot();
+   * System.out.println(snapshot);
+   * }</pre>
+   *
+   * <p> An example of logging the focused node's name:
+   * <pre>{@code
+   * // FIXME
+   * String snapshot = page.accessibility().snapshot();
+   * }</pre>
    */
   String snapshot(SnapshotOptions options);
 }

--- a/playwright/src/main/java/com/microsoft/playwright/Browser.java
+++ b/playwright/src/main/java/com/microsoft/playwright/Browser.java
@@ -22,9 +22,22 @@ import java.util.*;
 import java.util.function.Consumer;
 
 /**
- * - extends: [EventEmitter]
+ * A Browser is created via [{@code method: BrowserType.launch}]. An example of using a {@code Browser} to create a {@code Page}:
+ * <pre>{@code
+ * import com.microsoft.playwright.*;
  *
- * <p> A Browser is created via [{@code method: BrowserType.launch}]. An example of using a {@code Browser} to create a {@code Page}:
+ * public class Example {
+ *   public static void main(String[] args) {
+ *     try (Playwright playwright = Playwright.create()) {
+ *       BrowserType firefox = playwright.firefox()
+ *       Browser browser = firefox.launch();
+ *       Page page = browser.newPage();
+ *       page.navigate('https://example.com');
+ *       browser.close();
+ *     }
+ *   }
+ * }
+ * }</pre>
  */
 public interface Browser extends AutoCloseable {
 
@@ -481,6 +494,12 @@ public interface Browser extends AutoCloseable {
   void close();
   /**
    * Returns an array of all open browser contexts. In a newly created browser, this will return zero browser contexts.
+   * <pre>{@code
+   * Browser browser = pw.webkit().launch();
+   * System.out.println(browser.contexts().size()); // prints "0"
+   * BrowserContext context = browser.newContext();
+   * System.out.println(browser.contexts().size()); // prints "1"
+   * }</pre>
    */
   List<BrowserContext> contexts();
   /**
@@ -489,12 +508,28 @@ public interface Browser extends AutoCloseable {
   boolean isConnected();
   /**
    * Creates a new browser context. It won't share cookies/cache with other browser contexts.
+   * <pre>{@code
+   * Browser browser = playwright.firefox().launch();  // Or 'chromium' or 'webkit'.
+   * // Create a new incognito browser context.
+   * BrowserContext context = browser.newContext();
+   * // Create a new page in a pristine context.
+   * Page page = context.newPage();
+   * page.navigate('https://example.com');
+   * }</pre>
    */
   default BrowserContext newContext() {
     return newContext(null);
   }
   /**
    * Creates a new browser context. It won't share cookies/cache with other browser contexts.
+   * <pre>{@code
+   * Browser browser = playwright.firefox().launch();  // Or 'chromium' or 'webkit'.
+   * // Create a new incognito browser context.
+   * BrowserContext context = browser.newContext();
+   * // Create a new page in a pristine context.
+   * Page page = context.newPage();
+   * page.navigate('https://example.com');
+   * }</pre>
    */
   BrowserContext newContext(NewContextOptions options);
   /**

--- a/playwright/src/main/java/com/microsoft/playwright/BrowserType.java
+++ b/playwright/src/main/java/com/microsoft/playwright/BrowserType.java
@@ -23,6 +23,22 @@ import java.util.*;
 /**
  * BrowserType provides methods to launch a specific browser instance or connect to an existing one. The following is a
  * typical example of using Playwright to drive automation:
+ * <pre>{@code
+ * import com.microsoft.playwright.*;
+ *
+ * public class Example {
+ *   public static void main(String[] args) {
+ *     try (Playwright playwright = Playwright.create()) {
+ *       BrowserType chromium = playwright.chromium();
+ *       Browser browser = chromium.launch();
+ *       Page page = browser.newPage();
+ *       page.navigate("https://example.com");
+ *       // other actions...
+ *       browser.close();
+ *     }
+ *   }
+ * }
+ * }</pre>
  */
 public interface BrowserType {
   class LaunchOptions {
@@ -502,16 +518,25 @@ public interface BrowserType {
    * Returns the browser instance.
    *
    * <p> You can use {@code ignoreDefaultArgs} to filter out {@code --mute-audio} from default arguments:
+   * <pre>{@code
+   * // Or "firefox" or "webkit".
+   * Browser browser = chromium.launch(new BrowserType.LaunchOptions()
+   *   .withIgnoreDefaultArgs(Arrays.asList("--mute-audio")));
+   * }</pre>
    *
-   * <p> **Chromium-only** Playwright can also be used to control the Google Chrome or Microsoft Edge browsers, but it works
+   * <p> > **Chromium-only** Playwright can also be used to control the Google Chrome or Microsoft Edge browsers, but it works
    * best with the version of Chromium it is bundled with. There is no guarantee it will work with any other version. Use
    * {@code executablePath} option with extreme caution.
-   * >
-   * If Google Chrome (rather than Chromium) is preferred, a
+   *
+   * <p> >
+   *
+   * <p> > If Google Chrome (rather than Chromium) is preferred, a
    * [Chrome Canary](https://www.google.com/chrome/browser/canary.html) or
    * [Dev Channel](https://www.chromium.org/getting-involved/dev-channel) build is suggested.
-   * >
-   * Stock browsers like Google Chrome and Microsoft Edge are suitable for tests that require proprietary media codecs for
+   *
+   * <p> >
+   *
+   * <p> > Stock browsers like Google Chrome and Microsoft Edge are suitable for tests that require proprietary media codecs for
    * video playback. See
    * [this article](https://www.howtogeek.com/202825/what%E2%80%99s-the-difference-between-chromium-and-chrome/) for other
    * differences between Chromium and Chrome.
@@ -525,16 +550,25 @@ public interface BrowserType {
    * Returns the browser instance.
    *
    * <p> You can use {@code ignoreDefaultArgs} to filter out {@code --mute-audio} from default arguments:
+   * <pre>{@code
+   * // Or "firefox" or "webkit".
+   * Browser browser = chromium.launch(new BrowserType.LaunchOptions()
+   *   .withIgnoreDefaultArgs(Arrays.asList("--mute-audio")));
+   * }</pre>
    *
-   * <p> **Chromium-only** Playwright can also be used to control the Google Chrome or Microsoft Edge browsers, but it works
+   * <p> > **Chromium-only** Playwright can also be used to control the Google Chrome or Microsoft Edge browsers, but it works
    * best with the version of Chromium it is bundled with. There is no guarantee it will work with any other version. Use
    * {@code executablePath} option with extreme caution.
-   * >
-   * If Google Chrome (rather than Chromium) is preferred, a
+   *
+   * <p> >
+   *
+   * <p> > If Google Chrome (rather than Chromium) is preferred, a
    * [Chrome Canary](https://www.google.com/chrome/browser/canary.html) or
    * [Dev Channel](https://www.chromium.org/getting-involved/dev-channel) build is suggested.
-   * >
-   * Stock browsers like Google Chrome and Microsoft Edge are suitable for tests that require proprietary media codecs for
+   *
+   * <p> >
+   *
+   * <p> > Stock browsers like Google Chrome and Microsoft Edge are suitable for tests that require proprietary media codecs for
    * video playback. See
    * [this article](https://www.howtogeek.com/202825/what%E2%80%99s-the-difference-between-chromium-and-chrome/) for other
    * differences between Chromium and Chrome.

--- a/playwright/src/main/java/com/microsoft/playwright/Dialog.java
+++ b/playwright/src/main/java/com/microsoft/playwright/Dialog.java
@@ -21,8 +21,29 @@ import java.util.*;
 /**
  * {@code Dialog} objects are dispatched by page via the [{@code event: Page.dialog}] event.
  *
- * <p> <strong>NOTE:</strong> Dialogs are dismissed automatically, unless there is a [{@code event: Page.dialog}] listener. When listener is
- * present, it **must** either [{@code method: Dialog.accept}] or [{@code method: Dialog.dismiss}] the dialog - otherwise the page will
+ * <p> An example of using {@code Dialog} class:
+ * <pre>{@code
+ * import com.microsoft.playwright.*;
+ *
+ * public class Example {
+ *   public static void main(String[] args) {
+ *     try (Playwright playwright = Playwright.create()) {
+ *       BrowserType chromium = playwright.chromium();
+ *       Browser browser = chromium.launch();
+ *       Page page = browser.newPage();
+ *       page.onDialog(dialog -> {
+ *         System.out.println(dialog.message());
+ *         dialog.dismiss();
+ *       });
+ *       page.evaluate("alert('1')");
+ *       browser.close();
+ *     }
+ *   }
+ * }
+ * }</pre>
+ *
+ * <p> <strong>NOTE:</strong> Dialogs are dismissed automatically, unless there is a [{@code event: Page.dialog}] listener. When listener is present, it
+ * **must** either [{@code method: Dialog.accept}] or [{@code method: Dialog.dismiss}] the dialog - otherwise the page will
  * [freeze](https://developer.mozilla.org/en-US/docs/Web/JavaScript/EventLoop#never_blocking) waiting for the dialog, and
  * actions like click will never finish.
  */

--- a/playwright/src/main/java/com/microsoft/playwright/Download.java
+++ b/playwright/src/main/java/com/microsoft/playwright/Download.java
@@ -27,10 +27,24 @@ import java.util.*;
  * files are deleted when the browser closes.
  *
  * <p> Download event is emitted once the download starts. Download path becomes available once download completes:
+ * <pre>{@code
+ * // wait for download to start
+ * Download download  = page.waitForDownload(() -> page.click("a")); 
+ * // wait for download to complete
+ * Path path = download.path();
+ * }</pre>
+ * <pre>{@code
+ * // wait for download to start
+ * Download download = page.waitForDownload(() -> {
+ *   page.click("a");
+ * });
+ * // wait for download to complete
+ * Path path = download.path();
+ * }</pre>
  *
- * <p> <strong>NOTE:</strong> Browser context **must** be created with the {@code acceptDownloads} set to {@code true} when user needs access to the
- * downloaded content. If {@code acceptDownloads} is not set, download events are emitted, but the actual download is not
- * performed and user has no access to the downloaded files.
+ * <p> <strong>NOTE:</strong> Browser context **must** be created with the {@code acceptDownloads} set to {@code true} when user needs access to the downloaded
+ * content. If {@code acceptDownloads} is not set, download events are emitted, but the actual download is not performed and user
+ * has no access to the downloaded files.
  */
 public interface Download {
   /**

--- a/playwright/src/main/java/com/microsoft/playwright/ElementHandle.java
+++ b/playwright/src/main/java/com/microsoft/playwright/ElementHandle.java
@@ -21,10 +21,25 @@ import java.nio.file.Path;
 import java.util.*;
 
 /**
- * - extends: {@code JSHandle}
- *
- * <p> ElementHandle represents an in-page DOM element. ElementHandles can be created with the [{@code method: Page.querySelector}]
+ * ElementHandle represents an in-page DOM element. ElementHandles can be created with the [{@code method: Page.querySelector}]
  * method.
+ * <pre>{@code
+ * import com.microsoft.playwright.*;
+ *
+ * public class Example {
+ *   public static void main(String[] args) {
+ *     try (Playwright playwright = Playwright.create()) {
+ *       BrowserType chromium = playwright.chromium();
+ *       Browser browser = chromium.launch();
+ *       Page page = browser.newPage();
+ *       page.navigate("https://example.com");
+ *       ElementHandle hrefElement = page.querySelector("a");
+ *       hrefElement.click();
+ *       // ...
+ *     }
+ *   }
+ * }
+ * }</pre>
  *
  * <p> ElementHandle prevents DOM element from garbage collection unless the handle is disposed with
  * [{@code method: JSHandle.dispose}]. ElementHandles are auto-disposed when their origin frame gets navigated.
@@ -539,12 +554,14 @@ public interface ElementHandle extends JSHandle {
   class WaitForSelectorOptions {
     /**
      * Defaults to {@code 'visible'}. Can be either:
-     * - {@code 'attached'} - wait for element to be present in DOM.
-     * - {@code 'detached'} - wait for element to not be present in DOM.
-     * - {@code 'visible'} - wait for element to have non-empty bounding box and no {@code visibility:hidden}. Note that element without
-     *   any content or with {@code display:none} has an empty bounding box and is not considered visible.
-     * - {@code 'hidden'} - wait for element to be either detached from DOM, or have an empty bounding box or {@code visibility:hidden}.
-     *   This is opposite to the {@code 'visible'} option.
+     * <ul>
+     * <li> {@code 'attached'} - wait for element to be present in DOM.</li>
+     * <li> {@code 'detached'} - wait for element to not be present in DOM.</li>
+     * <li> {@code 'visible'} - wait for element to have non-empty bounding box and no {@code visibility:hidden}. Note that element without any
+     * content or with {@code display:none} has an empty bounding box and is not considered visible.</li>
+     * <li> {@code 'hidden'} - wait for element to be either detached from DOM, or have an empty bounding box or {@code visibility:hidden}. This
+     * is opposite to the {@code 'visible'} option.</li>
+     * </ul>
      */
     public WaitForSelectorState state;
     /**
@@ -575,17 +592,23 @@ public interface ElementHandle extends JSHandle {
    *
    * <p> Assuming the page is static, it is safe to use bounding box coordinates to perform input. For example, the following
    * snippet should click the center of the element.
+   * <pre>{@code
+   * BoundingBox box = elementHandle.boundingBox();
+   * page.mouse().click(box.x + box.width / 2, box.y + box.height / 2);
+   * }</pre>
    */
   BoundingBox boundingBox();
   /**
    * This method checks the element by performing the following steps:
-   * 1. Ensure that element is a checkbox or a radio input. If not, this method rejects. If the element is already
-   *    checked, this method returns immediately.
-   * 1. Wait for [actionability](./actionability.md) checks on the element, unless {@code force} option is set.
-   * 1. Scroll the element into view if needed.
-   * 1. Use [{@code property: Page.mouse}] to click in the center of the element.
-   * 1. Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.
-   * 1. Ensure that the element is now checked. If not, this method rejects.
+   * <ol>
+   * <li> Ensure that element is a checkbox or a radio input. If not, this method rejects. If the element is already checked, this
+   * method returns immediately.</li>
+   * <li> Wait for [actionability](./actionability.md) checks on the element, unless {@code force} option is set.</li>
+   * <li> Scroll the element into view if needed.</li>
+   * <li> Use [{@code property: Page.mouse}] to click in the center of the element.</li>
+   * <li> Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.</li>
+   * <li> Ensure that the element is now checked. If not, this method rejects.</li>
+   * </ol>
    *
    * <p> If the element is detached from the DOM at any moment during the action, this method rejects.
    *
@@ -597,13 +620,15 @@ public interface ElementHandle extends JSHandle {
   }
   /**
    * This method checks the element by performing the following steps:
-   * 1. Ensure that element is a checkbox or a radio input. If not, this method rejects. If the element is already
-   *    checked, this method returns immediately.
-   * 1. Wait for [actionability](./actionability.md) checks on the element, unless {@code force} option is set.
-   * 1. Scroll the element into view if needed.
-   * 1. Use [{@code property: Page.mouse}] to click in the center of the element.
-   * 1. Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.
-   * 1. Ensure that the element is now checked. If not, this method rejects.
+   * <ol>
+   * <li> Ensure that element is a checkbox or a radio input. If not, this method rejects. If the element is already checked, this
+   * method returns immediately.</li>
+   * <li> Wait for [actionability](./actionability.md) checks on the element, unless {@code force} option is set.</li>
+   * <li> Scroll the element into view if needed.</li>
+   * <li> Use [{@code property: Page.mouse}] to click in the center of the element.</li>
+   * <li> Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.</li>
+   * <li> Ensure that the element is now checked. If not, this method rejects.</li>
+   * </ol>
    *
    * <p> If the element is detached from the DOM at any moment during the action, this method rejects.
    *
@@ -613,10 +638,12 @@ public interface ElementHandle extends JSHandle {
   void check(CheckOptions options);
   /**
    * This method clicks the element by performing the following steps:
-   * 1. Wait for [actionability](./actionability.md) checks on the element, unless {@code force} option is set.
-   * 1. Scroll the element into view if needed.
-   * 1. Use [{@code property: Page.mouse}] to click in the center of the element, or the specified {@code position}.
-   * 1. Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.
+   * <ol>
+   * <li> Wait for [actionability](./actionability.md) checks on the element, unless {@code force} option is set.</li>
+   * <li> Scroll the element into view if needed.</li>
+   * <li> Use [{@code property: Page.mouse}] to click in the center of the element, or the specified {@code position}.</li>
+   * <li> Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.</li>
+   * </ol>
    *
    * <p> If the element is detached from the DOM at any moment during the action, this method rejects.
    *
@@ -628,10 +655,12 @@ public interface ElementHandle extends JSHandle {
   }
   /**
    * This method clicks the element by performing the following steps:
-   * 1. Wait for [actionability](./actionability.md) checks on the element, unless {@code force} option is set.
-   * 1. Scroll the element into view if needed.
-   * 1. Use [{@code property: Page.mouse}] to click in the center of the element, or the specified {@code position}.
-   * 1. Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.
+   * <ol>
+   * <li> Wait for [actionability](./actionability.md) checks on the element, unless {@code force} option is set.</li>
+   * <li> Scroll the element into view if needed.</li>
+   * <li> Use [{@code property: Page.mouse}] to click in the center of the element, or the specified {@code position}.</li>
+   * <li> Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.</li>
+   * </ol>
    *
    * <p> If the element is detached from the DOM at any moment during the action, this method rejects.
    *
@@ -645,11 +674,13 @@ public interface ElementHandle extends JSHandle {
   Frame contentFrame();
   /**
    * This method double clicks the element by performing the following steps:
-   * 1. Wait for [actionability](./actionability.md) checks on the element, unless {@code force} option is set.
-   * 1. Scroll the element into view if needed.
-   * 1. Use [{@code property: Page.mouse}] to double click in the center of the element, or the specified {@code position}.
-   * 1. Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set. Note that if the
-   *    first click of the {@code dblclick()} triggers a navigation event, this method will reject.
+   * <ol>
+   * <li> Wait for [actionability](./actionability.md) checks on the element, unless {@code force} option is set.</li>
+   * <li> Scroll the element into view if needed.</li>
+   * <li> Use [{@code property: Page.mouse}] to double click in the center of the element, or the specified {@code position}.</li>
+   * <li> Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set. Note that if the first
+   * click of the {@code dblclick()} triggers a navigation event, this method will reject.</li>
+   * </ol>
    *
    * <p> If the element is detached from the DOM at any moment during the action, this method rejects.
    *
@@ -663,11 +694,13 @@ public interface ElementHandle extends JSHandle {
   }
   /**
    * This method double clicks the element by performing the following steps:
-   * 1. Wait for [actionability](./actionability.md) checks on the element, unless {@code force} option is set.
-   * 1. Scroll the element into view if needed.
-   * 1. Use [{@code property: Page.mouse}] to double click in the center of the element, or the specified {@code position}.
-   * 1. Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set. Note that if the
-   *    first click of the {@code dblclick()} triggers a navigation event, this method will reject.
+   * <ol>
+   * <li> Wait for [actionability](./actionability.md) checks on the element, unless {@code force} option is set.</li>
+   * <li> Scroll the element into view if needed.</li>
+   * <li> Use [{@code property: Page.mouse}] to double click in the center of the element, or the specified {@code position}.</li>
+   * <li> Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set. Note that if the first
+   * click of the {@code dblclick()} triggers a navigation event, this method will reject.</li>
+   * </ol>
    *
    * <p> If the element is detached from the DOM at any moment during the action, this method rejects.
    *
@@ -681,21 +714,32 @@ public interface ElementHandle extends JSHandle {
    * The snippet below dispatches the {@code click} event on the element. Regardless of the visibility state of the elment, {@code click}
    * is dispatched. This is equivalend to calling
    * [element.click()](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/click).
+   * <pre>{@code
+   * elementHandle.dispatchEvent("click");
+   * }</pre>
    *
    * <p> Under the hood, it creates an instance of an event based on the given {@code type}, initializes it with {@code eventInit} properties
    * and dispatches it on the element. Events are {@code composed}, {@code cancelable} and bubble by default.
    *
    * <p> Since {@code eventInit} is event-specific, please refer to the events documentation for the lists of initial properties:
-   * - [DragEvent](https://developer.mozilla.org/en-US/docs/Web/API/DragEvent/DragEvent)
-   * - [FocusEvent](https://developer.mozilla.org/en-US/docs/Web/API/FocusEvent/FocusEvent)
-   * - [KeyboardEvent](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/KeyboardEvent)
-   * - [MouseEvent](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/MouseEvent)
-   * - [PointerEvent](https://developer.mozilla.org/en-US/docs/Web/API/PointerEvent/PointerEvent)
-   * - [TouchEvent](https://developer.mozilla.org/en-US/docs/Web/API/TouchEvent/TouchEvent)
-   * - [Event](https://developer.mozilla.org/en-US/docs/Web/API/Event/Event)
+   * <ul>
+   * <li> [DragEvent](https://developer.mozilla.org/en-US/docs/Web/API/DragEvent/DragEvent)</li>
+   * <li> [FocusEvent](https://developer.mozilla.org/en-US/docs/Web/API/FocusEvent/FocusEvent)</li>
+   * <li> [KeyboardEvent](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/KeyboardEvent)</li>
+   * <li> [MouseEvent](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/MouseEvent)</li>
+   * <li> [PointerEvent](https://developer.mozilla.org/en-US/docs/Web/API/PointerEvent/PointerEvent)</li>
+   * <li> [TouchEvent](https://developer.mozilla.org/en-US/docs/Web/API/TouchEvent/TouchEvent)</li>
+   * <li> [Event](https://developer.mozilla.org/en-US/docs/Web/API/Event/Event)</li>
+   * </ul>
    *
    * <p> You can also specify {@code JSHandle} as the property value if you want live objects to be passed into the event:
-   *
+   * <pre>{@code
+   * // Note you can only create DataTransfer in Chromium and Firefox
+   * JSHandle dataTransfer = page.evaluateHandle("() => new DataTransfer()");
+   * Map<String, Object> arg = new HashMap<>();
+   * arg.put("dataTransfer", dataTransfer);
+   * elementHandle.dispatchEvent("dragstart", arg);
+   * }</pre>
    *
    * @param type DOM event type: {@code "click"}, {@code "dragstart"}, etc.
    */
@@ -706,21 +750,32 @@ public interface ElementHandle extends JSHandle {
    * The snippet below dispatches the {@code click} event on the element. Regardless of the visibility state of the elment, {@code click}
    * is dispatched. This is equivalend to calling
    * [element.click()](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/click).
+   * <pre>{@code
+   * elementHandle.dispatchEvent("click");
+   * }</pre>
    *
    * <p> Under the hood, it creates an instance of an event based on the given {@code type}, initializes it with {@code eventInit} properties
    * and dispatches it on the element. Events are {@code composed}, {@code cancelable} and bubble by default.
    *
    * <p> Since {@code eventInit} is event-specific, please refer to the events documentation for the lists of initial properties:
-   * - [DragEvent](https://developer.mozilla.org/en-US/docs/Web/API/DragEvent/DragEvent)
-   * - [FocusEvent](https://developer.mozilla.org/en-US/docs/Web/API/FocusEvent/FocusEvent)
-   * - [KeyboardEvent](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/KeyboardEvent)
-   * - [MouseEvent](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/MouseEvent)
-   * - [PointerEvent](https://developer.mozilla.org/en-US/docs/Web/API/PointerEvent/PointerEvent)
-   * - [TouchEvent](https://developer.mozilla.org/en-US/docs/Web/API/TouchEvent/TouchEvent)
-   * - [Event](https://developer.mozilla.org/en-US/docs/Web/API/Event/Event)
+   * <ul>
+   * <li> [DragEvent](https://developer.mozilla.org/en-US/docs/Web/API/DragEvent/DragEvent)</li>
+   * <li> [FocusEvent](https://developer.mozilla.org/en-US/docs/Web/API/FocusEvent/FocusEvent)</li>
+   * <li> [KeyboardEvent](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/KeyboardEvent)</li>
+   * <li> [MouseEvent](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/MouseEvent)</li>
+   * <li> [PointerEvent](https://developer.mozilla.org/en-US/docs/Web/API/PointerEvent/PointerEvent)</li>
+   * <li> [TouchEvent](https://developer.mozilla.org/en-US/docs/Web/API/TouchEvent/TouchEvent)</li>
+   * <li> [Event](https://developer.mozilla.org/en-US/docs/Web/API/Event/Event)</li>
+   * </ul>
    *
    * <p> You can also specify {@code JSHandle} as the property value if you want live objects to be passed into the event:
-   *
+   * <pre>{@code
+   * // Note you can only create DataTransfer in Chromium and Firefox
+   * JSHandle dataTransfer = page.evaluateHandle("() => new DataTransfer()");
+   * Map<String, Object> arg = new HashMap<>();
+   * arg.put("dataTransfer", dataTransfer);
+   * elementHandle.dispatchEvent("dragstart", arg);
+   * }</pre>
    *
    * @param type DOM event type: {@code "click"}, {@code "dragstart"}, etc.
    * @param eventInit Optional event-specific initialization properties.
@@ -736,6 +791,12 @@ public interface ElementHandle extends JSHandle {
    * <p> If {@code expression} returns a [Promise], then [{@code method: ElementHandle.evalOnSelector}] would wait for the promise to resolve
    * and return its value.
    *
+   * <p> Examples:
+   * <pre>{@code
+   * ElementHandle tweetHandle = page.querySelector(".tweet");
+   * assertEquals("100", tweetHandle.evalOnSelector(".like", "node => node.innerText"));
+   * assertEquals("10", tweetHandle.evalOnSelector(".retweets", "node => node.innerText"));
+   * }</pre>
    *
    * @param selector A selector to query for. See [working with selectors](./selectors.md) for more details.
    * @param expression JavaScript expression to be evaluated in the browser context. If it looks like a function declaration, it is interpreted
@@ -754,6 +815,12 @@ public interface ElementHandle extends JSHandle {
    * <p> If {@code expression} returns a [Promise], then [{@code method: ElementHandle.evalOnSelector}] would wait for the promise to resolve
    * and return its value.
    *
+   * <p> Examples:
+   * <pre>{@code
+   * ElementHandle tweetHandle = page.querySelector(".tweet");
+   * assertEquals("100", tweetHandle.evalOnSelector(".like", "node => node.innerText"));
+   * assertEquals("10", tweetHandle.evalOnSelector(".retweets", "node => node.innerText"));
+   * }</pre>
    *
    * @param selector A selector to query for. See [working with selectors](./selectors.md) for more details.
    * @param expression JavaScript expression to be evaluated in the browser context. If it looks like a function declaration, it is interpreted
@@ -770,6 +837,11 @@ public interface ElementHandle extends JSHandle {
    * <p> If {@code expression} returns a [Promise], then [{@code method: ElementHandle.evalOnSelectorAll}] would wait for the promise to
    * resolve and return its value.
    *
+   * <p> Examples:
+   * <pre>{@code
+   * ElementHandle feedHandle = page.querySelector(".feed");
+   * assertEquals(Arrays.asList("Hello!", "Hi!"), feedHandle.evalOnSelectorAll(".tweet", "nodes => nodes.map(n => n.innerText)"));
+   * }</pre>
    *
    * @param selector A selector to query for. See [working with selectors](./selectors.md) for more details.
    * @param expression JavaScript expression to be evaluated in the browser context. If it looks like a function declaration, it is interpreted
@@ -787,6 +859,11 @@ public interface ElementHandle extends JSHandle {
    * <p> If {@code expression} returns a [Promise], then [{@code method: ElementHandle.evalOnSelectorAll}] would wait for the promise to
    * resolve and return its value.
    *
+   * <p> Examples:
+   * <pre>{@code
+   * ElementHandle feedHandle = page.querySelector(".feed");
+   * assertEquals(Arrays.asList("Hello!", "Hi!"), feedHandle.evalOnSelectorAll(".tweet", "nodes => nodes.map(n => n.innerText)"));
+   * }</pre>
    *
    * @param selector A selector to query for. See [working with selectors](./selectors.md) for more details.
    * @param expression JavaScript expression to be evaluated in the browser context. If it looks like a function declaration, it is interpreted
@@ -828,10 +905,12 @@ public interface ElementHandle extends JSHandle {
   String getAttribute(String name);
   /**
    * This method hovers over the element by performing the following steps:
-   * 1. Wait for [actionability](./actionability.md) checks on the element, unless {@code force} option is set.
-   * 1. Scroll the element into view if needed.
-   * 1. Use [{@code property: Page.mouse}] to hover over the center of the element, or the specified {@code position}.
-   * 1. Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.
+   * <ol>
+   * <li> Wait for [actionability](./actionability.md) checks on the element, unless {@code force} option is set.</li>
+   * <li> Scroll the element into view if needed.</li>
+   * <li> Use [{@code property: Page.mouse}] to hover over the center of the element, or the specified {@code position}.</li>
+   * <li> Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.</li>
+   * </ol>
    *
    * <p> If the element is detached from the DOM at any moment during the action, this method rejects.
    *
@@ -843,10 +922,12 @@ public interface ElementHandle extends JSHandle {
   }
   /**
    * This method hovers over the element by performing the following steps:
-   * 1. Wait for [actionability](./actionability.md) checks on the element, unless {@code force} option is set.
-   * 1. Scroll the element into view if needed.
-   * 1. Use [{@code property: Page.mouse}] to hover over the center of the element, or the specified {@code position}.
-   * 1. Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.
+   * <ol>
+   * <li> Wait for [actionability](./actionability.md) checks on the element, unless {@code force} option is set.</li>
+   * <li> Scroll the element into view if needed.</li>
+   * <li> Use [{@code property: Page.mouse}] to hover over the center of the element, or the specified {@code position}.</li>
+   * <li> Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.</li>
+   * </ol>
    *
    * <p> If the element is detached from the DOM at any moment during the action, this method rejects.
    *
@@ -995,7 +1076,14 @@ public interface ElementHandle extends JSHandle {
    * element, the method throws an error.
    *
    * <p> Will wait until all specified options are present in the {@code <select>} element.
-   *
+   * <pre>{@code
+   * // single selection matching the value
+   * handle.selectOption("blue");
+   * // single selection matching the label
+   * handle.selectOption(new SelectOption().withLabel("Blue"));
+   * // multiple selection
+   * handle.selectOption(new String[] {"red", "green", "blue"});
+   * }</pre>
    *
    * @param values Options to select. If the {@code <select>} has the {@code multiple} attribute, all matching options are selected, otherwise only the
    * first option matching one of the passed options is selected. String values are equivalent to {@code {value:'string'}}. Option
@@ -1011,7 +1099,14 @@ public interface ElementHandle extends JSHandle {
    * element, the method throws an error.
    *
    * <p> Will wait until all specified options are present in the {@code <select>} element.
-   *
+   * <pre>{@code
+   * // single selection matching the value
+   * handle.selectOption("blue");
+   * // single selection matching the label
+   * handle.selectOption(new SelectOption().withLabel("Blue"));
+   * // multiple selection
+   * handle.selectOption(new String[] {"red", "green", "blue"});
+   * }</pre>
    *
    * @param values Options to select. If the {@code <select>} has the {@code multiple} attribute, all matching options are selected, otherwise only the
    * first option matching one of the passed options is selected. String values are equivalent to {@code {value:'string'}}. Option
@@ -1025,7 +1120,14 @@ public interface ElementHandle extends JSHandle {
    * element, the method throws an error.
    *
    * <p> Will wait until all specified options are present in the {@code <select>} element.
-   *
+   * <pre>{@code
+   * // single selection matching the value
+   * handle.selectOption("blue");
+   * // single selection matching the label
+   * handle.selectOption(new SelectOption().withLabel("Blue"));
+   * // multiple selection
+   * handle.selectOption(new String[] {"red", "green", "blue"});
+   * }</pre>
    *
    * @param values Options to select. If the {@code <select>} has the {@code multiple} attribute, all matching options are selected, otherwise only the
    * first option matching one of the passed options is selected. String values are equivalent to {@code {value:'string'}}. Option
@@ -1041,7 +1143,14 @@ public interface ElementHandle extends JSHandle {
    * element, the method throws an error.
    *
    * <p> Will wait until all specified options are present in the {@code <select>} element.
-   *
+   * <pre>{@code
+   * // single selection matching the value
+   * handle.selectOption("blue");
+   * // single selection matching the label
+   * handle.selectOption(new SelectOption().withLabel("Blue"));
+   * // multiple selection
+   * handle.selectOption(new String[] {"red", "green", "blue"});
+   * }</pre>
    *
    * @param values Options to select. If the {@code <select>} has the {@code multiple} attribute, all matching options are selected, otherwise only the
    * first option matching one of the passed options is selected. String values are equivalent to {@code {value:'string'}}. Option
@@ -1055,7 +1164,14 @@ public interface ElementHandle extends JSHandle {
    * element, the method throws an error.
    *
    * <p> Will wait until all specified options are present in the {@code <select>} element.
-   *
+   * <pre>{@code
+   * // single selection matching the value
+   * handle.selectOption("blue");
+   * // single selection matching the label
+   * handle.selectOption(new SelectOption().withLabel("Blue"));
+   * // multiple selection
+   * handle.selectOption(new String[] {"red", "green", "blue"});
+   * }</pre>
    *
    * @param values Options to select. If the {@code <select>} has the {@code multiple} attribute, all matching options are selected, otherwise only the
    * first option matching one of the passed options is selected. String values are equivalent to {@code {value:'string'}}. Option
@@ -1071,7 +1187,14 @@ public interface ElementHandle extends JSHandle {
    * element, the method throws an error.
    *
    * <p> Will wait until all specified options are present in the {@code <select>} element.
-   *
+   * <pre>{@code
+   * // single selection matching the value
+   * handle.selectOption("blue");
+   * // single selection matching the label
+   * handle.selectOption(new SelectOption().withLabel("Blue"));
+   * // multiple selection
+   * handle.selectOption(new String[] {"red", "green", "blue"});
+   * }</pre>
    *
    * @param values Options to select. If the {@code <select>} has the {@code multiple} attribute, all matching options are selected, otherwise only the
    * first option matching one of the passed options is selected. String values are equivalent to {@code {value:'string'}}. Option
@@ -1085,7 +1208,14 @@ public interface ElementHandle extends JSHandle {
    * element, the method throws an error.
    *
    * <p> Will wait until all specified options are present in the {@code <select>} element.
-   *
+   * <pre>{@code
+   * // single selection matching the value
+   * handle.selectOption("blue");
+   * // single selection matching the label
+   * handle.selectOption(new SelectOption().withLabel("Blue"));
+   * // multiple selection
+   * handle.selectOption(new String[] {"red", "green", "blue"});
+   * }</pre>
    *
    * @param values Options to select. If the {@code <select>} has the {@code multiple} attribute, all matching options are selected, otherwise only the
    * first option matching one of the passed options is selected. String values are equivalent to {@code {value:'string'}}. Option
@@ -1101,7 +1231,14 @@ public interface ElementHandle extends JSHandle {
    * element, the method throws an error.
    *
    * <p> Will wait until all specified options are present in the {@code <select>} element.
-   *
+   * <pre>{@code
+   * // single selection matching the value
+   * handle.selectOption("blue");
+   * // single selection matching the label
+   * handle.selectOption(new SelectOption().withLabel("Blue"));
+   * // multiple selection
+   * handle.selectOption(new String[] {"red", "green", "blue"});
+   * }</pre>
    *
    * @param values Options to select. If the {@code <select>} has the {@code multiple} attribute, all matching options are selected, otherwise only the
    * first option matching one of the passed options is selected. String values are equivalent to {@code {value:'string'}}. Option
@@ -1115,7 +1252,14 @@ public interface ElementHandle extends JSHandle {
    * element, the method throws an error.
    *
    * <p> Will wait until all specified options are present in the {@code <select>} element.
-   *
+   * <pre>{@code
+   * // single selection matching the value
+   * handle.selectOption("blue");
+   * // single selection matching the label
+   * handle.selectOption(new SelectOption().withLabel("Blue"));
+   * // multiple selection
+   * handle.selectOption(new String[] {"red", "green", "blue"});
+   * }</pre>
    *
    * @param values Options to select. If the {@code <select>} has the {@code multiple} attribute, all matching options are selected, otherwise only the
    * first option matching one of the passed options is selected. String values are equivalent to {@code {value:'string'}}. Option
@@ -1131,7 +1275,14 @@ public interface ElementHandle extends JSHandle {
    * element, the method throws an error.
    *
    * <p> Will wait until all specified options are present in the {@code <select>} element.
-   *
+   * <pre>{@code
+   * // single selection matching the value
+   * handle.selectOption("blue");
+   * // single selection matching the label
+   * handle.selectOption(new SelectOption().withLabel("Blue"));
+   * // multiple selection
+   * handle.selectOption(new String[] {"red", "green", "blue"});
+   * }</pre>
    *
    * @param values Options to select. If the {@code <select>} has the {@code multiple} attribute, all matching options are selected, otherwise only the
    * first option matching one of the passed options is selected. String values are equivalent to {@code {value:'string'}}. Option
@@ -1145,7 +1296,14 @@ public interface ElementHandle extends JSHandle {
    * element, the method throws an error.
    *
    * <p> Will wait until all specified options are present in the {@code <select>} element.
-   *
+   * <pre>{@code
+   * // single selection matching the value
+   * handle.selectOption("blue");
+   * // single selection matching the label
+   * handle.selectOption(new SelectOption().withLabel("Blue"));
+   * // multiple selection
+   * handle.selectOption(new String[] {"red", "green", "blue"});
+   * }</pre>
    *
    * @param values Options to select. If the {@code <select>} has the {@code multiple} attribute, all matching options are selected, otherwise only the
    * first option matching one of the passed options is selected. String values are equivalent to {@code {value:'string'}}. Option
@@ -1161,7 +1319,14 @@ public interface ElementHandle extends JSHandle {
    * element, the method throws an error.
    *
    * <p> Will wait until all specified options are present in the {@code <select>} element.
-   *
+   * <pre>{@code
+   * // single selection matching the value
+   * handle.selectOption("blue");
+   * // single selection matching the label
+   * handle.selectOption(new SelectOption().withLabel("Blue"));
+   * // multiple selection
+   * handle.selectOption(new String[] {"red", "green", "blue"});
+   * }</pre>
    *
    * @param values Options to select. If the {@code <select>} has the {@code multiple} attribute, all matching options are selected, otherwise only the
    * first option matching one of the passed options is selected. String values are equivalent to {@code {value:'string'}}. Option
@@ -1254,10 +1419,12 @@ public interface ElementHandle extends JSHandle {
   void setInputFiles(FilePayload[] files, SetInputFilesOptions options);
   /**
    * This method taps the element by performing the following steps:
-   * 1. Wait for [actionability](./actionability.md) checks on the element, unless {@code force} option is set.
-   * 1. Scroll the element into view if needed.
-   * 1. Use [{@code property: Page.touchscreen}] to tap the center of the element, or the specified {@code position}.
-   * 1. Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.
+   * <ol>
+   * <li> Wait for [actionability](./actionability.md) checks on the element, unless {@code force} option is set.</li>
+   * <li> Scroll the element into view if needed.</li>
+   * <li> Use [{@code property: Page.touchscreen}] to tap the center of the element, or the specified {@code position}.</li>
+   * <li> Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.</li>
+   * </ol>
    *
    * <p> If the element is detached from the DOM at any moment during the action, this method rejects.
    *
@@ -1271,10 +1438,12 @@ public interface ElementHandle extends JSHandle {
   }
   /**
    * This method taps the element by performing the following steps:
-   * 1. Wait for [actionability](./actionability.md) checks on the element, unless {@code force} option is set.
-   * 1. Scroll the element into view if needed.
-   * 1. Use [{@code property: Page.touchscreen}] to tap the center of the element, or the specified {@code position}.
-   * 1. Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.
+   * <ol>
+   * <li> Wait for [actionability](./actionability.md) checks on the element, unless {@code force} option is set.</li>
+   * <li> Scroll the element into view if needed.</li>
+   * <li> Use [{@code property: Page.touchscreen}] to tap the center of the element, or the specified {@code position}.</li>
+   * <li> Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.</li>
+   * </ol>
    *
    * <p> If the element is detached from the DOM at any moment during the action, this method rejects.
    *
@@ -1292,7 +1461,17 @@ public interface ElementHandle extends JSHandle {
    * Focuses the element, and then sends a {@code keydown}, {@code keypress}/{@code input}, and {@code keyup} event for each character in the text.
    *
    * <p> To press a special key, like {@code Control} or {@code ArrowDown}, use [{@code method: ElementHandle.press}].
+   * <pre>{@code
+   * elementHandle.type("Hello"); // Types instantly
+   * elementHandle.type("World", new ElementHandle.TypeOptions().withDelay(100)); // Types slower, like a user
+   * }</pre>
    *
+   * <p> An example of typing into a text field and then submitting the form:
+   * <pre>{@code
+   * ElementHandle elementHandle = page.querySelector("input");
+   * elementHandle.type("some text");
+   * elementHandle.press("Enter");
+   * }</pre>
    *
    * @param text A text to type into a focused element.
    */
@@ -1303,20 +1482,32 @@ public interface ElementHandle extends JSHandle {
    * Focuses the element, and then sends a {@code keydown}, {@code keypress}/{@code input}, and {@code keyup} event for each character in the text.
    *
    * <p> To press a special key, like {@code Control} or {@code ArrowDown}, use [{@code method: ElementHandle.press}].
+   * <pre>{@code
+   * elementHandle.type("Hello"); // Types instantly
+   * elementHandle.type("World", new ElementHandle.TypeOptions().withDelay(100)); // Types slower, like a user
+   * }</pre>
    *
+   * <p> An example of typing into a text field and then submitting the form:
+   * <pre>{@code
+   * ElementHandle elementHandle = page.querySelector("input");
+   * elementHandle.type("some text");
+   * elementHandle.press("Enter");
+   * }</pre>
    *
    * @param text A text to type into a focused element.
    */
   void type(String text, TypeOptions options);
   /**
    * This method checks the element by performing the following steps:
-   * 1. Ensure that element is a checkbox or a radio input. If not, this method rejects. If the element is already
-   *    unchecked, this method returns immediately.
-   * 1. Wait for [actionability](./actionability.md) checks on the element, unless {@code force} option is set.
-   * 1. Scroll the element into view if needed.
-   * 1. Use [{@code property: Page.mouse}] to click in the center of the element.
-   * 1. Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.
-   * 1. Ensure that the element is now unchecked. If not, this method rejects.
+   * <ol>
+   * <li> Ensure that element is a checkbox or a radio input. If not, this method rejects. If the element is already unchecked,
+   * this method returns immediately.</li>
+   * <li> Wait for [actionability](./actionability.md) checks on the element, unless {@code force} option is set.</li>
+   * <li> Scroll the element into view if needed.</li>
+   * <li> Use [{@code property: Page.mouse}] to click in the center of the element.</li>
+   * <li> Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.</li>
+   * <li> Ensure that the element is now unchecked. If not, this method rejects.</li>
+   * </ol>
    *
    * <p> If the element is detached from the DOM at any moment during the action, this method rejects.
    *
@@ -1328,13 +1519,15 @@ public interface ElementHandle extends JSHandle {
   }
   /**
    * This method checks the element by performing the following steps:
-   * 1. Ensure that element is a checkbox or a radio input. If not, this method rejects. If the element is already
-   *    unchecked, this method returns immediately.
-   * 1. Wait for [actionability](./actionability.md) checks on the element, unless {@code force} option is set.
-   * 1. Scroll the element into view if needed.
-   * 1. Use [{@code property: Page.mouse}] to click in the center of the element.
-   * 1. Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.
-   * 1. Ensure that the element is now unchecked. If not, this method rejects.
+   * <ol>
+   * <li> Ensure that element is a checkbox or a radio input. If not, this method rejects. If the element is already unchecked,
+   * this method returns immediately.</li>
+   * <li> Wait for [actionability](./actionability.md) checks on the element, unless {@code force} option is set.</li>
+   * <li> Scroll the element into view if needed.</li>
+   * <li> Use [{@code property: Page.mouse}] to click in the center of the element.</li>
+   * <li> Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.</li>
+   * <li> Ensure that the element is now unchecked. If not, this method rejects.</li>
+   * </ol>
    *
    * <p> If the element is detached from the DOM at any moment during the action, this method rejects.
    *
@@ -1347,14 +1540,15 @@ public interface ElementHandle extends JSHandle {
    *
    * <p> Depending on the {@code state} parameter, this method waits for one of the [actionability](./actionability.md) checks to pass.
    * This method throws when the element is detached while waiting, unless waiting for the {@code "hidden"} state.
-   * - {@code "visible"} Wait until the element is [visible](./actionability.md#visible).
-   * - {@code "hidden"} Wait until the element is [not visible](./actionability.md#visible) or
-   *   [not attached](./actionability.md#attached). Note that waiting for hidden does not throw when the element detaches.
-   * - {@code "stable"} Wait until the element is both [visible](./actionability.md#visible) and
-   *   [stable](./actionability.md#stable).
-   * - {@code "enabled"} Wait until the element is [enabled](./actionability.md#enabled).
-   * - {@code "disabled"} Wait until the element is [not enabled](./actionability.md#enabled).
-   * - {@code "editable"} Wait until the element is [editable](./actionability.md#editable).
+   * <ul>
+   * <li> {@code "visible"} Wait until the element is [visible](./actionability.md#visible).</li>
+   * <li> {@code "hidden"} Wait until the element is [not visible](./actionability.md#visible) or
+   * [not attached](./actionability.md#attached). Note that waiting for hidden does not throw when the element detaches.</li>
+   * <li> {@code "stable"} Wait until the element is both [visible](./actionability.md#visible) and [stable](./actionability.md#stable).</li>
+   * <li> {@code "enabled"} Wait until the element is [enabled](./actionability.md#enabled).</li>
+   * <li> {@code "disabled"} Wait until the element is [not enabled](./actionability.md#enabled).</li>
+   * <li> {@code "editable"} Wait until the element is [editable](./actionability.md#editable).</li>
+   * </ul>
    *
    * <p> If the element does not satisfy the condition for the {@code timeout} milliseconds, this method will throw.
    *
@@ -1368,14 +1562,15 @@ public interface ElementHandle extends JSHandle {
    *
    * <p> Depending on the {@code state} parameter, this method waits for one of the [actionability](./actionability.md) checks to pass.
    * This method throws when the element is detached while waiting, unless waiting for the {@code "hidden"} state.
-   * - {@code "visible"} Wait until the element is [visible](./actionability.md#visible).
-   * - {@code "hidden"} Wait until the element is [not visible](./actionability.md#visible) or
-   *   [not attached](./actionability.md#attached). Note that waiting for hidden does not throw when the element detaches.
-   * - {@code "stable"} Wait until the element is both [visible](./actionability.md#visible) and
-   *   [stable](./actionability.md#stable).
-   * - {@code "enabled"} Wait until the element is [enabled](./actionability.md#enabled).
-   * - {@code "disabled"} Wait until the element is [not enabled](./actionability.md#enabled).
-   * - {@code "editable"} Wait until the element is [editable](./actionability.md#editable).
+   * <ul>
+   * <li> {@code "visible"} Wait until the element is [visible](./actionability.md#visible).</li>
+   * <li> {@code "hidden"} Wait until the element is [not visible](./actionability.md#visible) or
+   * [not attached](./actionability.md#attached). Note that waiting for hidden does not throw when the element detaches.</li>
+   * <li> {@code "stable"} Wait until the element is both [visible](./actionability.md#visible) and [stable](./actionability.md#stable).</li>
+   * <li> {@code "enabled"} Wait until the element is [enabled](./actionability.md#enabled).</li>
+   * <li> {@code "disabled"} Wait until the element is [not enabled](./actionability.md#enabled).</li>
+   * <li> {@code "editable"} Wait until the element is [editable](./actionability.md#editable).</li>
+   * </ul>
    *
    * <p> If the element does not satisfy the condition for the {@code timeout} milliseconds, this method will throw.
    *
@@ -1390,6 +1585,13 @@ public interface ElementHandle extends JSHandle {
    * become visible/hidden). If at the moment of calling the method {@code selector} already satisfies the condition, the method
    * will return immediately. If the selector doesn't satisfy the condition for the {@code timeout} milliseconds, the function will
    * throw.
+   * <pre>{@code
+   * page.setContent("<div><span></span></div>");
+   * ElementHandle div = page.querySelector("div");
+   * // Waiting for the "span" selector relative to the div.
+   * ElementHandle span = div.waitForSelector("span", new ElementHandle.WaitForSelectorOptions()
+   *   .withState(WaitForSelectorState.ATTACHED));
+   * }</pre>
    *
    * <p> <strong>NOTE:</strong> This method does not work across navigations, use [{@code method: Page.waitForSelector}] instead.
    *
@@ -1406,6 +1608,13 @@ public interface ElementHandle extends JSHandle {
    * become visible/hidden). If at the moment of calling the method {@code selector} already satisfies the condition, the method
    * will return immediately. If the selector doesn't satisfy the condition for the {@code timeout} milliseconds, the function will
    * throw.
+   * <pre>{@code
+   * page.setContent("<div><span></span></div>");
+   * ElementHandle div = page.querySelector("div");
+   * // Waiting for the "span" selector relative to the div.
+   * ElementHandle span = div.waitForSelector("span", new ElementHandle.WaitForSelectorOptions()
+   *   .withState(WaitForSelectorState.ATTACHED));
+   * }</pre>
    *
    * <p> <strong>NOTE:</strong> This method does not work across navigations, use [{@code method: Page.waitForSelector}] instead.
    *

--- a/playwright/src/main/java/com/microsoft/playwright/FileChooser.java
+++ b/playwright/src/main/java/com/microsoft/playwright/FileChooser.java
@@ -22,6 +22,10 @@ import java.util.*;
 
 /**
  * {@code FileChooser} objects are dispatched by the page in the [{@code event: Page.fileChooser}] event.
+ * <pre>{@code
+ * FileChooser fileChooser = page.waitForFileChooser(() -> page.click("upload"));
+ * fileChooser.setFiles(Paths.get("myfile.pdf"));
+ * }</pre>
  */
 public interface FileChooser {
   class SetFilesOptions {

--- a/playwright/src/main/java/com/microsoft/playwright/Frame.java
+++ b/playwright/src/main/java/com/microsoft/playwright/Frame.java
@@ -27,11 +27,37 @@ import java.util.regex.Pattern;
  * [{@code method: Frame.childFrames}] methods.
  *
  * <p> {@code Frame} object's lifecycle is controlled by three events, dispatched on the page object:
- * - [{@code event: Page.frameAttached}] - fired when the frame gets attached to the page. A Frame can be attached to the page
- *   only once.
- * - [{@code event: Page.frameNavigated}] - fired when the frame commits navigation to a different URL.
- * - [{@code event: Page.frameDetached}] - fired when the frame gets detached from the page.  A Frame can be detached from the
- *   page only once.
+ * <ul>
+ * <li> [{@code event: Page.frameAttached}] - fired when the frame gets attached to the page. A Frame can be attached to the page only
+ * once.</li>
+ * <li> [{@code event: Page.frameNavigated}] - fired when the frame commits navigation to a different URL.</li>
+ * <li> [{@code event: Page.frameDetached}] - fired when the frame gets detached from the page.  A Frame can be detached from the page
+ * only once.</li>
+ * </ul>
+ *
+ * <p> An example of dumping frame tree:
+ * <pre>{@code
+ * import com.microsoft.playwright.*;
+ *
+ * public class Example {
+ *   public static void main(String[] args) {
+ *     try (Playwright playwright = Playwright.create()) {
+ *       BrowserType firefox = playwright.firefox();
+ *       Browser browser = firefox.launch();
+ *       Page page = browser.newPage();
+ *       page.navigate("https://www.google.com/chrome/browser/canary.html");
+ *       dumpFrameTree(page.mainFrame(), "");
+ *       browser.close();
+ *     }
+ *   }
+ *   static void dumpFrameTree(Frame frame, String indent) {
+ *     System.out.println(indent + frame.url());
+ *     for (Frame child : frame.childFrames()) {
+ *       dumpFrameTree(child, indent + "  ");
+ *     }
+ *   }
+ * }
+ * }</pre>
  */
 public interface Frame {
   class AddScriptTagOptions {
@@ -344,9 +370,11 @@ public interface Frame {
     public Double timeout;
     /**
      * When to consider operation succeeded, defaults to {@code load}. Events can be either:
-     * - {@code 'domcontentloaded'} - consider operation to be finished when the {@code DOMContentLoaded} event is fired.
-     * - {@code 'load'} - consider operation to be finished when the {@code load} event is fired.
-     * - {@code 'networkidle'} - consider operation to be finished when there are no network connections for at least {@code 500} ms.
+     * <ul>
+     * <li> {@code 'domcontentloaded'} - consider operation to be finished when the {@code DOMContentLoaded} event is fired.</li>
+     * <li> {@code 'load'} - consider operation to be finished when the {@code load} event is fired.</li>
+     * <li> {@code 'networkidle'} - consider operation to be finished when there are no network connections for at least {@code 500} ms.</li>
+     * </ul>
      */
     public WaitUntilState waitUntil;
 
@@ -562,9 +590,11 @@ public interface Frame {
     public Double timeout;
     /**
      * When to consider operation succeeded, defaults to {@code load}. Events can be either:
-     * - {@code 'domcontentloaded'} - consider operation to be finished when the {@code DOMContentLoaded} event is fired.
-     * - {@code 'load'} - consider operation to be finished when the {@code load} event is fired.
-     * - {@code 'networkidle'} - consider operation to be finished when there are no network connections for at least {@code 500} ms.
+     * <ul>
+     * <li> {@code 'domcontentloaded'} - consider operation to be finished when the {@code DOMContentLoaded} event is fired.</li>
+     * <li> {@code 'load'} - consider operation to be finished when the {@code load} event is fired.</li>
+     * <li> {@code 'networkidle'} - consider operation to be finished when there are no network connections for at least {@code 500} ms.</li>
+     * </ul>
      */
     public WaitUntilState waitUntil;
 
@@ -771,9 +801,11 @@ public interface Frame {
     public Object url;
     /**
      * When to consider operation succeeded, defaults to {@code load}. Events can be either:
-     * - {@code 'domcontentloaded'} - consider operation to be finished when the {@code DOMContentLoaded} event is fired.
-     * - {@code 'load'} - consider operation to be finished when the {@code load} event is fired.
-     * - {@code 'networkidle'} - consider operation to be finished when there are no network connections for at least {@code 500} ms.
+     * <ul>
+     * <li> {@code 'domcontentloaded'} - consider operation to be finished when the {@code DOMContentLoaded} event is fired.</li>
+     * <li> {@code 'load'} - consider operation to be finished when the {@code load} event is fired.</li>
+     * <li> {@code 'networkidle'} - consider operation to be finished when there are no network connections for at least {@code 500} ms.</li>
+     * </ul>
      */
     public WaitUntilState waitUntil;
 
@@ -801,12 +833,14 @@ public interface Frame {
   class WaitForSelectorOptions {
     /**
      * Defaults to {@code 'visible'}. Can be either:
-     * - {@code 'attached'} - wait for element to be present in DOM.
-     * - {@code 'detached'} - wait for element to not be present in DOM.
-     * - {@code 'visible'} - wait for element to have non-empty bounding box and no {@code visibility:hidden}. Note that element without
-     *   any content or with {@code display:none} has an empty bounding box and is not considered visible.
-     * - {@code 'hidden'} - wait for element to be either detached from DOM, or have an empty bounding box or {@code visibility:hidden}.
-     *   This is opposite to the {@code 'visible'} option.
+     * <ul>
+     * <li> {@code 'attached'} - wait for element to be present in DOM.</li>
+     * <li> {@code 'detached'} - wait for element to not be present in DOM.</li>
+     * <li> {@code 'visible'} - wait for element to have non-empty bounding box and no {@code visibility:hidden}. Note that element without any
+     * content or with {@code display:none} has an empty bounding box and is not considered visible.</li>
+     * <li> {@code 'hidden'} - wait for element to be either detached from DOM, or have an empty bounding box or {@code visibility:hidden}. This
+     * is opposite to the {@code 'visible'} option.</li>
+     * </ul>
      */
     public WaitForSelectorState state;
     /**
@@ -856,15 +890,17 @@ public interface Frame {
   ElementHandle addStyleTag(AddStyleTagOptions options);
   /**
    * This method checks an element matching {@code selector} by performing the following steps:
-   * 1. Find an element match matching {@code selector}. If there is none, wait until a matching element is attached to the DOM.
-   * 1. Ensure that matched element is a checkbox or a radio input. If not, this method rejects. If the element is already
-   *    checked, this method returns immediately.
-   * 1. Wait for [actionability](./actionability.md) checks on the matched element, unless {@code force} option is set. If the
-   *    element is detached during the checks, the whole action is retried.
-   * 1. Scroll the element into view if needed.
-   * 1. Use [{@code property: Page.mouse}] to click in the center of the element.
-   * 1. Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.
-   * 1. Ensure that the element is now checked. If not, this method rejects.
+   * <ol>
+   * <li> Find an element match matching {@code selector}. If there is none, wait until a matching element is attached to the DOM.</li>
+   * <li> Ensure that matched element is a checkbox or a radio input. If not, this method rejects. If the element is already
+   * checked, this method returns immediately.</li>
+   * <li> Wait for [actionability](./actionability.md) checks on the matched element, unless {@code force} option is set. If the element
+   * is detached during the checks, the whole action is retried.</li>
+   * <li> Scroll the element into view if needed.</li>
+   * <li> Use [{@code property: Page.mouse}] to click in the center of the element.</li>
+   * <li> Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.</li>
+   * <li> Ensure that the element is now checked. If not, this method rejects.</li>
+   * </ol>
    *
    * <p> When all steps combined have not finished during the specified {@code timeout}, this method rejects with a {@code TimeoutError}.
    * Passing zero timeout disables this.
@@ -877,15 +913,17 @@ public interface Frame {
   }
   /**
    * This method checks an element matching {@code selector} by performing the following steps:
-   * 1. Find an element match matching {@code selector}. If there is none, wait until a matching element is attached to the DOM.
-   * 1. Ensure that matched element is a checkbox or a radio input. If not, this method rejects. If the element is already
-   *    checked, this method returns immediately.
-   * 1. Wait for [actionability](./actionability.md) checks on the matched element, unless {@code force} option is set. If the
-   *    element is detached during the checks, the whole action is retried.
-   * 1. Scroll the element into view if needed.
-   * 1. Use [{@code property: Page.mouse}] to click in the center of the element.
-   * 1. Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.
-   * 1. Ensure that the element is now checked. If not, this method rejects.
+   * <ol>
+   * <li> Find an element match matching {@code selector}. If there is none, wait until a matching element is attached to the DOM.</li>
+   * <li> Ensure that matched element is a checkbox or a radio input. If not, this method rejects. If the element is already
+   * checked, this method returns immediately.</li>
+   * <li> Wait for [actionability](./actionability.md) checks on the matched element, unless {@code force} option is set. If the element
+   * is detached during the checks, the whole action is retried.</li>
+   * <li> Scroll the element into view if needed.</li>
+   * <li> Use [{@code property: Page.mouse}] to click in the center of the element.</li>
+   * <li> Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.</li>
+   * <li> Ensure that the element is now checked. If not, this method rejects.</li>
+   * </ol>
    *
    * <p> When all steps combined have not finished during the specified {@code timeout}, this method rejects with a {@code TimeoutError}.
    * Passing zero timeout disables this.
@@ -897,12 +935,14 @@ public interface Frame {
   List<Frame> childFrames();
   /**
    * This method clicks an element matching {@code selector} by performing the following steps:
-   * 1. Find an element match matching {@code selector}. If there is none, wait until a matching element is attached to the DOM.
-   * 1. Wait for [actionability](./actionability.md) checks on the matched element, unless {@code force} option is set. If the
-   *    element is detached during the checks, the whole action is retried.
-   * 1. Scroll the element into view if needed.
-   * 1. Use [{@code property: Page.mouse}] to click in the center of the element, or the specified {@code position}.
-   * 1. Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.
+   * <ol>
+   * <li> Find an element match matching {@code selector}. If there is none, wait until a matching element is attached to the DOM.</li>
+   * <li> Wait for [actionability](./actionability.md) checks on the matched element, unless {@code force} option is set. If the element
+   * is detached during the checks, the whole action is retried.</li>
+   * <li> Scroll the element into view if needed.</li>
+   * <li> Use [{@code property: Page.mouse}] to click in the center of the element, or the specified {@code position}.</li>
+   * <li> Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.</li>
+   * </ol>
    *
    * <p> When all steps combined have not finished during the specified {@code timeout}, this method rejects with a {@code TimeoutError}.
    * Passing zero timeout disables this.
@@ -915,12 +955,14 @@ public interface Frame {
   }
   /**
    * This method clicks an element matching {@code selector} by performing the following steps:
-   * 1. Find an element match matching {@code selector}. If there is none, wait until a matching element is attached to the DOM.
-   * 1. Wait for [actionability](./actionability.md) checks on the matched element, unless {@code force} option is set. If the
-   *    element is detached during the checks, the whole action is retried.
-   * 1. Scroll the element into view if needed.
-   * 1. Use [{@code property: Page.mouse}] to click in the center of the element, or the specified {@code position}.
-   * 1. Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.
+   * <ol>
+   * <li> Find an element match matching {@code selector}. If there is none, wait until a matching element is attached to the DOM.</li>
+   * <li> Wait for [actionability](./actionability.md) checks on the matched element, unless {@code force} option is set. If the element
+   * is detached during the checks, the whole action is retried.</li>
+   * <li> Scroll the element into view if needed.</li>
+   * <li> Use [{@code property: Page.mouse}] to click in the center of the element, or the specified {@code position}.</li>
+   * <li> Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.</li>
+   * </ol>
    *
    * <p> When all steps combined have not finished during the specified {@code timeout}, this method rejects with a {@code TimeoutError}.
    * Passing zero timeout disables this.
@@ -935,13 +977,15 @@ public interface Frame {
   String content();
   /**
    * This method double clicks an element matching {@code selector} by performing the following steps:
-   * 1. Find an element match matching {@code selector}. If there is none, wait until a matching element is attached to the DOM.
-   * 1. Wait for [actionability](./actionability.md) checks on the matched element, unless {@code force} option is set. If the
-   *    element is detached during the checks, the whole action is retried.
-   * 1. Scroll the element into view if needed.
-   * 1. Use [{@code property: Page.mouse}] to double click in the center of the element, or the specified {@code position}.
-   * 1. Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set. Note that if the
-   *    first click of the {@code dblclick()} triggers a navigation event, this method will reject.
+   * <ol>
+   * <li> Find an element match matching {@code selector}. If there is none, wait until a matching element is attached to the DOM.</li>
+   * <li> Wait for [actionability](./actionability.md) checks on the matched element, unless {@code force} option is set. If the element
+   * is detached during the checks, the whole action is retried.</li>
+   * <li> Scroll the element into view if needed.</li>
+   * <li> Use [{@code property: Page.mouse}] to double click in the center of the element, or the specified {@code position}.</li>
+   * <li> Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set. Note that if the first
+   * click of the {@code dblclick()} triggers a navigation event, this method will reject.</li>
+   * </ol>
    *
    * <p> When all steps combined have not finished during the specified {@code timeout}, this method rejects with a {@code TimeoutError}.
    * Passing zero timeout disables this.
@@ -956,13 +1000,15 @@ public interface Frame {
   }
   /**
    * This method double clicks an element matching {@code selector} by performing the following steps:
-   * 1. Find an element match matching {@code selector}. If there is none, wait until a matching element is attached to the DOM.
-   * 1. Wait for [actionability](./actionability.md) checks on the matched element, unless {@code force} option is set. If the
-   *    element is detached during the checks, the whole action is retried.
-   * 1. Scroll the element into view if needed.
-   * 1. Use [{@code property: Page.mouse}] to double click in the center of the element, or the specified {@code position}.
-   * 1. Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set. Note that if the
-   *    first click of the {@code dblclick()} triggers a navigation event, this method will reject.
+   * <ol>
+   * <li> Find an element match matching {@code selector}. If there is none, wait until a matching element is attached to the DOM.</li>
+   * <li> Wait for [actionability](./actionability.md) checks on the matched element, unless {@code force} option is set. If the element
+   * is detached during the checks, the whole action is retried.</li>
+   * <li> Scroll the element into view if needed.</li>
+   * <li> Use [{@code property: Page.mouse}] to double click in the center of the element, or the specified {@code position}.</li>
+   * <li> Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set. Note that if the first
+   * click of the {@code dblclick()} triggers a navigation event, this method will reject.</li>
+   * </ol>
    *
    * <p> When all steps combined have not finished during the specified {@code timeout}, this method rejects with a {@code TimeoutError}.
    * Passing zero timeout disables this.
@@ -977,21 +1023,32 @@ public interface Frame {
    * The snippet below dispatches the {@code click} event on the element. Regardless of the visibility state of the elment, {@code click}
    * is dispatched. This is equivalend to calling
    * [element.click()](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/click).
+   * <pre>{@code
+   * frame.dispatchEvent("button#submit", "click");
+   * }</pre>
    *
    * <p> Under the hood, it creates an instance of an event based on the given {@code type}, initializes it with {@code eventInit} properties
    * and dispatches it on the element. Events are {@code composed}, {@code cancelable} and bubble by default.
    *
    * <p> Since {@code eventInit} is event-specific, please refer to the events documentation for the lists of initial properties:
-   * - [DragEvent](https://developer.mozilla.org/en-US/docs/Web/API/DragEvent/DragEvent)
-   * - [FocusEvent](https://developer.mozilla.org/en-US/docs/Web/API/FocusEvent/FocusEvent)
-   * - [KeyboardEvent](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/KeyboardEvent)
-   * - [MouseEvent](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/MouseEvent)
-   * - [PointerEvent](https://developer.mozilla.org/en-US/docs/Web/API/PointerEvent/PointerEvent)
-   * - [TouchEvent](https://developer.mozilla.org/en-US/docs/Web/API/TouchEvent/TouchEvent)
-   * - [Event](https://developer.mozilla.org/en-US/docs/Web/API/Event/Event)
+   * <ul>
+   * <li> [DragEvent](https://developer.mozilla.org/en-US/docs/Web/API/DragEvent/DragEvent)</li>
+   * <li> [FocusEvent](https://developer.mozilla.org/en-US/docs/Web/API/FocusEvent/FocusEvent)</li>
+   * <li> [KeyboardEvent](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/KeyboardEvent)</li>
+   * <li> [MouseEvent](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/MouseEvent)</li>
+   * <li> [PointerEvent](https://developer.mozilla.org/en-US/docs/Web/API/PointerEvent/PointerEvent)</li>
+   * <li> [TouchEvent](https://developer.mozilla.org/en-US/docs/Web/API/TouchEvent/TouchEvent)</li>
+   * <li> [Event](https://developer.mozilla.org/en-US/docs/Web/API/Event/Event)</li>
+   * </ul>
    *
    * <p> You can also specify {@code JSHandle} as the property value if you want live objects to be passed into the event:
-   *
+   * <pre>{@code
+   * // Note you can only create DataTransfer in Chromium and Firefox
+   * JSHandle dataTransfer = frame.evaluateHandle("() => new DataTransfer()");
+   * Map<String, Object> arg = new HashMap<>();
+   * arg.put("dataTransfer", dataTransfer);
+   * frame.dispatchEvent("#source", "dragstart", arg);
+   * }</pre>
    *
    * @param selector A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See
    * [working with selectors](./selectors.md) for more details.
@@ -1005,21 +1062,32 @@ public interface Frame {
    * The snippet below dispatches the {@code click} event on the element. Regardless of the visibility state of the elment, {@code click}
    * is dispatched. This is equivalend to calling
    * [element.click()](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/click).
+   * <pre>{@code
+   * frame.dispatchEvent("button#submit", "click");
+   * }</pre>
    *
    * <p> Under the hood, it creates an instance of an event based on the given {@code type}, initializes it with {@code eventInit} properties
    * and dispatches it on the element. Events are {@code composed}, {@code cancelable} and bubble by default.
    *
    * <p> Since {@code eventInit} is event-specific, please refer to the events documentation for the lists of initial properties:
-   * - [DragEvent](https://developer.mozilla.org/en-US/docs/Web/API/DragEvent/DragEvent)
-   * - [FocusEvent](https://developer.mozilla.org/en-US/docs/Web/API/FocusEvent/FocusEvent)
-   * - [KeyboardEvent](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/KeyboardEvent)
-   * - [MouseEvent](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/MouseEvent)
-   * - [PointerEvent](https://developer.mozilla.org/en-US/docs/Web/API/PointerEvent/PointerEvent)
-   * - [TouchEvent](https://developer.mozilla.org/en-US/docs/Web/API/TouchEvent/TouchEvent)
-   * - [Event](https://developer.mozilla.org/en-US/docs/Web/API/Event/Event)
+   * <ul>
+   * <li> [DragEvent](https://developer.mozilla.org/en-US/docs/Web/API/DragEvent/DragEvent)</li>
+   * <li> [FocusEvent](https://developer.mozilla.org/en-US/docs/Web/API/FocusEvent/FocusEvent)</li>
+   * <li> [KeyboardEvent](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/KeyboardEvent)</li>
+   * <li> [MouseEvent](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/MouseEvent)</li>
+   * <li> [PointerEvent](https://developer.mozilla.org/en-US/docs/Web/API/PointerEvent/PointerEvent)</li>
+   * <li> [TouchEvent](https://developer.mozilla.org/en-US/docs/Web/API/TouchEvent/TouchEvent)</li>
+   * <li> [Event](https://developer.mozilla.org/en-US/docs/Web/API/Event/Event)</li>
+   * </ul>
    *
    * <p> You can also specify {@code JSHandle} as the property value if you want live objects to be passed into the event:
-   *
+   * <pre>{@code
+   * // Note you can only create DataTransfer in Chromium and Firefox
+   * JSHandle dataTransfer = frame.evaluateHandle("() => new DataTransfer()");
+   * Map<String, Object> arg = new HashMap<>();
+   * arg.put("dataTransfer", dataTransfer);
+   * frame.dispatchEvent("#source", "dragstart", arg);
+   * }</pre>
    *
    * @param selector A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See
    * [working with selectors](./selectors.md) for more details.
@@ -1032,21 +1100,32 @@ public interface Frame {
    * The snippet below dispatches the {@code click} event on the element. Regardless of the visibility state of the elment, {@code click}
    * is dispatched. This is equivalend to calling
    * [element.click()](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/click).
+   * <pre>{@code
+   * frame.dispatchEvent("button#submit", "click");
+   * }</pre>
    *
    * <p> Under the hood, it creates an instance of an event based on the given {@code type}, initializes it with {@code eventInit} properties
    * and dispatches it on the element. Events are {@code composed}, {@code cancelable} and bubble by default.
    *
    * <p> Since {@code eventInit} is event-specific, please refer to the events documentation for the lists of initial properties:
-   * - [DragEvent](https://developer.mozilla.org/en-US/docs/Web/API/DragEvent/DragEvent)
-   * - [FocusEvent](https://developer.mozilla.org/en-US/docs/Web/API/FocusEvent/FocusEvent)
-   * - [KeyboardEvent](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/KeyboardEvent)
-   * - [MouseEvent](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/MouseEvent)
-   * - [PointerEvent](https://developer.mozilla.org/en-US/docs/Web/API/PointerEvent/PointerEvent)
-   * - [TouchEvent](https://developer.mozilla.org/en-US/docs/Web/API/TouchEvent/TouchEvent)
-   * - [Event](https://developer.mozilla.org/en-US/docs/Web/API/Event/Event)
+   * <ul>
+   * <li> [DragEvent](https://developer.mozilla.org/en-US/docs/Web/API/DragEvent/DragEvent)</li>
+   * <li> [FocusEvent](https://developer.mozilla.org/en-US/docs/Web/API/FocusEvent/FocusEvent)</li>
+   * <li> [KeyboardEvent](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/KeyboardEvent)</li>
+   * <li> [MouseEvent](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/MouseEvent)</li>
+   * <li> [PointerEvent](https://developer.mozilla.org/en-US/docs/Web/API/PointerEvent/PointerEvent)</li>
+   * <li> [TouchEvent](https://developer.mozilla.org/en-US/docs/Web/API/TouchEvent/TouchEvent)</li>
+   * <li> [Event](https://developer.mozilla.org/en-US/docs/Web/API/Event/Event)</li>
+   * </ul>
    *
    * <p> You can also specify {@code JSHandle} as the property value if you want live objects to be passed into the event:
-   *
+   * <pre>{@code
+   * // Note you can only create DataTransfer in Chromium and Firefox
+   * JSHandle dataTransfer = frame.evaluateHandle("() => new DataTransfer()");
+   * Map<String, Object> arg = new HashMap<>();
+   * arg.put("dataTransfer", dataTransfer);
+   * frame.dispatchEvent("#source", "dragstart", arg);
+   * }</pre>
    *
    * @param selector A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See
    * [working with selectors](./selectors.md) for more details.
@@ -1064,6 +1143,12 @@ public interface Frame {
    * <p> If {@code expression} returns a [Promise], then [{@code method: Frame.evalOnSelector}] would wait for the promise to resolve and
    * return its value.
    *
+   * <p> Examples:
+   * <pre>{@code
+   * String searchValue = (String) frame.evalOnSelector("#search", "el => el.value");
+   * String preloadHref = (String) frame.evalOnSelector("link[rel=preload]", "el => el.href");
+   * String html = (String) frame.evalOnSelector(".main-container", "(e, suffix) => e.outerHTML + suffix", "hello");
+   * }</pre>
    *
    * @param selector A selector to query for. See [working with selectors](./selectors.md) for more details.
    * @param expression JavaScript expression to be evaluated in the browser context. If it looks like a function declaration, it is interpreted
@@ -1082,6 +1167,12 @@ public interface Frame {
    * <p> If {@code expression} returns a [Promise], then [{@code method: Frame.evalOnSelector}] would wait for the promise to resolve and
    * return its value.
    *
+   * <p> Examples:
+   * <pre>{@code
+   * String searchValue = (String) frame.evalOnSelector("#search", "el => el.value");
+   * String preloadHref = (String) frame.evalOnSelector("link[rel=preload]", "el => el.href");
+   * String html = (String) frame.evalOnSelector(".main-container", "(e, suffix) => e.outerHTML + suffix", "hello");
+   * }</pre>
    *
    * @param selector A selector to query for. See [working with selectors](./selectors.md) for more details.
    * @param expression JavaScript expression to be evaluated in the browser context. If it looks like a function declaration, it is interpreted
@@ -1098,6 +1189,10 @@ public interface Frame {
    * <p> If {@code expression} returns a [Promise], then [{@code method: Frame.evalOnSelectorAll}] would wait for the promise to resolve and
    * return its value.
    *
+   * <p> Examples:
+   * <pre>{@code
+   * boolean divsCounts = (boolean) page.evalOnSelectorAll("div", "(divs, min) => divs.length >= min", 10);
+   * }</pre>
    *
    * @param selector A selector to query for. See [working with selectors](./selectors.md) for more details.
    * @param expression JavaScript expression to be evaluated in the browser context. If it looks like a function declaration, it is interpreted
@@ -1115,6 +1210,10 @@ public interface Frame {
    * <p> If {@code expression} returns a [Promise], then [{@code method: Frame.evalOnSelectorAll}] would wait for the promise to resolve and
    * return its value.
    *
+   * <p> Examples:
+   * <pre>{@code
+   * boolean divsCounts = (boolean) page.evalOnSelectorAll("div", "(divs, min) => divs.length >= min", 10);
+   * }</pre>
    *
    * @param selector A selector to query for. See [working with selectors](./selectors.md) for more details.
    * @param expression JavaScript expression to be evaluated in the browser context. If it looks like a function declaration, it is interpreted
@@ -1131,11 +1230,24 @@ public interface Frame {
    * <p> If the function passed to the [{@code method: Frame.evaluate}] returns a non-[Serializable] value, then
    * [{@code method: Frame.evaluate}] returns {@code undefined}. Playwright also supports transferring some additional values that are
    * not serializable by {@code JSON}: {@code -0}, {@code NaN}, {@code Infinity}, {@code -Infinity}.
+   * <pre>{@code
+   * Object result = frame.evaluate("([x, y]) => {\n" +
+   *   "  return Promise.resolve(x * y);\n" +
+   *   "}", Arrays.asList(7, 8));
+   * System.out.println(result); // prints "56"
+   * }</pre>
    *
    * <p> A string can also be passed in instead of a function.
+   * <pre>{@code
+   * System.out.println(frame.evaluate("1 + 2")); // prints "3"
+   * }</pre>
    *
    * <p> {@code ElementHandle} instances can be passed as an argument to the [{@code method: Frame.evaluate}]:
-   *
+   * <pre>{@code
+   * ElementHandle bodyHandle = frame.querySelector("body");
+   * String html = (String) frame.evaluate("([body, suffix]) => body.innerHTML + suffix", Arrays.asList(bodyHandle, "hello"));
+   * bodyHandle.dispose();
+   * }</pre>
    *
    * @param expression JavaScript expression to be evaluated in the browser context. If it looks like a function declaration, it is interpreted
    * as a function. Otherwise, evaluated as an expression.
@@ -1152,11 +1264,24 @@ public interface Frame {
    * <p> If the function passed to the [{@code method: Frame.evaluate}] returns a non-[Serializable] value, then
    * [{@code method: Frame.evaluate}] returns {@code undefined}. Playwright also supports transferring some additional values that are
    * not serializable by {@code JSON}: {@code -0}, {@code NaN}, {@code Infinity}, {@code -Infinity}.
+   * <pre>{@code
+   * Object result = frame.evaluate("([x, y]) => {\n" +
+   *   "  return Promise.resolve(x * y);\n" +
+   *   "}", Arrays.asList(7, 8));
+   * System.out.println(result); // prints "56"
+   * }</pre>
    *
    * <p> A string can also be passed in instead of a function.
+   * <pre>{@code
+   * System.out.println(frame.evaluate("1 + 2")); // prints "3"
+   * }</pre>
    *
    * <p> {@code ElementHandle} instances can be passed as an argument to the [{@code method: Frame.evaluate}]:
-   *
+   * <pre>{@code
+   * ElementHandle bodyHandle = frame.querySelector("body");
+   * String html = (String) frame.evaluate("([body, suffix]) => body.innerHTML + suffix", Arrays.asList(bodyHandle, "hello"));
+   * bodyHandle.dispose();
+   * }</pre>
    *
    * @param expression JavaScript expression to be evaluated in the browser context. If it looks like a function declaration, it is interpreted
    * as a function. Otherwise, evaluated as an expression.
@@ -1171,11 +1296,23 @@ public interface Frame {
    *
    * <p> If the function, passed to the [{@code method: Frame.evaluateHandle}], returns a [Promise], then
    * [{@code method: Frame.evaluateHandle}] would wait for the promise to resolve and return its value.
+   * <pre>{@code
+   * // Handle for the window object.
+   * JSHandle aWindowHandle = frame.evaluateHandle("() => Promise.resolve(window)");
+   * }</pre>
    *
    * <p> A string can also be passed in instead of a function.
+   * <pre>{@code
+   * JSHandle aHandle = frame.evaluateHandle("document"); // Handle for the "document".
+   * }</pre>
    *
    * <p> {@code JSHandle} instances can be passed as an argument to the [{@code method: Frame.evaluateHandle}]:
-   *
+   * <pre>{@code
+   * JSHandle aHandle = frame.evaluateHandle("() => document.body");
+   * JSHandle resultHandle = frame.evaluateHandle("([body, suffix]) => body.innerHTML + suffix", Arrays.asList(aHandle, "hello"));
+   * System.out.println(resultHandle.jsonValue());
+   * resultHandle.dispose();
+   * }</pre>
    *
    * @param expression JavaScript expression to be evaluated in the browser context. If it looks like a function declaration, it is interpreted
    * as a function. Otherwise, evaluated as an expression.
@@ -1191,11 +1328,23 @@ public interface Frame {
    *
    * <p> If the function, passed to the [{@code method: Frame.evaluateHandle}], returns a [Promise], then
    * [{@code method: Frame.evaluateHandle}] would wait for the promise to resolve and return its value.
+   * <pre>{@code
+   * // Handle for the window object.
+   * JSHandle aWindowHandle = frame.evaluateHandle("() => Promise.resolve(window)");
+   * }</pre>
    *
    * <p> A string can also be passed in instead of a function.
+   * <pre>{@code
+   * JSHandle aHandle = frame.evaluateHandle("document"); // Handle for the "document".
+   * }</pre>
    *
    * <p> {@code JSHandle} instances can be passed as an argument to the [{@code method: Frame.evaluateHandle}]:
-   *
+   * <pre>{@code
+   * JSHandle aHandle = frame.evaluateHandle("() => document.body");
+   * JSHandle resultHandle = frame.evaluateHandle("([body, suffix]) => body.innerHTML + suffix", Arrays.asList(aHandle, "hello"));
+   * System.out.println(resultHandle.jsonValue());
+   * resultHandle.dispose();
+   * }</pre>
    *
    * @param expression JavaScript expression to be evaluated in the browser context. If it looks like a function declaration, it is interpreted
    * as a function. Otherwise, evaluated as an expression.
@@ -1257,6 +1406,11 @@ public interface Frame {
    * frame.
    *
    * <p> This method throws an error if the frame has been detached before {@code frameElement()} returns.
+   * <pre>{@code
+   * ElementHandle frameElement = frame.frameElement();
+   * Frame contentFrame = frameElement.contentFrame();
+   * System.out.println(frame == contentFrame);  // -> true
+   * }</pre>
    */
   ElementHandle frameElement();
   /**
@@ -1282,11 +1436,13 @@ public interface Frame {
    * last redirect.
    *
    * <p> {@code frame.goto} will throw an error if:
-   * - there's an SSL error (e.g. in case of self-signed certificates).
-   * - target URL is invalid.
-   * - the {@code timeout} is exceeded during navigation.
-   * - the remote server does not respond or is unreachable.
-   * - the main resource failed to load.
+   * <ul>
+   * <li> there's an SSL error (e.g. in case of self-signed certificates).</li>
+   * <li> target URL is invalid.</li>
+   * <li> the {@code timeout} is exceeded during navigation.</li>
+   * <li> the remote server does not respond or is unreachable.</li>
+   * <li> the main resource failed to load.</li>
+   * </ul>
    *
    * <p> {@code frame.goto} will not throw an error when any valid HTTP status code is returned by the remote server, including 404
    * "Not Found" and 500 "Internal Server Error".  The status code for such responses can be retrieved by calling
@@ -1294,7 +1450,8 @@ public interface Frame {
    *
    * <p> <strong>NOTE:</strong> {@code frame.goto} either throws an error or returns a main resource response. The only exceptions are navigation to
    * {@code about:blank} or navigation to the same URL with a different hash, which would succeed and return {@code null}.
-   * <strong>NOTE:</strong> Headless mode doesn't support navigation to a PDF document. See the
+   *
+   * <p> <strong>NOTE:</strong> Headless mode doesn't support navigation to a PDF document. See the
    * [upstream issue](https://bugs.chromium.org/p/chromium/issues/detail?id=761295).
    *
    * @param url URL to navigate frame to. The url should include scheme, e.g. {@code https://}.
@@ -1307,11 +1464,13 @@ public interface Frame {
    * last redirect.
    *
    * <p> {@code frame.goto} will throw an error if:
-   * - there's an SSL error (e.g. in case of self-signed certificates).
-   * - target URL is invalid.
-   * - the {@code timeout} is exceeded during navigation.
-   * - the remote server does not respond or is unreachable.
-   * - the main resource failed to load.
+   * <ul>
+   * <li> there's an SSL error (e.g. in case of self-signed certificates).</li>
+   * <li> target URL is invalid.</li>
+   * <li> the {@code timeout} is exceeded during navigation.</li>
+   * <li> the remote server does not respond or is unreachable.</li>
+   * <li> the main resource failed to load.</li>
+   * </ul>
    *
    * <p> {@code frame.goto} will not throw an error when any valid HTTP status code is returned by the remote server, including 404
    * "Not Found" and 500 "Internal Server Error".  The status code for such responses can be retrieved by calling
@@ -1319,7 +1478,8 @@ public interface Frame {
    *
    * <p> <strong>NOTE:</strong> {@code frame.goto} either throws an error or returns a main resource response. The only exceptions are navigation to
    * {@code about:blank} or navigation to the same URL with a different hash, which would succeed and return {@code null}.
-   * <strong>NOTE:</strong> Headless mode doesn't support navigation to a PDF document. See the
+   *
+   * <p> <strong>NOTE:</strong> Headless mode doesn't support navigation to a PDF document. See the
    * [upstream issue](https://bugs.chromium.org/p/chromium/issues/detail?id=761295).
    *
    * @param url URL to navigate frame to. The url should include scheme, e.g. {@code https://}.
@@ -1327,12 +1487,14 @@ public interface Frame {
   Response navigate(String url, NavigateOptions options);
   /**
    * This method hovers over an element matching {@code selector} by performing the following steps:
-   * 1. Find an element match matching {@code selector}. If there is none, wait until a matching element is attached to the DOM.
-   * 1. Wait for [actionability](./actionability.md) checks on the matched element, unless {@code force} option is set. If the
-   *    element is detached during the checks, the whole action is retried.
-   * 1. Scroll the element into view if needed.
-   * 1. Use [{@code property: Page.mouse}] to hover over the center of the element, or the specified {@code position}.
-   * 1. Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.
+   * <ol>
+   * <li> Find an element match matching {@code selector}. If there is none, wait until a matching element is attached to the DOM.</li>
+   * <li> Wait for [actionability](./actionability.md) checks on the matched element, unless {@code force} option is set. If the element
+   * is detached during the checks, the whole action is retried.</li>
+   * <li> Scroll the element into view if needed.</li>
+   * <li> Use [{@code property: Page.mouse}] to hover over the center of the element, or the specified {@code position}.</li>
+   * <li> Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.</li>
+   * </ol>
    *
    * <p> When all steps combined have not finished during the specified {@code timeout}, this method rejects with a {@code TimeoutError}.
    * Passing zero timeout disables this.
@@ -1345,12 +1507,14 @@ public interface Frame {
   }
   /**
    * This method hovers over an element matching {@code selector} by performing the following steps:
-   * 1. Find an element match matching {@code selector}. If there is none, wait until a matching element is attached to the DOM.
-   * 1. Wait for [actionability](./actionability.md) checks on the matched element, unless {@code force} option is set. If the
-   *    element is detached during the checks, the whole action is retried.
-   * 1. Scroll the element into view if needed.
-   * 1. Use [{@code property: Page.mouse}] to hover over the center of the element, or the specified {@code position}.
-   * 1. Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.
+   * <ol>
+   * <li> Find an element match matching {@code selector}. If there is none, wait until a matching element is attached to the DOM.</li>
+   * <li> Wait for [actionability](./actionability.md) checks on the matched element, unless {@code force} option is set. If the element
+   * is detached during the checks, the whole action is retried.</li>
+   * <li> Scroll the element into view if needed.</li>
+   * <li> Use [{@code property: Page.mouse}] to hover over the center of the element, or the specified {@code position}.</li>
+   * <li> Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.</li>
+   * </ol>
    *
    * <p> When all steps combined have not finished during the specified {@code timeout}, this method rejects with a {@code TimeoutError}.
    * Passing zero timeout disables this.
@@ -1584,7 +1748,14 @@ public interface Frame {
    * matching {@code selector}, the method throws an error.
    *
    * <p> Will wait until all specified options are present in the {@code <select>} element.
-   *
+   * <pre>{@code
+   * // single selection matching the value
+   * frame.selectOption("select#colors", "blue");
+   * // single selection matching both the value and the label
+   * frame.selectOption("select#colors", new SelectOption().withLabel("Blue"));
+   * // multiple selection
+   * frame.selectOption("select#colors", new String[] {"red", "green", "blue"});
+   * }</pre>
    *
    * @param selector A selector to query for. See [working with selectors](./selectors.md) for more details.
    * @param values Options to select. If the {@code <select>} has the {@code multiple} attribute, all matching options are selected, otherwise only the
@@ -1601,7 +1772,14 @@ public interface Frame {
    * matching {@code selector}, the method throws an error.
    *
    * <p> Will wait until all specified options are present in the {@code <select>} element.
-   *
+   * <pre>{@code
+   * // single selection matching the value
+   * frame.selectOption("select#colors", "blue");
+   * // single selection matching both the value and the label
+   * frame.selectOption("select#colors", new SelectOption().withLabel("Blue"));
+   * // multiple selection
+   * frame.selectOption("select#colors", new String[] {"red", "green", "blue"});
+   * }</pre>
    *
    * @param selector A selector to query for. See [working with selectors](./selectors.md) for more details.
    * @param values Options to select. If the {@code <select>} has the {@code multiple} attribute, all matching options are selected, otherwise only the
@@ -1616,7 +1794,14 @@ public interface Frame {
    * matching {@code selector}, the method throws an error.
    *
    * <p> Will wait until all specified options are present in the {@code <select>} element.
-   *
+   * <pre>{@code
+   * // single selection matching the value
+   * frame.selectOption("select#colors", "blue");
+   * // single selection matching both the value and the label
+   * frame.selectOption("select#colors", new SelectOption().withLabel("Blue"));
+   * // multiple selection
+   * frame.selectOption("select#colors", new String[] {"red", "green", "blue"});
+   * }</pre>
    *
    * @param selector A selector to query for. See [working with selectors](./selectors.md) for more details.
    * @param values Options to select. If the {@code <select>} has the {@code multiple} attribute, all matching options are selected, otherwise only the
@@ -1633,7 +1818,14 @@ public interface Frame {
    * matching {@code selector}, the method throws an error.
    *
    * <p> Will wait until all specified options are present in the {@code <select>} element.
-   *
+   * <pre>{@code
+   * // single selection matching the value
+   * frame.selectOption("select#colors", "blue");
+   * // single selection matching both the value and the label
+   * frame.selectOption("select#colors", new SelectOption().withLabel("Blue"));
+   * // multiple selection
+   * frame.selectOption("select#colors", new String[] {"red", "green", "blue"});
+   * }</pre>
    *
    * @param selector A selector to query for. See [working with selectors](./selectors.md) for more details.
    * @param values Options to select. If the {@code <select>} has the {@code multiple} attribute, all matching options are selected, otherwise only the
@@ -1648,7 +1840,14 @@ public interface Frame {
    * matching {@code selector}, the method throws an error.
    *
    * <p> Will wait until all specified options are present in the {@code <select>} element.
-   *
+   * <pre>{@code
+   * // single selection matching the value
+   * frame.selectOption("select#colors", "blue");
+   * // single selection matching both the value and the label
+   * frame.selectOption("select#colors", new SelectOption().withLabel("Blue"));
+   * // multiple selection
+   * frame.selectOption("select#colors", new String[] {"red", "green", "blue"});
+   * }</pre>
    *
    * @param selector A selector to query for. See [working with selectors](./selectors.md) for more details.
    * @param values Options to select. If the {@code <select>} has the {@code multiple} attribute, all matching options are selected, otherwise only the
@@ -1665,7 +1864,14 @@ public interface Frame {
    * matching {@code selector}, the method throws an error.
    *
    * <p> Will wait until all specified options are present in the {@code <select>} element.
-   *
+   * <pre>{@code
+   * // single selection matching the value
+   * frame.selectOption("select#colors", "blue");
+   * // single selection matching both the value and the label
+   * frame.selectOption("select#colors", new SelectOption().withLabel("Blue"));
+   * // multiple selection
+   * frame.selectOption("select#colors", new String[] {"red", "green", "blue"});
+   * }</pre>
    *
    * @param selector A selector to query for. See [working with selectors](./selectors.md) for more details.
    * @param values Options to select. If the {@code <select>} has the {@code multiple} attribute, all matching options are selected, otherwise only the
@@ -1680,7 +1886,14 @@ public interface Frame {
    * matching {@code selector}, the method throws an error.
    *
    * <p> Will wait until all specified options are present in the {@code <select>} element.
-   *
+   * <pre>{@code
+   * // single selection matching the value
+   * frame.selectOption("select#colors", "blue");
+   * // single selection matching both the value and the label
+   * frame.selectOption("select#colors", new SelectOption().withLabel("Blue"));
+   * // multiple selection
+   * frame.selectOption("select#colors", new String[] {"red", "green", "blue"});
+   * }</pre>
    *
    * @param selector A selector to query for. See [working with selectors](./selectors.md) for more details.
    * @param values Options to select. If the {@code <select>} has the {@code multiple} attribute, all matching options are selected, otherwise only the
@@ -1697,7 +1910,14 @@ public interface Frame {
    * matching {@code selector}, the method throws an error.
    *
    * <p> Will wait until all specified options are present in the {@code <select>} element.
-   *
+   * <pre>{@code
+   * // single selection matching the value
+   * frame.selectOption("select#colors", "blue");
+   * // single selection matching both the value and the label
+   * frame.selectOption("select#colors", new SelectOption().withLabel("Blue"));
+   * // multiple selection
+   * frame.selectOption("select#colors", new String[] {"red", "green", "blue"});
+   * }</pre>
    *
    * @param selector A selector to query for. See [working with selectors](./selectors.md) for more details.
    * @param values Options to select. If the {@code <select>} has the {@code multiple} attribute, all matching options are selected, otherwise only the
@@ -1712,7 +1932,14 @@ public interface Frame {
    * matching {@code selector}, the method throws an error.
    *
    * <p> Will wait until all specified options are present in the {@code <select>} element.
-   *
+   * <pre>{@code
+   * // single selection matching the value
+   * frame.selectOption("select#colors", "blue");
+   * // single selection matching both the value and the label
+   * frame.selectOption("select#colors", new SelectOption().withLabel("Blue"));
+   * // multiple selection
+   * frame.selectOption("select#colors", new String[] {"red", "green", "blue"});
+   * }</pre>
    *
    * @param selector A selector to query for. See [working with selectors](./selectors.md) for more details.
    * @param values Options to select. If the {@code <select>} has the {@code multiple} attribute, all matching options are selected, otherwise only the
@@ -1729,7 +1956,14 @@ public interface Frame {
    * matching {@code selector}, the method throws an error.
    *
    * <p> Will wait until all specified options are present in the {@code <select>} element.
-   *
+   * <pre>{@code
+   * // single selection matching the value
+   * frame.selectOption("select#colors", "blue");
+   * // single selection matching both the value and the label
+   * frame.selectOption("select#colors", new SelectOption().withLabel("Blue"));
+   * // multiple selection
+   * frame.selectOption("select#colors", new String[] {"red", "green", "blue"});
+   * }</pre>
    *
    * @param selector A selector to query for. See [working with selectors](./selectors.md) for more details.
    * @param values Options to select. If the {@code <select>} has the {@code multiple} attribute, all matching options are selected, otherwise only the
@@ -1744,7 +1978,14 @@ public interface Frame {
    * matching {@code selector}, the method throws an error.
    *
    * <p> Will wait until all specified options are present in the {@code <select>} element.
-   *
+   * <pre>{@code
+   * // single selection matching the value
+   * frame.selectOption("select#colors", "blue");
+   * // single selection matching both the value and the label
+   * frame.selectOption("select#colors", new SelectOption().withLabel("Blue"));
+   * // multiple selection
+   * frame.selectOption("select#colors", new String[] {"red", "green", "blue"});
+   * }</pre>
    *
    * @param selector A selector to query for. See [working with selectors](./selectors.md) for more details.
    * @param values Options to select. If the {@code <select>} has the {@code multiple} attribute, all matching options are selected, otherwise only the
@@ -1761,7 +2002,14 @@ public interface Frame {
    * matching {@code selector}, the method throws an error.
    *
    * <p> Will wait until all specified options are present in the {@code <select>} element.
-   *
+   * <pre>{@code
+   * // single selection matching the value
+   * frame.selectOption("select#colors", "blue");
+   * // single selection matching both the value and the label
+   * frame.selectOption("select#colors", new SelectOption().withLabel("Blue"));
+   * // multiple selection
+   * frame.selectOption("select#colors", new String[] {"red", "green", "blue"});
+   * }</pre>
    *
    * @param selector A selector to query for. See [working with selectors](./selectors.md) for more details.
    * @param values Options to select. If the {@code <select>} has the {@code multiple} attribute, all matching options are selected, otherwise only the
@@ -1881,12 +2129,14 @@ public interface Frame {
   void setInputFiles(String selector, FilePayload[] files, SetInputFilesOptions options);
   /**
    * This method taps an element matching {@code selector} by performing the following steps:
-   * 1. Find an element match matching {@code selector}. If there is none, wait until a matching element is attached to the DOM.
-   * 1. Wait for [actionability](./actionability.md) checks on the matched element, unless {@code force} option is set. If the
-   *    element is detached during the checks, the whole action is retried.
-   * 1. Scroll the element into view if needed.
-   * 1. Use [{@code property: Page.touchscreen}] to tap the center of the element, or the specified {@code position}.
-   * 1. Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.
+   * <ol>
+   * <li> Find an element match matching {@code selector}. If there is none, wait until a matching element is attached to the DOM.</li>
+   * <li> Wait for [actionability](./actionability.md) checks on the matched element, unless {@code force} option is set. If the element
+   * is detached during the checks, the whole action is retried.</li>
+   * <li> Scroll the element into view if needed.</li>
+   * <li> Use [{@code property: Page.touchscreen}] to tap the center of the element, or the specified {@code position}.</li>
+   * <li> Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.</li>
+   * </ol>
    *
    * <p> When all steps combined have not finished during the specified {@code timeout}, this method rejects with a {@code TimeoutError}.
    * Passing zero timeout disables this.
@@ -1901,12 +2151,14 @@ public interface Frame {
   }
   /**
    * This method taps an element matching {@code selector} by performing the following steps:
-   * 1. Find an element match matching {@code selector}. If there is none, wait until a matching element is attached to the DOM.
-   * 1. Wait for [actionability](./actionability.md) checks on the matched element, unless {@code force} option is set. If the
-   *    element is detached during the checks, the whole action is retried.
-   * 1. Scroll the element into view if needed.
-   * 1. Use [{@code property: Page.touchscreen}] to tap the center of the element, or the specified {@code position}.
-   * 1. Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.
+   * <ol>
+   * <li> Find an element match matching {@code selector}. If there is none, wait until a matching element is attached to the DOM.</li>
+   * <li> Wait for [actionability](./actionability.md) checks on the matched element, unless {@code force} option is set. If the element
+   * is detached during the checks, the whole action is retried.</li>
+   * <li> Scroll the element into view if needed.</li>
+   * <li> Use [{@code property: Page.touchscreen}] to tap the center of the element, or the specified {@code position}.</li>
+   * <li> Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.</li>
+   * </ol>
    *
    * <p> When all steps combined have not finished during the specified {@code timeout}, this method rejects with a {@code TimeoutError}.
    * Passing zero timeout disables this.
@@ -1942,7 +2194,12 @@ public interface Frame {
    * send fine-grained keyboard events. To fill values in form fields, use [{@code method: Frame.fill}].
    *
    * <p> To press a special key, like {@code Control} or {@code ArrowDown}, use [{@code method: Keyboard.press}].
-   *
+   * <pre>{@code
+   * // Types instantly
+   * frame.type("#mytextarea", "Hello");
+   * // Types slower, like a user
+   * frame.type("#mytextarea", "World", new Frame.TypeOptions().withDelay(100)); 
+   * }</pre>
    *
    * @param selector A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See
    * [working with selectors](./selectors.md) for more details.
@@ -1956,7 +2213,12 @@ public interface Frame {
    * send fine-grained keyboard events. To fill values in form fields, use [{@code method: Frame.fill}].
    *
    * <p> To press a special key, like {@code Control} or {@code ArrowDown}, use [{@code method: Keyboard.press}].
-   *
+   * <pre>{@code
+   * // Types instantly
+   * frame.type("#mytextarea", "Hello");
+   * // Types slower, like a user
+   * frame.type("#mytextarea", "World", new Frame.TypeOptions().withDelay(100)); 
+   * }</pre>
    *
    * @param selector A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See
    * [working with selectors](./selectors.md) for more details.
@@ -1965,15 +2227,17 @@ public interface Frame {
   void type(String selector, String text, TypeOptions options);
   /**
    * This method checks an element matching {@code selector} by performing the following steps:
-   * 1. Find an element match matching {@code selector}. If there is none, wait until a matching element is attached to the DOM.
-   * 1. Ensure that matched element is a checkbox or a radio input. If not, this method rejects. If the element is already
-   *    unchecked, this method returns immediately.
-   * 1. Wait for [actionability](./actionability.md) checks on the matched element, unless {@code force} option is set. If the
-   *    element is detached during the checks, the whole action is retried.
-   * 1. Scroll the element into view if needed.
-   * 1. Use [{@code property: Page.mouse}] to click in the center of the element.
-   * 1. Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.
-   * 1. Ensure that the element is now unchecked. If not, this method rejects.
+   * <ol>
+   * <li> Find an element match matching {@code selector}. If there is none, wait until a matching element is attached to the DOM.</li>
+   * <li> Ensure that matched element is a checkbox or a radio input. If not, this method rejects. If the element is already
+   * unchecked, this method returns immediately.</li>
+   * <li> Wait for [actionability](./actionability.md) checks on the matched element, unless {@code force} option is set. If the element
+   * is detached during the checks, the whole action is retried.</li>
+   * <li> Scroll the element into view if needed.</li>
+   * <li> Use [{@code property: Page.mouse}] to click in the center of the element.</li>
+   * <li> Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.</li>
+   * <li> Ensure that the element is now unchecked. If not, this method rejects.</li>
+   * </ol>
    *
    * <p> When all steps combined have not finished during the specified {@code timeout}, this method rejects with a {@code TimeoutError}.
    * Passing zero timeout disables this.
@@ -1986,15 +2250,17 @@ public interface Frame {
   }
   /**
    * This method checks an element matching {@code selector} by performing the following steps:
-   * 1. Find an element match matching {@code selector}. If there is none, wait until a matching element is attached to the DOM.
-   * 1. Ensure that matched element is a checkbox or a radio input. If not, this method rejects. If the element is already
-   *    unchecked, this method returns immediately.
-   * 1. Wait for [actionability](./actionability.md) checks on the matched element, unless {@code force} option is set. If the
-   *    element is detached during the checks, the whole action is retried.
-   * 1. Scroll the element into view if needed.
-   * 1. Use [{@code property: Page.mouse}] to click in the center of the element.
-   * 1. Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.
-   * 1. Ensure that the element is now unchecked. If not, this method rejects.
+   * <ol>
+   * <li> Find an element match matching {@code selector}. If there is none, wait until a matching element is attached to the DOM.</li>
+   * <li> Ensure that matched element is a checkbox or a radio input. If not, this method rejects. If the element is already
+   * unchecked, this method returns immediately.</li>
+   * <li> Wait for [actionability](./actionability.md) checks on the matched element, unless {@code force} option is set. If the element
+   * is detached during the checks, the whole action is retried.</li>
+   * <li> Scroll the element into view if needed.</li>
+   * <li> Use [{@code property: Page.mouse}] to click in the center of the element.</li>
+   * <li> Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.</li>
+   * <li> Ensure that the element is now unchecked. If not, this method rejects.</li>
+   * </ol>
    *
    * <p> When all steps combined have not finished during the specified {@code timeout}, this method rejects with a {@code TimeoutError}.
    * Passing zero timeout disables this.
@@ -2011,9 +2277,28 @@ public interface Frame {
    * Returns when the {@code expression} returns a truthy value, returns that value.
    *
    * <p> The [{@code method: Frame.waitForFunction}] can be used to observe viewport size change:
+   * <pre>{@code
+   * import com.microsoft.playwright.*;
+   *
+   * public class Example {
+   *   public static void main(String[] args) {
+   *     try (Playwright playwright = Playwright.create()) {
+   *       BrowserType firefox = playwright.firefox();
+   *       Browser browser = firefox.launch();
+   *       Page page = browser.newPage();
+   *       page.setViewportSize(50, 50);
+   *       page.mainFrame().waitForFunction("window.innerWidth < 100");
+   *       browser.close();
+   *     }
+   *   }
+   * }
+   * }</pre>
    *
    * <p> To pass an argument to the predicate of {@code frame.waitForFunction} function:
-   *
+   * <pre>{@code
+   * String selector = ".foo";
+   * frame.waitForFunction("selector => !!document.querySelector(selector)", selector);
+   * }</pre>
    *
    * @param expression JavaScript expression to be evaluated in the browser context. If it looks like a function declaration, it is interpreted
    * as a function. Otherwise, evaluated as an expression.
@@ -2026,9 +2311,28 @@ public interface Frame {
    * Returns when the {@code expression} returns a truthy value, returns that value.
    *
    * <p> The [{@code method: Frame.waitForFunction}] can be used to observe viewport size change:
+   * <pre>{@code
+   * import com.microsoft.playwright.*;
+   *
+   * public class Example {
+   *   public static void main(String[] args) {
+   *     try (Playwright playwright = Playwright.create()) {
+   *       BrowserType firefox = playwright.firefox();
+   *       Browser browser = firefox.launch();
+   *       Page page = browser.newPage();
+   *       page.setViewportSize(50, 50);
+   *       page.mainFrame().waitForFunction("window.innerWidth < 100");
+   *       browser.close();
+   *     }
+   *   }
+   * }
+   * }</pre>
    *
    * <p> To pass an argument to the predicate of {@code frame.waitForFunction} function:
-   *
+   * <pre>{@code
+   * String selector = ".foo";
+   * frame.waitForFunction("selector => !!document.querySelector(selector)", selector);
+   * }</pre>
    *
    * @param expression JavaScript expression to be evaluated in the browser context. If it looks like a function declaration, it is interpreted
    * as a function. Otherwise, evaluated as an expression.
@@ -2040,9 +2344,28 @@ public interface Frame {
    * Returns when the {@code expression} returns a truthy value, returns that value.
    *
    * <p> The [{@code method: Frame.waitForFunction}] can be used to observe viewport size change:
+   * <pre>{@code
+   * import com.microsoft.playwright.*;
+   *
+   * public class Example {
+   *   public static void main(String[] args) {
+   *     try (Playwright playwright = Playwright.create()) {
+   *       BrowserType firefox = playwright.firefox();
+   *       Browser browser = firefox.launch();
+   *       Page page = browser.newPage();
+   *       page.setViewportSize(50, 50);
+   *       page.mainFrame().waitForFunction("window.innerWidth < 100");
+   *       browser.close();
+   *     }
+   *   }
+   * }
+   * }</pre>
    *
    * <p> To pass an argument to the predicate of {@code frame.waitForFunction} function:
-   *
+   * <pre>{@code
+   * String selector = ".foo";
+   * frame.waitForFunction("selector => !!document.querySelector(selector)", selector);
+   * }</pre>
    *
    * @param expression JavaScript expression to be evaluated in the browser context. If it looks like a function declaration, it is interpreted
    * as a function. Otherwise, evaluated as an expression.
@@ -2054,13 +2377,18 @@ public interface Frame {
    *
    * <p> This returns when the frame reaches a required load state, {@code load} by default. The navigation must have been committed
    * when this method is called. If current document has already reached the required state, resolves immediately.
-   *
+   * <pre>{@code
+   * frame.click("button"); // Click triggers navigation.
+   * frame.waitForLoadState(); // Waits for "load" state by default.
+   * }</pre>
    *
    * @param state Optional load state to wait for, defaults to {@code load}. If the state has been already reached while loading current
    * document, the method resolves immediately. Can be one of:
-   * - {@code 'load'} - wait for the {@code load} event to be fired.
-   * - {@code 'domcontentloaded'} - wait for the {@code DOMContentLoaded} event to be fired.
-   * - {@code 'networkidle'} - wait until there are no network connections for at least {@code 500} ms.
+   * <ul>
+   * <li> {@code 'load'} - wait for the {@code load} event to be fired.</li>
+   * <li> {@code 'domcontentloaded'} - wait for the {@code DOMContentLoaded} event to be fired.</li>
+   * <li> {@code 'networkidle'} - wait until there are no network connections for at least {@code 500} ms.</li>
+   * </ul>
    */
   default void waitForLoadState(LoadState state) {
     waitForLoadState(state, null);
@@ -2070,6 +2398,10 @@ public interface Frame {
    *
    * <p> This returns when the frame reaches a required load state, {@code load} by default. The navigation must have been committed
    * when this method is called. If current document has already reached the required state, resolves immediately.
+   * <pre>{@code
+   * frame.click("button"); // Click triggers navigation.
+   * frame.waitForLoadState(); // Waits for "load" state by default.
+   * }</pre>
    */
   default void waitForLoadState() {
     waitForLoadState(null);
@@ -2079,13 +2411,18 @@ public interface Frame {
    *
    * <p> This returns when the frame reaches a required load state, {@code load} by default. The navigation must have been committed
    * when this method is called. If current document has already reached the required state, resolves immediately.
-   *
+   * <pre>{@code
+   * frame.click("button"); // Click triggers navigation.
+   * frame.waitForLoadState(); // Waits for "load" state by default.
+   * }</pre>
    *
    * @param state Optional load state to wait for, defaults to {@code load}. If the state has been already reached while loading current
    * document, the method resolves immediately. Can be one of:
-   * - {@code 'load'} - wait for the {@code load} event to be fired.
-   * - {@code 'domcontentloaded'} - wait for the {@code DOMContentLoaded} event to be fired.
-   * - {@code 'networkidle'} - wait until there are no network connections for at least {@code 500} ms.
+   * <ul>
+   * <li> {@code 'load'} - wait for the {@code load} event to be fired.</li>
+   * <li> {@code 'domcontentloaded'} - wait for the {@code DOMContentLoaded} event to be fired.</li>
+   * <li> {@code 'networkidle'} - wait until there are no network connections for at least {@code 500} ms.</li>
+   * </ul>
    */
   void waitForLoadState(LoadState state, WaitForLoadStateOptions options);
   /**
@@ -2095,9 +2432,16 @@ public interface Frame {
    *
    * <p> This method waits for the frame to navigate to a new URL. It is useful for when you run code which will indirectly cause
    * the frame to navigate. Consider this example:
+   * <pre>{@code
+   * // The method returns after navigation has finished
+   * Response response = frame.waitForNavigation(() -> {
+   *   // Clicking the link will indirectly cause a navigation
+   *   frame.click("a.delayed-navigation");
+   * });
+   * }</pre>
    *
-   * <p> <strong>NOTE:</strong> Usage of the [History API](https://developer.mozilla.org/en-US/docs/Web/API/History_API) to change the URL is
-   * considered a navigation.
+   * <p> <strong>NOTE:</strong> Usage of the [History API](https://developer.mozilla.org/en-US/docs/Web/API/History_API) to change the URL is considered
+   * a navigation.
    *
    * @param callback Callback that performs the action triggering the event.
    */
@@ -2111,9 +2455,16 @@ public interface Frame {
    *
    * <p> This method waits for the frame to navigate to a new URL. It is useful for when you run code which will indirectly cause
    * the frame to navigate. Consider this example:
+   * <pre>{@code
+   * // The method returns after navigation has finished
+   * Response response = frame.waitForNavigation(() -> {
+   *   // Clicking the link will indirectly cause a navigation
+   *   frame.click("a.delayed-navigation");
+   * });
+   * }</pre>
    *
-   * <p> <strong>NOTE:</strong> Usage of the [History API](https://developer.mozilla.org/en-US/docs/Web/API/History_API) to change the URL is
-   * considered a navigation.
+   * <p> <strong>NOTE:</strong> Usage of the [History API](https://developer.mozilla.org/en-US/docs/Web/API/History_API) to change the URL is considered
+   * a navigation.
    *
    * @param callback Callback that performs the action triggering the event.
    */
@@ -2127,7 +2478,25 @@ public interface Frame {
    * selector doesn't satisfy the condition for the {@code timeout} milliseconds, the function will throw.
    *
    * <p> This method works across navigations:
+   * <pre>{@code
+   * import com.microsoft.playwright.*;
    *
+   * public class Example {
+   *   public static void main(String[] args) {
+   *     try (Playwright playwright = Playwright.create()) {
+   *       BrowserType chromium = playwright.chromium();
+   *       Browser browser = chromium.launch();
+   *       Page page = browser.newPage();
+   *       for (String currentURL : Arrays.asList("https://google.com", "https://bbc.com")) {
+   *         page.navigate(currentURL);
+   *         ElementHandle element = page.mainFrame().waitForSelector("img");
+   *         System.out.println("Loaded image: " + element.getAttribute("src"));
+   *       }
+   *       browser.close();
+   *     }
+   *   }
+   * }
+   * }</pre>
    *
    * @param selector A selector to query for. See [working with selectors](./selectors.md) for more details.
    */
@@ -2143,7 +2512,25 @@ public interface Frame {
    * selector doesn't satisfy the condition for the {@code timeout} milliseconds, the function will throw.
    *
    * <p> This method works across navigations:
+   * <pre>{@code
+   * import com.microsoft.playwright.*;
    *
+   * public class Example {
+   *   public static void main(String[] args) {
+   *     try (Playwright playwright = Playwright.create()) {
+   *       BrowserType chromium = playwright.chromium();
+   *       Browser browser = chromium.launch();
+   *       Page page = browser.newPage();
+   *       for (String currentURL : Arrays.asList("https://google.com", "https://bbc.com")) {
+   *         page.navigate(currentURL);
+   *         ElementHandle element = page.mainFrame().waitForSelector("img");
+   *         System.out.println("Loaded image: " + element.getAttribute("src"));
+   *       }
+   *       browser.close();
+   *     }
+   *   }
+   * }
+   * }</pre>
    *
    * @param selector A selector to query for. See [working with selectors](./selectors.md) for more details.
    */

--- a/playwright/src/main/java/com/microsoft/playwright/JSHandle.java
+++ b/playwright/src/main/java/com/microsoft/playwright/JSHandle.java
@@ -21,6 +21,10 @@ import java.util.*;
 /**
  * JSHandle represents an in-page JavaScript object. JSHandles can be created with the [{@code method: Page.evaluateHandle}]
  * method.
+ * <pre>{@code
+ * JSHandle windowHandle = page.evaluateHandle("() => window");
+ * // ...
+ * }</pre>
  *
  * <p> JSHandle prevents the referenced JavaScript object being garbage collected unless the handle is exposed with
  * [{@code method: JSHandle.dispose}]. JSHandles are auto-disposed when their origin frame gets navigated or the parent context
@@ -45,6 +49,11 @@ public interface JSHandle {
    *
    * <p> If {@code expression} returns a [Promise], then {@code handle.evaluate} would wait for the promise to resolve and return its value.
    *
+   * <p> Examples:
+   * <pre>{@code
+   * ElementHandle tweetHandle = page.querySelector(".tweet .retweets");
+   * assertEquals("10 retweets", tweetHandle.evaluate("node => node.innerText"));
+   * }</pre>
    *
    * @param expression JavaScript expression to be evaluated in the browser context. If it looks like a function declaration, it is interpreted
    * as a function. Otherwise, evaluated as an expression.
@@ -59,6 +68,11 @@ public interface JSHandle {
    *
    * <p> If {@code expression} returns a [Promise], then {@code handle.evaluate} would wait for the promise to resolve and return its value.
    *
+   * <p> Examples:
+   * <pre>{@code
+   * ElementHandle tweetHandle = page.querySelector(".tweet .retweets");
+   * assertEquals("10 retweets", tweetHandle.evaluate("node => node.innerText"));
+   * }</pre>
    *
    * @param expression JavaScript expression to be evaluated in the browser context. If it looks like a function declaration, it is interpreted
    * as a function. Otherwise, evaluated as an expression.
@@ -104,6 +118,13 @@ public interface JSHandle {
   JSHandle evaluateHandle(String expression, Object arg);
   /**
    * The method returns a map with **own property names** as keys and JSHandle instances for the property values.
+   * <pre>{@code
+   * JSHandle handle = page.evaluateHandle("() => ({window, document}"););
+   * Map<String, JSHandle> properties = handle.getProperties();
+   * JSHandle windowHandle = properties.get("window");
+   * JSHandle documentHandle = properties.get("document");
+   * handle.dispose();
+   * }</pre>
    */
   Map<String, JSHandle> getProperties();
   /**
@@ -115,8 +136,8 @@ public interface JSHandle {
   /**
    * Returns a JSON representation of the object. If the object has a {@code toJSON} function, it **will not be called**.
    *
-   * <p> <strong>NOTE:</strong> The method will return an empty JSON object if the referenced object is not stringifiable. It will throw an
-   * error if the object has circular references.
+   * <p> <strong>NOTE:</strong> The method will return an empty JSON object if the referenced object is not stringifiable. It will throw an error if the
+   * object has circular references.
    */
   Object jsonValue();
 }

--- a/playwright/src/main/java/com/microsoft/playwright/Keyboard.java
+++ b/playwright/src/main/java/com/microsoft/playwright/Keyboard.java
@@ -26,7 +26,32 @@ import java.util.*;
  * <p> For finer control, you can use [{@code method: Keyboard.down}], [{@code method: Keyboard.up}], and [{@code method: Keyboard.insertText}]
  * to manually fire events as if they were generated from a real keyboard.
  *
+ * <p> An example of holding down {@code Shift} in order to select and delete some text:
+ * <pre>{@code
+ * page.keyboard().type("Hello World!");
+ * page.keyboard().press("ArrowLeft");
+ * page.keyboard().down("Shift");
+ * for (int i = 0; i < " World".length(); i++)
+ *   page.keyboard().press("ArrowLeft");
+ * page.keyboard().up("Shift");
+ * page.keyboard().press("Backspace");
+ * // Result text will end up saying "Hello!"
+ * }</pre>
+ *
+ * <p> An example of pressing uppercase {@code A}
+ * <pre>{@code
+ * page.keyboard().press("Shift+KeyA");
+ * // or
+ * page.keyboard().press("Shift+A");
+ * }</pre>
+ *
  * <p> An example to trigger select-all with the keyboard
+ * <pre>{@code
+ * // on Windows and Linux
+ * page.keyboard().press("Control+A");
+ * // on macOS
+ * page.keyboard().press("Meta+A");
+ * }</pre>
  */
 public interface Keyboard {
   class PressOptions {
@@ -82,6 +107,9 @@ public interface Keyboard {
   void down(String key);
   /**
    * Dispatches only {@code input} event, does not emit the {@code keydown}, {@code keyup} or {@code keypress} events.
+   * <pre>{@code
+   * page.keyboard().insertText("嗨");
+   * }</pre>
    *
    * <p> <strong>NOTE:</strong> Modifier keys DO NOT effect {@code keyboard.insertText}. Holding down {@code Shift} will not type the text in upper case.
    *
@@ -105,6 +133,17 @@ public interface Keyboard {
    *
    * <p> Shortcuts such as {@code key: "Control+o"} or {@code key: "Control+Shift+T"} are supported as well. When speficied with the
    * modifier, modifier is pressed and being held while the subsequent key is being pressed.
+   * <pre>{@code
+   * Page page = browser.newPage();
+   * page.navigate("https://keycode.info");
+   * page.keyboard().press("A");
+   * page.screenshot(new Page.ScreenshotOptions().withPath(Paths.get("A.png"));
+   * page.keyboard().press("ArrowLeft");
+   * page.screenshot(new Page.ScreenshotOptions().withPath(Paths.get("ArrowLeft.png")));
+   * page.keyboard().press("Shift+O");
+   * page.screenshot(new Page.ScreenshotOptions().withPath(Paths.get("O.png")));
+   * browser.close();
+   * }</pre>
    *
    * <p> Shortcut for [{@code method: Keyboard.down}] and [{@code method: Keyboard.up}].
    *
@@ -130,6 +169,17 @@ public interface Keyboard {
    *
    * <p> Shortcuts such as {@code key: "Control+o"} or {@code key: "Control+Shift+T"} are supported as well. When speficied with the
    * modifier, modifier is pressed and being held while the subsequent key is being pressed.
+   * <pre>{@code
+   * Page page = browser.newPage();
+   * page.navigate("https://keycode.info");
+   * page.keyboard().press("A");
+   * page.screenshot(new Page.ScreenshotOptions().withPath(Paths.get("A.png"));
+   * page.keyboard().press("ArrowLeft");
+   * page.screenshot(new Page.ScreenshotOptions().withPath(Paths.get("ArrowLeft.png")));
+   * page.keyboard().press("Shift+O");
+   * page.screenshot(new Page.ScreenshotOptions().withPath(Paths.get("O.png")));
+   * browser.close();
+   * }</pre>
    *
    * <p> Shortcut for [{@code method: Keyboard.down}] and [{@code method: Keyboard.up}].
    *
@@ -140,6 +190,12 @@ public interface Keyboard {
    * Sends a {@code keydown}, {@code keypress}/{@code input}, and {@code keyup} event for each character in the text.
    *
    * <p> To press a special key, like {@code Control} or {@code ArrowDown}, use [{@code method: Keyboard.press}].
+   * <pre>{@code
+   * // Types instantly
+   * page.keyboard().type("Hello");
+   * // Types slower, like a user
+   * page.keyboard().type("World", new Keyboard.TypeOptions().withDelay(100));
+   * }</pre>
    *
    * <p> <strong>NOTE:</strong> Modifier keys DO NOT effect {@code keyboard.type}. Holding down {@code Shift} will not type the text in upper case.
    *
@@ -152,6 +208,12 @@ public interface Keyboard {
    * Sends a {@code keydown}, {@code keypress}/{@code input}, and {@code keyup} event for each character in the text.
    *
    * <p> To press a special key, like {@code Control} or {@code ArrowDown}, use [{@code method: Keyboard.press}].
+   * <pre>{@code
+   * // Types instantly
+   * page.keyboard().type("Hello");
+   * // Types slower, like a user
+   * page.keyboard().type("World", new Keyboard.TypeOptions().withDelay(100));
+   * }</pre>
    *
    * <p> <strong>NOTE:</strong> Modifier keys DO NOT effect {@code keyboard.type}. Holding down {@code Shift} will not type the text in upper case.
    *

--- a/playwright/src/main/java/com/microsoft/playwright/Mouse.java
+++ b/playwright/src/main/java/com/microsoft/playwright/Mouse.java
@@ -23,6 +23,16 @@ import java.util.*;
  * The Mouse class operates in main-frame CSS pixels relative to the top-left corner of the viewport.
  *
  * <p> Every {@code page} object has its own Mouse, accessible with [{@code property: Page.mouse}].
+ * <pre>{@code
+ * // Using ‘page.mouse’ to trace a 100x100 square.
+ * page.mouse().move(0, 0);
+ * page.mouse().down();
+ * page.mouse().move(0, 100);
+ * page.mouse().move(100, 100);
+ * page.mouse().move(100, 0);
+ * page.mouse().move(0, 0);
+ * page.mouse().up();
+ * }</pre>
  */
 public interface Mouse {
   class ClickOptions {

--- a/playwright/src/main/java/com/microsoft/playwright/Page.java
+++ b/playwright/src/main/java/com/microsoft/playwright/Page.java
@@ -24,17 +24,47 @@ import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
 /**
- * - extends: [EventEmitter]
- *
- * <p> Page provides methods to interact with a single tab in a {@code Browser}, or an
+ * Page provides methods to interact with a single tab in a {@code Browser}, or an
  * [extension background page](https://developer.chrome.com/extensions/background_pages) in Chromium. One {@code Browser}
  * instance might have multiple {@code Page} instances.
+ *
+ * <p> This example creates a page, navigates it to a URL, and then saves a screenshot:
+ * <pre>{@code
+ * import com.microsoft.playwright.*;
+ *
+ * public class Example {
+ *   public static void main(String[] args) {
+ *     try (Playwright playwright = Playwright.create()) {
+ *       BrowserType webkit = playwright.webkit();
+ *       Browser browser = webkit.launch();
+ *       BrowserContext context = browser.newContext();
+ *       Page page = context.newPage();
+ *       page.navigate("https://example.com");
+ *       page.screenshot(new Page.ScreenshotOptions().withPath(Paths.get("screenshot.png")));
+ *       browser.close();
+ *     }
+ *   }
+ * }
+ * }</pre>
  *
  * <p> The Page class emits various events (described below) which can be handled using any of Node's native
  * [{@code EventEmitter}](https://nodejs.org/api/events.html#events_class_eventemitter) methods, such as {@code on}, {@code once} or
  * {@code removeListener}.
  *
+ * <p> This example logs a message for a single page {@code load} event:
+ * <pre>{@code
+ * page.onLoad(p -> System.out.println("Page loaded!"));
+ * }</pre>
+ *
  * <p> To unsubscribe from events use the {@code removeListener} method:
+ * <pre>{@code
+ * Consumer<Request> logRequest = interceptedRequest -> {
+ *   System.out.println("A request was made: " + interceptedRequest.url());
+ * };
+ * page.onRequest(logRequest);
+ * // Sometime later...
+ * page.offRequest(logRequest);
+ * }</pre>
  */
 public interface Page extends AutoCloseable {
 
@@ -445,9 +475,11 @@ public interface Page extends AutoCloseable {
     public Double timeout;
     /**
      * When to consider operation succeeded, defaults to {@code load}. Events can be either:
-     * - {@code 'domcontentloaded'} - consider operation to be finished when the {@code DOMContentLoaded} event is fired.
-     * - {@code 'load'} - consider operation to be finished when the {@code load} event is fired.
-     * - {@code 'networkidle'} - consider operation to be finished when there are no network connections for at least {@code 500} ms.
+     * <ul>
+     * <li> {@code 'domcontentloaded'} - consider operation to be finished when the {@code DOMContentLoaded} event is fired.</li>
+     * <li> {@code 'load'} - consider operation to be finished when the {@code load} event is fired.</li>
+     * <li> {@code 'networkidle'} - consider operation to be finished when there are no network connections for at least {@code 500} ms.</li>
+     * </ul>
      */
     public WaitUntilState waitUntil;
 
@@ -470,9 +502,11 @@ public interface Page extends AutoCloseable {
     public Double timeout;
     /**
      * When to consider operation succeeded, defaults to {@code load}. Events can be either:
-     * - {@code 'domcontentloaded'} - consider operation to be finished when the {@code DOMContentLoaded} event is fired.
-     * - {@code 'load'} - consider operation to be finished when the {@code load} event is fired.
-     * - {@code 'networkidle'} - consider operation to be finished when there are no network connections for at least {@code 500} ms.
+     * <ul>
+     * <li> {@code 'domcontentloaded'} - consider operation to be finished when the {@code DOMContentLoaded} event is fired.</li>
+     * <li> {@code 'load'} - consider operation to be finished when the {@code load} event is fired.</li>
+     * <li> {@code 'networkidle'} - consider operation to be finished when there are no network connections for at least {@code 500} ms.</li>
+     * </ul>
      */
     public WaitUntilState waitUntil;
 
@@ -500,9 +534,11 @@ public interface Page extends AutoCloseable {
     public Double timeout;
     /**
      * When to consider operation succeeded, defaults to {@code load}. Events can be either:
-     * - {@code 'domcontentloaded'} - consider operation to be finished when the {@code DOMContentLoaded} event is fired.
-     * - {@code 'load'} - consider operation to be finished when the {@code load} event is fired.
-     * - {@code 'networkidle'} - consider operation to be finished when there are no network connections for at least {@code 500} ms.
+     * <ul>
+     * <li> {@code 'domcontentloaded'} - consider operation to be finished when the {@code DOMContentLoaded} event is fired.</li>
+     * <li> {@code 'load'} - consider operation to be finished when the {@code load} event is fired.</li>
+     * <li> {@code 'networkidle'} - consider operation to be finished when there are no network connections for at least {@code 500} ms.</li>
+     * </ul>
      */
     public WaitUntilState waitUntil;
 
@@ -672,11 +708,13 @@ public interface Page extends AutoCloseable {
     /**
      * HTML template for the print header. Should be valid HTML markup with following classes used to inject printing values
      * into them:
-     * - {@code 'date'} formatted print date
-     * - {@code 'title'} document title
-     * - {@code 'url'} document location
-     * - {@code 'pageNumber'} current page number
-     * - {@code 'totalPages'} total pages in the document
+     * <ul>
+     * <li> {@code 'date'} formatted print date</li>
+     * <li> {@code 'title'} document title</li>
+     * <li> {@code 'url'} document location</li>
+     * <li> {@code 'pageNumber'} current page number</li>
+     * <li> {@code 'totalPages'} total pages in the document</li>
+     * </ul>
      */
     public String headerTemplate;
     /**
@@ -811,9 +849,11 @@ public interface Page extends AutoCloseable {
     public Double timeout;
     /**
      * When to consider operation succeeded, defaults to {@code load}. Events can be either:
-     * - {@code 'domcontentloaded'} - consider operation to be finished when the {@code DOMContentLoaded} event is fired.
-     * - {@code 'load'} - consider operation to be finished when the {@code load} event is fired.
-     * - {@code 'networkidle'} - consider operation to be finished when there are no network connections for at least {@code 500} ms.
+     * <ul>
+     * <li> {@code 'domcontentloaded'} - consider operation to be finished when the {@code DOMContentLoaded} event is fired.</li>
+     * <li> {@code 'load'} - consider operation to be finished when the {@code load} event is fired.</li>
+     * <li> {@code 'networkidle'} - consider operation to be finished when there are no network connections for at least {@code 500} ms.</li>
+     * </ul>
      */
     public WaitUntilState waitUntil;
 
@@ -925,9 +965,11 @@ public interface Page extends AutoCloseable {
     public Double timeout;
     /**
      * When to consider operation succeeded, defaults to {@code load}. Events can be either:
-     * - {@code 'domcontentloaded'} - consider operation to be finished when the {@code DOMContentLoaded} event is fired.
-     * - {@code 'load'} - consider operation to be finished when the {@code load} event is fired.
-     * - {@code 'networkidle'} - consider operation to be finished when there are no network connections for at least {@code 500} ms.
+     * <ul>
+     * <li> {@code 'domcontentloaded'} - consider operation to be finished when the {@code DOMContentLoaded} event is fired.</li>
+     * <li> {@code 'load'} - consider operation to be finished when the {@code load} event is fired.</li>
+     * <li> {@code 'networkidle'} - consider operation to be finished when there are no network connections for at least {@code 500} ms.</li>
+     * </ul>
      */
     public WaitUntilState waitUntil;
 
@@ -1206,9 +1248,11 @@ public interface Page extends AutoCloseable {
     public Object url;
     /**
      * When to consider operation succeeded, defaults to {@code load}. Events can be either:
-     * - {@code 'domcontentloaded'} - consider operation to be finished when the {@code DOMContentLoaded} event is fired.
-     * - {@code 'load'} - consider operation to be finished when the {@code load} event is fired.
-     * - {@code 'networkidle'} - consider operation to be finished when there are no network connections for at least {@code 500} ms.
+     * <ul>
+     * <li> {@code 'domcontentloaded'} - consider operation to be finished when the {@code DOMContentLoaded} event is fired.</li>
+     * <li> {@code 'load'} - consider operation to be finished when the {@code load} event is fired.</li>
+     * <li> {@code 'networkidle'} - consider operation to be finished when there are no network connections for at least {@code 500} ms.</li>
+     * </ul>
      */
     public WaitUntilState waitUntil;
 
@@ -1280,12 +1324,14 @@ public interface Page extends AutoCloseable {
   class WaitForSelectorOptions {
     /**
      * Defaults to {@code 'visible'}. Can be either:
-     * - {@code 'attached'} - wait for element to be present in DOM.
-     * - {@code 'detached'} - wait for element to not be present in DOM.
-     * - {@code 'visible'} - wait for element to have non-empty bounding box and no {@code visibility:hidden}. Note that element without
-     *   any content or with {@code display:none} has an empty bounding box and is not considered visible.
-     * - {@code 'hidden'} - wait for element to be either detached from DOM, or have an empty bounding box or {@code visibility:hidden}.
-     *   This is opposite to the {@code 'visible'} option.
+     * <ul>
+     * <li> {@code 'attached'} - wait for element to be present in DOM.</li>
+     * <li> {@code 'detached'} - wait for element to not be present in DOM.</li>
+     * <li> {@code 'visible'} - wait for element to have non-empty bounding box and no {@code visibility:hidden}. Note that element without any
+     * content or with {@code display:none} has an empty bounding box and is not considered visible.</li>
+     * <li> {@code 'hidden'} - wait for element to be either detached from DOM, or have an empty bounding box or {@code visibility:hidden}. This
+     * is opposite to the {@code 'visible'} option.</li>
+     * </ul>
      */
     public WaitForSelectorState state;
     /**
@@ -1346,12 +1392,20 @@ public interface Page extends AutoCloseable {
   Accessibility accessibility();
   /**
    * Adds a script which would be evaluated in one of the following scenarios:
-   * - Whenever the page is navigated.
-   * - Whenever the child frame is attached or navigated. In this case, the script is evaluated in the context of the newly
-   *   attached frame.
+   * <ul>
+   * <li> Whenever the page is navigated.</li>
+   * <li> Whenever the child frame is attached or navigated. In this case, the script is evaluated in the context of the newly
+   * attached frame.</li>
+   * </ul>
    *
    * <p> The script is evaluated after the document was created but before any of its scripts were run. This is useful to amend
    * the JavaScript environment, e.g. to seed {@code Math.random}.
+   *
+   * <p> An example of overriding {@code Math.random} before the page loads:
+   * <pre>{@code
+   * // In your playwright script, assuming the preload.js file is in same directory
+   * page.addInitScript(Paths.get("./preload.js"));
+   * }</pre>
    *
    * <p> <strong>NOTE:</strong> The order of evaluation of multiple scripts installed via [{@code method: BrowserContext.addInitScript}] and
    * [{@code method: Page.addInitScript}] is not defined.
@@ -1361,12 +1415,20 @@ public interface Page extends AutoCloseable {
   void addInitScript(String script);
   /**
    * Adds a script which would be evaluated in one of the following scenarios:
-   * - Whenever the page is navigated.
-   * - Whenever the child frame is attached or navigated. In this case, the script is evaluated in the context of the newly
-   *   attached frame.
+   * <ul>
+   * <li> Whenever the page is navigated.</li>
+   * <li> Whenever the child frame is attached or navigated. In this case, the script is evaluated in the context of the newly
+   * attached frame.</li>
+   * </ul>
    *
    * <p> The script is evaluated after the document was created but before any of its scripts were run. This is useful to amend
    * the JavaScript environment, e.g. to seed {@code Math.random}.
+   *
+   * <p> An example of overriding {@code Math.random} before the page loads:
+   * <pre>{@code
+   * // In your playwright script, assuming the preload.js file is in same directory
+   * page.addInitScript(Paths.get("./preload.js"));
+   * }</pre>
    *
    * <p> <strong>NOTE:</strong> The order of evaluation of multiple scripts installed via [{@code method: BrowserContext.addInitScript}] and
    * [{@code method: Page.addInitScript}] is not defined.
@@ -1412,15 +1474,17 @@ public interface Page extends AutoCloseable {
   void bringToFront();
   /**
    * This method checks an element matching {@code selector} by performing the following steps:
-   * 1. Find an element match matching {@code selector}. If there is none, wait until a matching element is attached to the DOM.
-   * 1. Ensure that matched element is a checkbox or a radio input. If not, this method rejects. If the element is already
-   *    checked, this method returns immediately.
-   * 1. Wait for [actionability](./actionability.md) checks on the matched element, unless {@code force} option is set. If the
-   *    element is detached during the checks, the whole action is retried.
-   * 1. Scroll the element into view if needed.
-   * 1. Use [{@code property: Page.mouse}] to click in the center of the element.
-   * 1. Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.
-   * 1. Ensure that the element is now checked. If not, this method rejects.
+   * <ol>
+   * <li> Find an element match matching {@code selector}. If there is none, wait until a matching element is attached to the DOM.</li>
+   * <li> Ensure that matched element is a checkbox or a radio input. If not, this method rejects. If the element is already
+   * checked, this method returns immediately.</li>
+   * <li> Wait for [actionability](./actionability.md) checks on the matched element, unless {@code force} option is set. If the element
+   * is detached during the checks, the whole action is retried.</li>
+   * <li> Scroll the element into view if needed.</li>
+   * <li> Use [{@code property: Page.mouse}] to click in the center of the element.</li>
+   * <li> Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.</li>
+   * <li> Ensure that the element is now checked. If not, this method rejects.</li>
+   * </ol>
    *
    * <p> When all steps combined have not finished during the specified {@code timeout}, this method rejects with a {@code TimeoutError}.
    * Passing zero timeout disables this.
@@ -1435,15 +1499,17 @@ public interface Page extends AutoCloseable {
   }
   /**
    * This method checks an element matching {@code selector} by performing the following steps:
-   * 1. Find an element match matching {@code selector}. If there is none, wait until a matching element is attached to the DOM.
-   * 1. Ensure that matched element is a checkbox or a radio input. If not, this method rejects. If the element is already
-   *    checked, this method returns immediately.
-   * 1. Wait for [actionability](./actionability.md) checks on the matched element, unless {@code force} option is set. If the
-   *    element is detached during the checks, the whole action is retried.
-   * 1. Scroll the element into view if needed.
-   * 1. Use [{@code property: Page.mouse}] to click in the center of the element.
-   * 1. Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.
-   * 1. Ensure that the element is now checked. If not, this method rejects.
+   * <ol>
+   * <li> Find an element match matching {@code selector}. If there is none, wait until a matching element is attached to the DOM.</li>
+   * <li> Ensure that matched element is a checkbox or a radio input. If not, this method rejects. If the element is already
+   * checked, this method returns immediately.</li>
+   * <li> Wait for [actionability](./actionability.md) checks on the matched element, unless {@code force} option is set. If the element
+   * is detached during the checks, the whole action is retried.</li>
+   * <li> Scroll the element into view if needed.</li>
+   * <li> Use [{@code property: Page.mouse}] to click in the center of the element.</li>
+   * <li> Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.</li>
+   * <li> Ensure that the element is now checked. If not, this method rejects.</li>
+   * </ol>
    *
    * <p> When all steps combined have not finished during the specified {@code timeout}, this method rejects with a {@code TimeoutError}.
    * Passing zero timeout disables this.
@@ -1456,12 +1522,14 @@ public interface Page extends AutoCloseable {
   void check(String selector, CheckOptions options);
   /**
    * This method clicks an element matching {@code selector} by performing the following steps:
-   * 1. Find an element match matching {@code selector}. If there is none, wait until a matching element is attached to the DOM.
-   * 1. Wait for [actionability](./actionability.md) checks on the matched element, unless {@code force} option is set. If the
-   *    element is detached during the checks, the whole action is retried.
-   * 1. Scroll the element into view if needed.
-   * 1. Use [{@code property: Page.mouse}] to click in the center of the element, or the specified {@code position}.
-   * 1. Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.
+   * <ol>
+   * <li> Find an element match matching {@code selector}. If there is none, wait until a matching element is attached to the DOM.</li>
+   * <li> Wait for [actionability](./actionability.md) checks on the matched element, unless {@code force} option is set. If the element
+   * is detached during the checks, the whole action is retried.</li>
+   * <li> Scroll the element into view if needed.</li>
+   * <li> Use [{@code property: Page.mouse}] to click in the center of the element, or the specified {@code position}.</li>
+   * <li> Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.</li>
+   * </ol>
    *
    * <p> When all steps combined have not finished during the specified {@code timeout}, this method rejects with a {@code TimeoutError}.
    * Passing zero timeout disables this.
@@ -1476,12 +1544,14 @@ public interface Page extends AutoCloseable {
   }
   /**
    * This method clicks an element matching {@code selector} by performing the following steps:
-   * 1. Find an element match matching {@code selector}. If there is none, wait until a matching element is attached to the DOM.
-   * 1. Wait for [actionability](./actionability.md) checks on the matched element, unless {@code force} option is set. If the
-   *    element is detached during the checks, the whole action is retried.
-   * 1. Scroll the element into view if needed.
-   * 1. Use [{@code property: Page.mouse}] to click in the center of the element, or the specified {@code position}.
-   * 1. Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.
+   * <ol>
+   * <li> Find an element match matching {@code selector}. If there is none, wait until a matching element is attached to the DOM.</li>
+   * <li> Wait for [actionability](./actionability.md) checks on the matched element, unless {@code force} option is set. If the element
+   * is detached during the checks, the whole action is retried.</li>
+   * <li> Scroll the element into view if needed.</li>
+   * <li> Use [{@code property: Page.mouse}] to click in the center of the element, or the specified {@code position}.</li>
+   * <li> Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.</li>
+   * </ol>
    *
    * <p> When all steps combined have not finished during the specified {@code timeout}, this method rejects with a {@code TimeoutError}.
    * Passing zero timeout disables this.
@@ -1498,8 +1568,8 @@ public interface Page extends AutoCloseable {
    *
    * <p> By default, {@code page.close()} **does not** run {@code beforeunload} handlers.
    *
-   * <p> <strong>NOTE:</strong> if {@code runBeforeUnload} is passed as true, a {@code beforeunload} dialog might be summoned and should be handled manually
-   * via [{@code event: Page.dialog}] event.
+   * <p> <strong>NOTE:</strong> if {@code runBeforeUnload} is passed as true, a {@code beforeunload} dialog might be summoned and should be handled manually via
+   * [{@code event: Page.dialog}] event.
    */
   default void close() {
     close(null);
@@ -1510,8 +1580,8 @@ public interface Page extends AutoCloseable {
    *
    * <p> By default, {@code page.close()} **does not** run {@code beforeunload} handlers.
    *
-   * <p> <strong>NOTE:</strong> if {@code runBeforeUnload} is passed as true, a {@code beforeunload} dialog might be summoned and should be handled manually
-   * via [{@code event: Page.dialog}] event.
+   * <p> <strong>NOTE:</strong> if {@code runBeforeUnload} is passed as true, a {@code beforeunload} dialog might be summoned and should be handled manually via
+   * [{@code event: Page.dialog}] event.
    */
   void close(CloseOptions options);
   /**
@@ -1524,13 +1594,15 @@ public interface Page extends AutoCloseable {
   BrowserContext context();
   /**
    * This method double clicks an element matching {@code selector} by performing the following steps:
-   * 1. Find an element match matching {@code selector}. If there is none, wait until a matching element is attached to the DOM.
-   * 1. Wait for [actionability](./actionability.md) checks on the matched element, unless {@code force} option is set. If the
-   *    element is detached during the checks, the whole action is retried.
-   * 1. Scroll the element into view if needed.
-   * 1. Use [{@code property: Page.mouse}] to double click in the center of the element, or the specified {@code position}.
-   * 1. Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set. Note that if the
-   *    first click of the {@code dblclick()} triggers a navigation event, this method will reject.
+   * <ol>
+   * <li> Find an element match matching {@code selector}. If there is none, wait until a matching element is attached to the DOM.</li>
+   * <li> Wait for [actionability](./actionability.md) checks on the matched element, unless {@code force} option is set. If the element
+   * is detached during the checks, the whole action is retried.</li>
+   * <li> Scroll the element into view if needed.</li>
+   * <li> Use [{@code property: Page.mouse}] to double click in the center of the element, or the specified {@code position}.</li>
+   * <li> Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set. Note that if the first
+   * click of the {@code dblclick()} triggers a navigation event, this method will reject.</li>
+   * </ol>
    *
    * <p> When all steps combined have not finished during the specified {@code timeout}, this method rejects with a {@code TimeoutError}.
    * Passing zero timeout disables this.
@@ -1547,13 +1619,15 @@ public interface Page extends AutoCloseable {
   }
   /**
    * This method double clicks an element matching {@code selector} by performing the following steps:
-   * 1. Find an element match matching {@code selector}. If there is none, wait until a matching element is attached to the DOM.
-   * 1. Wait for [actionability](./actionability.md) checks on the matched element, unless {@code force} option is set. If the
-   *    element is detached during the checks, the whole action is retried.
-   * 1. Scroll the element into view if needed.
-   * 1. Use [{@code property: Page.mouse}] to double click in the center of the element, or the specified {@code position}.
-   * 1. Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set. Note that if the
-   *    first click of the {@code dblclick()} triggers a navigation event, this method will reject.
+   * <ol>
+   * <li> Find an element match matching {@code selector}. If there is none, wait until a matching element is attached to the DOM.</li>
+   * <li> Wait for [actionability](./actionability.md) checks on the matched element, unless {@code force} option is set. If the element
+   * is detached during the checks, the whole action is retried.</li>
+   * <li> Scroll the element into view if needed.</li>
+   * <li> Use [{@code property: Page.mouse}] to double click in the center of the element, or the specified {@code position}.</li>
+   * <li> Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set. Note that if the first
+   * click of the {@code dblclick()} triggers a navigation event, this method will reject.</li>
+   * </ol>
    *
    * <p> When all steps combined have not finished during the specified {@code timeout}, this method rejects with a {@code TimeoutError}.
    * Passing zero timeout disables this.
@@ -1570,21 +1644,32 @@ public interface Page extends AutoCloseable {
    * The snippet below dispatches the {@code click} event on the element. Regardless of the visibility state of the elment, {@code click}
    * is dispatched. This is equivalend to calling
    * [element.click()](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/click).
+   * <pre>{@code
+   * page.dispatchEvent("button#submit", "click");
+   * }</pre>
    *
    * <p> Under the hood, it creates an instance of an event based on the given {@code type}, initializes it with {@code eventInit} properties
    * and dispatches it on the element. Events are {@code composed}, {@code cancelable} and bubble by default.
    *
    * <p> Since {@code eventInit} is event-specific, please refer to the events documentation for the lists of initial properties:
-   * - [DragEvent](https://developer.mozilla.org/en-US/docs/Web/API/DragEvent/DragEvent)
-   * - [FocusEvent](https://developer.mozilla.org/en-US/docs/Web/API/FocusEvent/FocusEvent)
-   * - [KeyboardEvent](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/KeyboardEvent)
-   * - [MouseEvent](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/MouseEvent)
-   * - [PointerEvent](https://developer.mozilla.org/en-US/docs/Web/API/PointerEvent/PointerEvent)
-   * - [TouchEvent](https://developer.mozilla.org/en-US/docs/Web/API/TouchEvent/TouchEvent)
-   * - [Event](https://developer.mozilla.org/en-US/docs/Web/API/Event/Event)
+   * <ul>
+   * <li> [DragEvent](https://developer.mozilla.org/en-US/docs/Web/API/DragEvent/DragEvent)</li>
+   * <li> [FocusEvent](https://developer.mozilla.org/en-US/docs/Web/API/FocusEvent/FocusEvent)</li>
+   * <li> [KeyboardEvent](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/KeyboardEvent)</li>
+   * <li> [MouseEvent](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/MouseEvent)</li>
+   * <li> [PointerEvent](https://developer.mozilla.org/en-US/docs/Web/API/PointerEvent/PointerEvent)</li>
+   * <li> [TouchEvent](https://developer.mozilla.org/en-US/docs/Web/API/TouchEvent/TouchEvent)</li>
+   * <li> [Event](https://developer.mozilla.org/en-US/docs/Web/API/Event/Event)</li>
+   * </ul>
    *
    * <p> You can also specify {@code JSHandle} as the property value if you want live objects to be passed into the event:
-   *
+   * <pre>{@code
+   * // Note you can only create DataTransfer in Chromium and Firefox
+   * JSHandle dataTransfer = page.evaluateHandle("() => new DataTransfer()");
+   * Map<String, Object> arg = new HashMap<>();
+   * arg.put("dataTransfer", dataTransfer);
+   * page.dispatchEvent("#source", "dragstart", arg);
+   * }</pre>
    *
    * @param selector A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See
    * [working with selectors](./selectors.md) for more details.
@@ -1598,21 +1683,32 @@ public interface Page extends AutoCloseable {
    * The snippet below dispatches the {@code click} event on the element. Regardless of the visibility state of the elment, {@code click}
    * is dispatched. This is equivalend to calling
    * [element.click()](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/click).
+   * <pre>{@code
+   * page.dispatchEvent("button#submit", "click");
+   * }</pre>
    *
    * <p> Under the hood, it creates an instance of an event based on the given {@code type}, initializes it with {@code eventInit} properties
    * and dispatches it on the element. Events are {@code composed}, {@code cancelable} and bubble by default.
    *
    * <p> Since {@code eventInit} is event-specific, please refer to the events documentation for the lists of initial properties:
-   * - [DragEvent](https://developer.mozilla.org/en-US/docs/Web/API/DragEvent/DragEvent)
-   * - [FocusEvent](https://developer.mozilla.org/en-US/docs/Web/API/FocusEvent/FocusEvent)
-   * - [KeyboardEvent](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/KeyboardEvent)
-   * - [MouseEvent](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/MouseEvent)
-   * - [PointerEvent](https://developer.mozilla.org/en-US/docs/Web/API/PointerEvent/PointerEvent)
-   * - [TouchEvent](https://developer.mozilla.org/en-US/docs/Web/API/TouchEvent/TouchEvent)
-   * - [Event](https://developer.mozilla.org/en-US/docs/Web/API/Event/Event)
+   * <ul>
+   * <li> [DragEvent](https://developer.mozilla.org/en-US/docs/Web/API/DragEvent/DragEvent)</li>
+   * <li> [FocusEvent](https://developer.mozilla.org/en-US/docs/Web/API/FocusEvent/FocusEvent)</li>
+   * <li> [KeyboardEvent](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/KeyboardEvent)</li>
+   * <li> [MouseEvent](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/MouseEvent)</li>
+   * <li> [PointerEvent](https://developer.mozilla.org/en-US/docs/Web/API/PointerEvent/PointerEvent)</li>
+   * <li> [TouchEvent](https://developer.mozilla.org/en-US/docs/Web/API/TouchEvent/TouchEvent)</li>
+   * <li> [Event](https://developer.mozilla.org/en-US/docs/Web/API/Event/Event)</li>
+   * </ul>
    *
    * <p> You can also specify {@code JSHandle} as the property value if you want live objects to be passed into the event:
-   *
+   * <pre>{@code
+   * // Note you can only create DataTransfer in Chromium and Firefox
+   * JSHandle dataTransfer = page.evaluateHandle("() => new DataTransfer()");
+   * Map<String, Object> arg = new HashMap<>();
+   * arg.put("dataTransfer", dataTransfer);
+   * page.dispatchEvent("#source", "dragstart", arg);
+   * }</pre>
    *
    * @param selector A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See
    * [working with selectors](./selectors.md) for more details.
@@ -1625,21 +1721,32 @@ public interface Page extends AutoCloseable {
    * The snippet below dispatches the {@code click} event on the element. Regardless of the visibility state of the elment, {@code click}
    * is dispatched. This is equivalend to calling
    * [element.click()](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/click).
+   * <pre>{@code
+   * page.dispatchEvent("button#submit", "click");
+   * }</pre>
    *
    * <p> Under the hood, it creates an instance of an event based on the given {@code type}, initializes it with {@code eventInit} properties
    * and dispatches it on the element. Events are {@code composed}, {@code cancelable} and bubble by default.
    *
    * <p> Since {@code eventInit} is event-specific, please refer to the events documentation for the lists of initial properties:
-   * - [DragEvent](https://developer.mozilla.org/en-US/docs/Web/API/DragEvent/DragEvent)
-   * - [FocusEvent](https://developer.mozilla.org/en-US/docs/Web/API/FocusEvent/FocusEvent)
-   * - [KeyboardEvent](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/KeyboardEvent)
-   * - [MouseEvent](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/MouseEvent)
-   * - [PointerEvent](https://developer.mozilla.org/en-US/docs/Web/API/PointerEvent/PointerEvent)
-   * - [TouchEvent](https://developer.mozilla.org/en-US/docs/Web/API/TouchEvent/TouchEvent)
-   * - [Event](https://developer.mozilla.org/en-US/docs/Web/API/Event/Event)
+   * <ul>
+   * <li> [DragEvent](https://developer.mozilla.org/en-US/docs/Web/API/DragEvent/DragEvent)</li>
+   * <li> [FocusEvent](https://developer.mozilla.org/en-US/docs/Web/API/FocusEvent/FocusEvent)</li>
+   * <li> [KeyboardEvent](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/KeyboardEvent)</li>
+   * <li> [MouseEvent](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/MouseEvent)</li>
+   * <li> [PointerEvent](https://developer.mozilla.org/en-US/docs/Web/API/PointerEvent/PointerEvent)</li>
+   * <li> [TouchEvent](https://developer.mozilla.org/en-US/docs/Web/API/TouchEvent/TouchEvent)</li>
+   * <li> [Event](https://developer.mozilla.org/en-US/docs/Web/API/Event/Event)</li>
+   * </ul>
    *
    * <p> You can also specify {@code JSHandle} as the property value if you want live objects to be passed into the event:
-   *
+   * <pre>{@code
+   * // Note you can only create DataTransfer in Chromium and Firefox
+   * JSHandle dataTransfer = page.evaluateHandle("() => new DataTransfer()");
+   * Map<String, Object> arg = new HashMap<>();
+   * arg.put("dataTransfer", dataTransfer);
+   * page.dispatchEvent("#source", "dragstart", arg);
+   * }</pre>
    *
    * @param selector A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See
    * [working with selectors](./selectors.md) for more details.
@@ -1647,9 +1754,67 @@ public interface Page extends AutoCloseable {
    * @param eventInit Optional event-specific initialization properties.
    */
   void dispatchEvent(String selector, String type, Object eventInit, DispatchEventOptions options);
+  /**
+   * <pre>{@code
+   * page.evaluate("() => matchMedia('screen').matches");
+   * // → true
+   * page.evaluate("() => matchMedia('print').matches");
+   * // → false
+   *
+   * page.emulateMedia(new Page.EmulateMediaOptions().withMedia(Media.PRINT));
+   * page.evaluate("() => matchMedia('screen').matches");
+   * // → false
+   * page.evaluate("() => matchMedia('print').matches");
+   * // → true
+   *
+   * page.emulateMedia(new Page.EmulateMediaOptions());
+   * page.evaluate("() => matchMedia('screen').matches");
+   * // → true
+   * page.evaluate("() => matchMedia('print').matches");
+   * // → false
+   * }</pre>
+   * <pre>{@code
+   * page.emulateMedia(new Page.EmulateMediaOptions().withColorScheme(ColorScheme.DARK));
+   * page.evaluate("() => matchMedia('(prefers-color-scheme: dark)').matches");
+   * // → true
+   * page.evaluate("() => matchMedia('(prefers-color-scheme: light)').matches");
+   * // → false
+   * page.evaluate("() => matchMedia('(prefers-color-scheme: no-preference)').matches");
+   * // → false
+   * }</pre>
+   */
   default void emulateMedia() {
     emulateMedia(null);
   }
+  /**
+   * <pre>{@code
+   * page.evaluate("() => matchMedia('screen').matches");
+   * // → true
+   * page.evaluate("() => matchMedia('print').matches");
+   * // → false
+   *
+   * page.emulateMedia(new Page.EmulateMediaOptions().withMedia(Media.PRINT));
+   * page.evaluate("() => matchMedia('screen').matches");
+   * // → false
+   * page.evaluate("() => matchMedia('print').matches");
+   * // → true
+   *
+   * page.emulateMedia(new Page.EmulateMediaOptions());
+   * page.evaluate("() => matchMedia('screen').matches");
+   * // → true
+   * page.evaluate("() => matchMedia('print').matches");
+   * // → false
+   * }</pre>
+   * <pre>{@code
+   * page.emulateMedia(new Page.EmulateMediaOptions().withColorScheme(ColorScheme.DARK));
+   * page.evaluate("() => matchMedia('(prefers-color-scheme: dark)').matches");
+   * // → true
+   * page.evaluate("() => matchMedia('(prefers-color-scheme: light)').matches");
+   * // → false
+   * page.evaluate("() => matchMedia('(prefers-color-scheme: no-preference)').matches");
+   * // → false
+   * }</pre>
+   */
   void emulateMedia(EmulateMediaOptions options);
   /**
    * The method finds an element matching the specified selector within the page and passes it as a first argument to
@@ -1657,6 +1822,13 @@ public interface Page extends AutoCloseable {
    *
    * <p> If {@code expression} returns a [Promise], then [{@code method: Page.evalOnSelector}] would wait for the promise to resolve and
    * return its value.
+   *
+   * <p> Examples:
+   * <pre>{@code
+   * String searchValue = (String) page.evalOnSelector("#search", "el => el.value");
+   * String preloadHref = (String) page.evalOnSelector("link[rel=preload]", "el => el.href");
+   * String html = (String) page.evalOnSelector(".main-container", "(e, suffix) => e.outerHTML + suffix", "hello");
+   * }</pre>
    *
    * <p> Shortcut for main frame's [{@code method: Frame.evalOnSelector}].
    *
@@ -1674,6 +1846,13 @@ public interface Page extends AutoCloseable {
    * <p> If {@code expression} returns a [Promise], then [{@code method: Page.evalOnSelector}] would wait for the promise to resolve and
    * return its value.
    *
+   * <p> Examples:
+   * <pre>{@code
+   * String searchValue = (String) page.evalOnSelector("#search", "el => el.value");
+   * String preloadHref = (String) page.evalOnSelector("link[rel=preload]", "el => el.href");
+   * String html = (String) page.evalOnSelector(".main-container", "(e, suffix) => e.outerHTML + suffix", "hello");
+   * }</pre>
+   *
    * <p> Shortcut for main frame's [{@code method: Frame.evalOnSelector}].
    *
    * @param selector A selector to query for. See [working with selectors](./selectors.md) for more details.
@@ -1689,6 +1868,10 @@ public interface Page extends AutoCloseable {
    * <p> If {@code expression} returns a [Promise], then [{@code method: Page.evalOnSelectorAll}] would wait for the promise to resolve and
    * return its value.
    *
+   * <p> Examples:
+   * <pre>{@code
+   * boolean divCounts = (boolean) page.evalOnSelectorAll("div", "(divs, min) => divs.length >= min", 10);
+   * }</pre>
    *
    * @param selector A selector to query for. See [working with selectors](./selectors.md) for more details.
    * @param expression JavaScript expression to be evaluated in the browser context. If it looks like a function declaration, it is interpreted
@@ -1704,6 +1887,10 @@ public interface Page extends AutoCloseable {
    * <p> If {@code expression} returns a [Promise], then [{@code method: Page.evalOnSelectorAll}] would wait for the promise to resolve and
    * return its value.
    *
+   * <p> Examples:
+   * <pre>{@code
+   * boolean divCounts = (boolean) page.evalOnSelectorAll("div", "(divs, min) => divs.length >= min", 10);
+   * }</pre>
    *
    * @param selector A selector to query for. See [working with selectors](./selectors.md) for more details.
    * @param expression JavaScript expression to be evaluated in the browser context. If it looks like a function declaration, it is interpreted
@@ -1722,10 +1909,24 @@ public interface Page extends AutoCloseable {
    * not serializable by {@code JSON}: {@code -0}, {@code NaN}, {@code Infinity}, {@code -Infinity}.
    *
    * <p> Passing argument to {@code expression}:
+   * <pre>{@code
+   * Object result = page.evaluate("([x, y]) => {\n" +
+   *   "  return Promise.resolve(x * y);\n" +
+   *   "}", Arrays.asList(7, 8));
+   * System.out.println(result); // prints "56"
+   * }</pre>
    *
    * <p> A string can also be passed in instead of a function:
+   * <pre>{@code
+   * System.out.println(page.evaluate("1 + 2")); // prints "3"
+   * }</pre>
    *
    * <p> {@code ElementHandle} instances can be passed as an argument to the [{@code method: Page.evaluate}]:
+   * <pre>{@code
+   * ElementHandle bodyHandle = page.querySelector("body");
+   * String html = (String) page.evaluate("([body, suffix]) => body.innerHTML + suffix", Arrays.asList(bodyHandle, "hello"));
+   * bodyHandle.dispose();
+   * }</pre>
    *
    * <p> Shortcut for main frame's [{@code method: Frame.evaluate}].
    *
@@ -1746,10 +1947,24 @@ public interface Page extends AutoCloseable {
    * not serializable by {@code JSON}: {@code -0}, {@code NaN}, {@code Infinity}, {@code -Infinity}.
    *
    * <p> Passing argument to {@code expression}:
+   * <pre>{@code
+   * Object result = page.evaluate("([x, y]) => {\n" +
+   *   "  return Promise.resolve(x * y);\n" +
+   *   "}", Arrays.asList(7, 8));
+   * System.out.println(result); // prints "56"
+   * }</pre>
    *
    * <p> A string can also be passed in instead of a function:
+   * <pre>{@code
+   * System.out.println(page.evaluate("1 + 2")); // prints "3"
+   * }</pre>
    *
    * <p> {@code ElementHandle} instances can be passed as an argument to the [{@code method: Page.evaluate}]:
+   * <pre>{@code
+   * ElementHandle bodyHandle = page.querySelector("body");
+   * String html = (String) page.evaluate("([body, suffix]) => body.innerHTML + suffix", Arrays.asList(bodyHandle, "hello"));
+   * bodyHandle.dispose();
+   * }</pre>
    *
    * <p> Shortcut for main frame's [{@code method: Frame.evaluate}].
    *
@@ -1766,11 +1981,23 @@ public interface Page extends AutoCloseable {
    *
    * <p> If the function passed to the [{@code method: Page.evaluateHandle}] returns a [Promise], then [{@code method: Page.evaluateHandle}]
    * would wait for the promise to resolve and return its value.
+   * <pre>{@code
+   * // Handle for the window object.
+   * JSHandle aWindowHandle = page.evaluateHandle("() => Promise.resolve(window)");
+   * }</pre>
    *
    * <p> A string can also be passed in instead of a function:
+   * <pre>{@code
+   * JSHandle aHandle = page.evaluateHandle("document"); // Handle for the "document".
+   * }</pre>
    *
    * <p> {@code JSHandle} instances can be passed as an argument to the [{@code method: Page.evaluateHandle}]:
-   *
+   * <pre>{@code
+   * JSHandle aHandle = page.evaluateHandle("() => document.body");
+   * JSHandle resultHandle = page.evaluateHandle("([body, suffix]) => body.innerHTML + suffix", Arrays.asList(aHandle, "hello"));
+   * System.out.println(resultHandle.jsonValue());
+   * resultHandle.dispose();
+   * }</pre>
    *
    * @param expression JavaScript expression to be evaluated in the browser context. If it looks like a function declaration, it is interpreted
    * as a function. Otherwise, evaluated as an expression.
@@ -1786,11 +2013,23 @@ public interface Page extends AutoCloseable {
    *
    * <p> If the function passed to the [{@code method: Page.evaluateHandle}] returns a [Promise], then [{@code method: Page.evaluateHandle}]
    * would wait for the promise to resolve and return its value.
+   * <pre>{@code
+   * // Handle for the window object.
+   * JSHandle aWindowHandle = page.evaluateHandle("() => Promise.resolve(window)");
+   * }</pre>
    *
    * <p> A string can also be passed in instead of a function:
+   * <pre>{@code
+   * JSHandle aHandle = page.evaluateHandle("document"); // Handle for the "document".
+   * }</pre>
    *
    * <p> {@code JSHandle} instances can be passed as an argument to the [{@code method: Page.evaluateHandle}]:
-   *
+   * <pre>{@code
+   * JSHandle aHandle = page.evaluateHandle("() => document.body");
+   * JSHandle resultHandle = page.evaluateHandle("([body, suffix]) => body.innerHTML + suffix", Arrays.asList(aHandle, "hello"));
+   * System.out.println(resultHandle.jsonValue());
+   * resultHandle.dispose();
+   * }</pre>
    *
    * @param expression JavaScript expression to be evaluated in the browser context. If it looks like a function declaration, it is interpreted
    * as a function. Otherwise, evaluated as an expression.
@@ -1802,13 +2041,52 @@ public interface Page extends AutoCloseable {
    * executes {@code callback} and returns a [Promise] which resolves to the return value of {@code callback}. If the {@code callback} returns
    * a [Promise], it will be awaited.
    *
-   * <p> The first argument of the {@code callback} function contains information about the caller: `{ browserContext: BrowserContext,
-   * page: Page, frame: Frame }`.
+   * <p> The first argument of the {@code callback} function contains information about the caller: {@code { browserContext: BrowserContext,
+   * page: Page, frame: Frame }}.
    *
    * <p> See [{@code method: BrowserContext.exposeBinding}] for the context-wide version.
    *
    * <p> <strong>NOTE:</strong> Functions installed via [{@code method: Page.exposeBinding}] survive navigations.
    *
+   * <p> An example of exposing page URL to all frames in a page:
+   * <pre>{@code
+   * import com.microsoft.playwright.*;
+   *
+   * public class Example {
+   *   public static void main(String[] args) {
+   *     try (Playwright playwright = Playwright.create()) {
+   *       BrowserType webkit = playwright.webkit();
+   *       Browser browser = webkit.launch({ headless: false });
+   *       BrowserContext context = browser.newContext();
+   *       Page page = context.newPage();
+   *       page.exposeBinding("pageURL", (source, args) -> source.page().url());
+   *       page.setContent("<script>\n" +
+   *         "  async function onClick() {\n" +
+   *         "    document.querySelector('div').textContent = await window.pageURL();\n" +
+   *         "  }\n" +
+   *         "</script>\n" +
+   *         "<button onclick=\"onClick()\">Click me</button>\n" +
+   *         "<div></div>");
+   *       page.click("button");
+   *     }
+   *   }
+   * }
+   * }</pre>
+   *
+   * <p> An example of passing an element handle:
+   * <pre>{@code
+   * page.exposeBinding("clicked", (source, args) -> {
+   *   ElementHandle element = (ElementHandle) args[0];
+   *   System.out.println(element.textContent());
+   *   return null;
+   * }, new Page.ExposeBindingOptions().withHandle(true));
+   * page.setContent("" +
+   *   "<script>\n" +
+   *   "  document.addEventListener('click', event => window.clicked(event.target));\n" +
+   *   "</script>\n" +
+   *   "<div>Click me</div>\n" +
+   *   "<div>Or click me</div>\n");
+   * }</pre>
    *
    * @param name Name of the function on the window object.
    * @param callback Callback function that will be called in the Playwright's context.
@@ -1821,13 +2099,52 @@ public interface Page extends AutoCloseable {
    * executes {@code callback} and returns a [Promise] which resolves to the return value of {@code callback}. If the {@code callback} returns
    * a [Promise], it will be awaited.
    *
-   * <p> The first argument of the {@code callback} function contains information about the caller: `{ browserContext: BrowserContext,
-   * page: Page, frame: Frame }`.
+   * <p> The first argument of the {@code callback} function contains information about the caller: {@code { browserContext: BrowserContext,
+   * page: Page, frame: Frame }}.
    *
    * <p> See [{@code method: BrowserContext.exposeBinding}] for the context-wide version.
    *
    * <p> <strong>NOTE:</strong> Functions installed via [{@code method: Page.exposeBinding}] survive navigations.
    *
+   * <p> An example of exposing page URL to all frames in a page:
+   * <pre>{@code
+   * import com.microsoft.playwright.*;
+   *
+   * public class Example {
+   *   public static void main(String[] args) {
+   *     try (Playwright playwright = Playwright.create()) {
+   *       BrowserType webkit = playwright.webkit();
+   *       Browser browser = webkit.launch({ headless: false });
+   *       BrowserContext context = browser.newContext();
+   *       Page page = context.newPage();
+   *       page.exposeBinding("pageURL", (source, args) -> source.page().url());
+   *       page.setContent("<script>\n" +
+   *         "  async function onClick() {\n" +
+   *         "    document.querySelector('div').textContent = await window.pageURL();\n" +
+   *         "  }\n" +
+   *         "</script>\n" +
+   *         "<button onclick=\"onClick()\">Click me</button>\n" +
+   *         "<div></div>");
+   *       page.click("button");
+   *     }
+   *   }
+   * }
+   * }</pre>
+   *
+   * <p> An example of passing an element handle:
+   * <pre>{@code
+   * page.exposeBinding("clicked", (source, args) -> {
+   *   ElementHandle element = (ElementHandle) args[0];
+   *   System.out.println(element.textContent());
+   *   return null;
+   * }, new Page.ExposeBindingOptions().withHandle(true));
+   * page.setContent("" +
+   *   "<script>\n" +
+   *   "  document.addEventListener('click', event => window.clicked(event.target));\n" +
+   *   "</script>\n" +
+   *   "<div>Click me</div>\n" +
+   *   "<div>Or click me</div>\n");
+   * }</pre>
    *
    * @param name Name of the function on the window object.
    * @param callback Callback function that will be called in the Playwright's context.
@@ -1843,6 +2160,44 @@ public interface Page extends AutoCloseable {
    *
    * <p> <strong>NOTE:</strong> Functions installed via [{@code method: Page.exposeFunction}] survive navigations.
    *
+   * <p> An example of adding an {@code sha1} function to the page:
+   * <pre>{@code
+   * import com.microsoft.playwright.*;
+   *
+   * import java.nio.charset.StandardCharsets;
+   * import java.security.MessageDigest;
+   * import java.security.NoSuchAlgorithmException;
+   * import java.util.Base64;
+   *
+   * public class Example {
+   *   public static void main(String[] args) {
+   *     try (Playwright playwright = Playwright.create()) {
+   *       BrowserType webkit = playwright.webkit();
+   *       Browser browser = webkit.launch({ headless: false });
+   *       Page page = browser.newPage();
+   *       page.exposeFunction("sha1", args -> {
+   *         String text = (String) args[0];
+   *         MessageDigest crypto;
+   *         try {
+   *           crypto = MessageDigest.getInstance("SHA-1");
+   *         } catch (NoSuchAlgorithmException e) {
+   *           return null;
+   *         }
+   *         byte[] token = crypto.digest(text.getBytes(StandardCharsets.UTF_8));
+   *         return Base64.getEncoder().encodeToString(token);
+   *       });
+   *       page.setContent("<script>\n" +
+   *         "  async function onClick() {\n" +
+   *         "    document.querySelector('div').textContent = await window.sha1('PLAYWRIGHT');\n" +
+   *         "  }\n" +
+   *         "</script>\n" +
+   *         "<button onclick=\"onClick()\">Click me</button>\n" +
+   *         "<div></div>\n");
+   *       page.click("button");
+   *     }
+   *   }
+   * }
+   * }</pre>
    *
    * @param name Name of the function on the window object
    * @param callback Callback function which will be called in Playwright's context.
@@ -1906,7 +2261,12 @@ public interface Page extends AutoCloseable {
   void focus(String selector, FocusOptions options);
   /**
    * Returns frame matching the specified criteria. Either {@code name} or {@code url} must be specified.
-   *
+   * <pre>{@code
+   * Frame frame = page.frame("frame-name");
+   * }</pre>
+   * <pre>{@code
+   * Frame frame = page.frameByUrl(Pattern.compile(".*domain.*");
+   * }</pre>
    *
    * @param name Frame name specified in the {@code iframe}'s {@code name} attribute.
    */
@@ -1988,11 +2348,13 @@ public interface Page extends AutoCloseable {
    * last redirect.
    *
    * <p> {@code page.goto} will throw an error if:
-   * - there's an SSL error (e.g. in case of self-signed certificates).
-   * - target URL is invalid.
-   * - the {@code timeout} is exceeded during navigation.
-   * - the remote server does not respond or is unreachable.
-   * - the main resource failed to load.
+   * <ul>
+   * <li> there's an SSL error (e.g. in case of self-signed certificates).</li>
+   * <li> target URL is invalid.</li>
+   * <li> the {@code timeout} is exceeded during navigation.</li>
+   * <li> the remote server does not respond or is unreachable.</li>
+   * <li> the main resource failed to load.</li>
+   * </ul>
    *
    * <p> {@code page.goto} will not throw an error when any valid HTTP status code is returned by the remote server, including 404 "Not
    * Found" and 500 "Internal Server Error".  The status code for such responses can be retrieved by calling
@@ -2000,7 +2362,8 @@ public interface Page extends AutoCloseable {
    *
    * <p> <strong>NOTE:</strong> {@code page.goto} either throws an error or returns a main resource response. The only exceptions are navigation to
    * {@code about:blank} or navigation to the same URL with a different hash, which would succeed and return {@code null}.
-   * <strong>NOTE:</strong> Headless mode doesn't support navigation to a PDF document. See the
+   *
+   * <p> <strong>NOTE:</strong> Headless mode doesn't support navigation to a PDF document. See the
    * [upstream issue](https://bugs.chromium.org/p/chromium/issues/detail?id=761295).
    *
    * <p> Shortcut for main frame's [{@code method: Frame.goto}]
@@ -2015,11 +2378,13 @@ public interface Page extends AutoCloseable {
    * last redirect.
    *
    * <p> {@code page.goto} will throw an error if:
-   * - there's an SSL error (e.g. in case of self-signed certificates).
-   * - target URL is invalid.
-   * - the {@code timeout} is exceeded during navigation.
-   * - the remote server does not respond or is unreachable.
-   * - the main resource failed to load.
+   * <ul>
+   * <li> there's an SSL error (e.g. in case of self-signed certificates).</li>
+   * <li> target URL is invalid.</li>
+   * <li> the {@code timeout} is exceeded during navigation.</li>
+   * <li> the remote server does not respond or is unreachable.</li>
+   * <li> the main resource failed to load.</li>
+   * </ul>
    *
    * <p> {@code page.goto} will not throw an error when any valid HTTP status code is returned by the remote server, including 404 "Not
    * Found" and 500 "Internal Server Error".  The status code for such responses can be retrieved by calling
@@ -2027,7 +2392,8 @@ public interface Page extends AutoCloseable {
    *
    * <p> <strong>NOTE:</strong> {@code page.goto} either throws an error or returns a main resource response. The only exceptions are navigation to
    * {@code about:blank} or navigation to the same URL with a different hash, which would succeed and return {@code null}.
-   * <strong>NOTE:</strong> Headless mode doesn't support navigation to a PDF document. See the
+   *
+   * <p> <strong>NOTE:</strong> Headless mode doesn't support navigation to a PDF document. See the
    * [upstream issue](https://bugs.chromium.org/p/chromium/issues/detail?id=761295).
    *
    * <p> Shortcut for main frame's [{@code method: Frame.goto}]
@@ -2037,12 +2403,14 @@ public interface Page extends AutoCloseable {
   Response navigate(String url, NavigateOptions options);
   /**
    * This method hovers over an element matching {@code selector} by performing the following steps:
-   * 1. Find an element match matching {@code selector}. If there is none, wait until a matching element is attached to the DOM.
-   * 1. Wait for [actionability](./actionability.md) checks on the matched element, unless {@code force} option is set. If the
-   *    element is detached during the checks, the whole action is retried.
-   * 1. Scroll the element into view if needed.
-   * 1. Use [{@code property: Page.mouse}] to hover over the center of the element, or the specified {@code position}.
-   * 1. Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.
+   * <ol>
+   * <li> Find an element match matching {@code selector}. If there is none, wait until a matching element is attached to the DOM.</li>
+   * <li> Wait for [actionability](./actionability.md) checks on the matched element, unless {@code force} option is set. If the element
+   * is detached during the checks, the whole action is retried.</li>
+   * <li> Scroll the element into view if needed.</li>
+   * <li> Use [{@code property: Page.mouse}] to hover over the center of the element, or the specified {@code position}.</li>
+   * <li> Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.</li>
+   * </ol>
    *
    * <p> When all steps combined have not finished during the specified {@code timeout}, this method rejects with a {@code TimeoutError}.
    * Passing zero timeout disables this.
@@ -2057,12 +2425,14 @@ public interface Page extends AutoCloseable {
   }
   /**
    * This method hovers over an element matching {@code selector} by performing the following steps:
-   * 1. Find an element match matching {@code selector}. If there is none, wait until a matching element is attached to the DOM.
-   * 1. Wait for [actionability](./actionability.md) checks on the matched element, unless {@code force} option is set. If the
-   *    element is detached during the checks, the whole action is retried.
-   * 1. Scroll the element into view if needed.
-   * 1. Use [{@code property: Page.mouse}] to hover over the center of the element, or the specified {@code position}.
-   * 1. Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.
+   * <ol>
+   * <li> Find an element match matching {@code selector}. If there is none, wait until a matching element is attached to the DOM.</li>
+   * <li> Wait for [actionability](./actionability.md) checks on the matched element, unless {@code force} option is set. If the element
+   * is detached during the checks, the whole action is retried.</li>
+   * <li> Scroll the element into view if needed.</li>
+   * <li> Use [{@code property: Page.mouse}] to hover over the center of the element, or the specified {@code position}.</li>
+   * <li> Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.</li>
+   * </ol>
    *
    * <p> When all steps combined have not finished during the specified {@code timeout}, this method rejects with a {@code TimeoutError}.
    * Passing zero timeout disables this.
@@ -2241,35 +2611,46 @@ public interface Page extends AutoCloseable {
    * <p> <strong>NOTE:</strong> By default, {@code page.pdf()} generates a pdf with modified colors for printing. Use the
    * [{@code -webkit-print-color-adjust}](https://developer.mozilla.org/en-US/docs/Web/CSS/-webkit-print-color-adjust) property to
    * force rendering of exact colors.
+   * <pre>{@code
+   * // Generates a PDF with "screen" media type.
+   * page.emulateMedia(new Page.EmulateMediaOptions().withMedia(Media.SCREEN));
+   * page.pdf(new Page.PdfOptions().withPath(Paths.get("page.pdf")));
+   * }</pre>
    *
    * <p> The {@code width}, {@code height}, and {@code margin} options accept values labeled with units. Unlabeled values are treated as pixels.
    *
    * <p> A few examples:
-   * - {@code page.pdf({width: 100})} - prints with width set to 100 pixels
-   * - {@code page.pdf({width: '100px'})} - prints with width set to 100 pixels
-   * - {@code page.pdf({width: '10cm'})} - prints with width set to 10 centimeters.
+   * <ul>
+   * <li> {@code page.pdf({width: 100})} - prints with width set to 100 pixels</li>
+   * <li> {@code page.pdf({width: '100px'})} - prints with width set to 100 pixels</li>
+   * <li> {@code page.pdf({width: '10cm'})} - prints with width set to 10 centimeters.</li>
+   * </ul>
    *
    * <p> All possible units are:
-   * - {@code px} - pixel
-   * - {@code in} - inch
-   * - {@code cm} - centimeter
-   * - {@code mm} - millimeter
+   * <ul>
+   * <li> {@code px} - pixel</li>
+   * <li> {@code in} - inch</li>
+   * <li> {@code cm} - centimeter</li>
+   * <li> {@code mm} - millimeter</li>
+   * </ul>
    *
    * <p> The {@code format} options are:
-   * - {@code Letter}: 8.5in x 11in
-   * - {@code Legal}: 8.5in x 14in
-   * - {@code Tabloid}: 11in x 17in
-   * - {@code Ledger}: 17in x 11in
-   * - {@code A0}: 33.1in x 46.8in
-   * - {@code A1}: 23.4in x 33.1in
-   * - {@code A2}: 16.54in x 23.4in
-   * - {@code A3}: 11.7in x 16.54in
-   * - {@code A4}: 8.27in x 11.7in
-   * - {@code A5}: 5.83in x 8.27in
-   * - {@code A6}: 4.13in x 5.83in
+   * <ul>
+   * <li> {@code Letter}: 8.5in x 11in</li>
+   * <li> {@code Legal}: 8.5in x 14in</li>
+   * <li> {@code Tabloid}: 11in x 17in</li>
+   * <li> {@code Ledger}: 17in x 11in</li>
+   * <li> {@code A0}: 33.1in x 46.8in</li>
+   * <li> {@code A1}: 23.4in x 33.1in</li>
+   * <li> {@code A2}: 16.54in x 23.4in</li>
+   * <li> {@code A3}: 11.7in x 16.54in</li>
+   * <li> {@code A4}: 8.27in x 11.7in</li>
+   * <li> {@code A5}: 5.83in x 8.27in</li>
+   * <li> {@code A6}: 4.13in x 5.83in</li>
+   * </ul>
    *
-   * <p> <strong>NOTE:</strong> {@code headerTemplate} and {@code footerTemplate} markup have the following limitations: > 1. Script tags inside templates
-   * are not evaluated. > 2. Page styles are not visible inside templates.
+   * <p> <strong>NOTE:</strong> {@code headerTemplate} and {@code footerTemplate} markup have the following limitations: > 1. Script tags inside templates are not
+   * evaluated. > 2. Page styles are not visible inside templates.
    */
   default byte[] pdf() {
     return pdf(null);
@@ -2285,35 +2666,46 @@ public interface Page extends AutoCloseable {
    * <p> <strong>NOTE:</strong> By default, {@code page.pdf()} generates a pdf with modified colors for printing. Use the
    * [{@code -webkit-print-color-adjust}](https://developer.mozilla.org/en-US/docs/Web/CSS/-webkit-print-color-adjust) property to
    * force rendering of exact colors.
+   * <pre>{@code
+   * // Generates a PDF with "screen" media type.
+   * page.emulateMedia(new Page.EmulateMediaOptions().withMedia(Media.SCREEN));
+   * page.pdf(new Page.PdfOptions().withPath(Paths.get("page.pdf")));
+   * }</pre>
    *
    * <p> The {@code width}, {@code height}, and {@code margin} options accept values labeled with units. Unlabeled values are treated as pixels.
    *
    * <p> A few examples:
-   * - {@code page.pdf({width: 100})} - prints with width set to 100 pixels
-   * - {@code page.pdf({width: '100px'})} - prints with width set to 100 pixels
-   * - {@code page.pdf({width: '10cm'})} - prints with width set to 10 centimeters.
+   * <ul>
+   * <li> {@code page.pdf({width: 100})} - prints with width set to 100 pixels</li>
+   * <li> {@code page.pdf({width: '100px'})} - prints with width set to 100 pixels</li>
+   * <li> {@code page.pdf({width: '10cm'})} - prints with width set to 10 centimeters.</li>
+   * </ul>
    *
    * <p> All possible units are:
-   * - {@code px} - pixel
-   * - {@code in} - inch
-   * - {@code cm} - centimeter
-   * - {@code mm} - millimeter
+   * <ul>
+   * <li> {@code px} - pixel</li>
+   * <li> {@code in} - inch</li>
+   * <li> {@code cm} - centimeter</li>
+   * <li> {@code mm} - millimeter</li>
+   * </ul>
    *
    * <p> The {@code format} options are:
-   * - {@code Letter}: 8.5in x 11in
-   * - {@code Legal}: 8.5in x 14in
-   * - {@code Tabloid}: 11in x 17in
-   * - {@code Ledger}: 17in x 11in
-   * - {@code A0}: 33.1in x 46.8in
-   * - {@code A1}: 23.4in x 33.1in
-   * - {@code A2}: 16.54in x 23.4in
-   * - {@code A3}: 11.7in x 16.54in
-   * - {@code A4}: 8.27in x 11.7in
-   * - {@code A5}: 5.83in x 8.27in
-   * - {@code A6}: 4.13in x 5.83in
+   * <ul>
+   * <li> {@code Letter}: 8.5in x 11in</li>
+   * <li> {@code Legal}: 8.5in x 14in</li>
+   * <li> {@code Tabloid}: 11in x 17in</li>
+   * <li> {@code Ledger}: 17in x 11in</li>
+   * <li> {@code A0}: 33.1in x 46.8in</li>
+   * <li> {@code A1}: 23.4in x 33.1in</li>
+   * <li> {@code A2}: 16.54in x 23.4in</li>
+   * <li> {@code A3}: 11.7in x 16.54in</li>
+   * <li> {@code A4}: 8.27in x 11.7in</li>
+   * <li> {@code A5}: 5.83in x 8.27in</li>
+   * <li> {@code A6}: 4.13in x 5.83in</li>
+   * </ul>
    *
-   * <p> <strong>NOTE:</strong> {@code headerTemplate} and {@code footerTemplate} markup have the following limitations: > 1. Script tags inside templates
-   * are not evaluated. > 2. Page styles are not visible inside templates.
+   * <p> <strong>NOTE:</strong> {@code headerTemplate} and {@code footerTemplate} markup have the following limitations: > 1. Script tags inside templates are not
+   * evaluated. > 2. Page styles are not visible inside templates.
    */
   byte[] pdf(PdfOptions options);
   /**
@@ -2335,7 +2727,16 @@ public interface Page extends AutoCloseable {
    *
    * <p> Shortcuts such as {@code key: "Control+o"} or {@code key: "Control+Shift+T"} are supported as well. When speficied with the
    * modifier, modifier is pressed and being held while the subsequent key is being pressed.
-   *
+   * <pre>{@code
+   * Page page = browser.newPage();
+   * page.navigate("https://keycode.info");
+   * page.press("body", "A");
+   * page.screenshot(new Page.ScreenshotOptions().withPath(Paths.get("A.png")));
+   * page.press("body", "ArrowLeft");
+   * page.screenshot(new Page.ScreenshotOptions().withPath(Paths.get("ArrowLeft.png" )));
+   * page.press("body", "Shift+O");
+   * page.screenshot(new Page.ScreenshotOptions().withPath(Paths.get("O.png" )));
+   * }</pre>
    *
    * @param selector A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See
    * [working with selectors](./selectors.md) for more details.
@@ -2363,7 +2764,16 @@ public interface Page extends AutoCloseable {
    *
    * <p> Shortcuts such as {@code key: "Control+o"} or {@code key: "Control+Shift+T"} are supported as well. When speficied with the
    * modifier, modifier is pressed and being held while the subsequent key is being pressed.
-   *
+   * <pre>{@code
+   * Page page = browser.newPage();
+   * page.navigate("https://keycode.info");
+   * page.press("body", "A");
+   * page.screenshot(new Page.ScreenshotOptions().withPath(Paths.get("A.png")));
+   * page.press("body", "ArrowLeft");
+   * page.screenshot(new Page.ScreenshotOptions().withPath(Paths.get("ArrowLeft.png" )));
+   * page.press("body", "Shift+O");
+   * page.screenshot(new Page.ScreenshotOptions().withPath(Paths.get("O.png" )));
+   * }</pre>
    *
    * @param selector A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See
    * [working with selectors](./selectors.md) for more details.
@@ -2407,7 +2817,21 @@ public interface Page extends AutoCloseable {
    *
    * <p> <strong>NOTE:</strong> The handler will only be called for the first url if the response is a redirect.
    *
+   * <p> An example of a naïve handler that aborts all image requests:
+   * <pre>{@code
+   * Page page = browser.newPage();
+   * page.route("**\/*.{png,jpg,jpeg}", route -> route.abort());
+   * page.navigate("https://example.com");
+   * browser.close();
+   * }</pre>
+   *
    * <p> or the same snippet using a regex pattern instead:
+   * <pre>{@code
+   * Page page = browser.newPage();
+   * page.route(Pattern.compile("(\\.png$)|(\\.jpg$)"),route -> route.abort());
+   * page.navigate("https://example.com");
+   * browser.close();
+   * }</pre>
    *
    * <p> Page routes take precedence over browser context routes (set up with [{@code method: BrowserContext.route}]) when request
    * matches both handlers.
@@ -2425,7 +2849,21 @@ public interface Page extends AutoCloseable {
    *
    * <p> <strong>NOTE:</strong> The handler will only be called for the first url if the response is a redirect.
    *
+   * <p> An example of a naïve handler that aborts all image requests:
+   * <pre>{@code
+   * Page page = browser.newPage();
+   * page.route("**\/*.{png,jpg,jpeg}", route -> route.abort());
+   * page.navigate("https://example.com");
+   * browser.close();
+   * }</pre>
+   *
    * <p> or the same snippet using a regex pattern instead:
+   * <pre>{@code
+   * Page page = browser.newPage();
+   * page.route(Pattern.compile("(\\.png$)|(\\.jpg$)"),route -> route.abort());
+   * page.navigate("https://example.com");
+   * browser.close();
+   * }</pre>
    *
    * <p> Page routes take precedence over browser context routes (set up with [{@code method: BrowserContext.route}]) when request
    * matches both handlers.
@@ -2443,7 +2881,21 @@ public interface Page extends AutoCloseable {
    *
    * <p> <strong>NOTE:</strong> The handler will only be called for the first url if the response is a redirect.
    *
+   * <p> An example of a naïve handler that aborts all image requests:
+   * <pre>{@code
+   * Page page = browser.newPage();
+   * page.route("**\/*.{png,jpg,jpeg}", route -> route.abort());
+   * page.navigate("https://example.com");
+   * browser.close();
+   * }</pre>
+   *
    * <p> or the same snippet using a regex pattern instead:
+   * <pre>{@code
+   * Page page = browser.newPage();
+   * page.route(Pattern.compile("(\\.png$)|(\\.jpg$)"),route -> route.abort());
+   * page.navigate("https://example.com");
+   * browser.close();
+   * }</pre>
    *
    * <p> Page routes take precedence over browser context routes (set up with [{@code method: BrowserContext.route}]) when request
    * matches both handlers.
@@ -2457,8 +2909,7 @@ public interface Page extends AutoCloseable {
   /**
    * Returns the buffer with the captured screenshot.
    *
-   * <p> <strong>NOTE:</strong> Screenshots take at least 1/6 second on Chromium OS X and Chromium Windows. See https://crbug.com/741689 for
-   * discussion.
+   * <p> <strong>NOTE:</strong> Screenshots take at least 1/6 second on Chromium OS X and Chromium Windows. See https://crbug.com/741689 for discussion.
    */
   default byte[] screenshot() {
     return screenshot(null);
@@ -2466,8 +2917,7 @@ public interface Page extends AutoCloseable {
   /**
    * Returns the buffer with the captured screenshot.
    *
-   * <p> <strong>NOTE:</strong> Screenshots take at least 1/6 second on Chromium OS X and Chromium Windows. See https://crbug.com/741689 for
-   * discussion.
+   * <p> <strong>NOTE:</strong> Screenshots take at least 1/6 second on Chromium OS X and Chromium Windows. See https://crbug.com/741689 for discussion.
    */
   byte[] screenshot(ScreenshotOptions options);
   /**
@@ -2477,6 +2927,14 @@ public interface Page extends AutoCloseable {
    * matching {@code selector}, the method throws an error.
    *
    * <p> Will wait until all specified options are present in the {@code <select>} element.
+   * <pre>{@code
+   * // single selection matching the value
+   * page.selectOption("select#colors", "blue");
+   * // single selection matching both the value and the label
+   * page.selectOption("select#colors", new SelectOption().withLabel("Blue"));
+   * // multiple selection
+   * page.selectOption("select#colors", new String[] {"red", "green", "blue"});
+   * }</pre>
    *
    * <p> Shortcut for main frame's [{@code method: Frame.selectOption}]
    *
@@ -2496,6 +2954,14 @@ public interface Page extends AutoCloseable {
    * matching {@code selector}, the method throws an error.
    *
    * <p> Will wait until all specified options are present in the {@code <select>} element.
+   * <pre>{@code
+   * // single selection matching the value
+   * page.selectOption("select#colors", "blue");
+   * // single selection matching both the value and the label
+   * page.selectOption("select#colors", new SelectOption().withLabel("Blue"));
+   * // multiple selection
+   * page.selectOption("select#colors", new String[] {"red", "green", "blue"});
+   * }</pre>
    *
    * <p> Shortcut for main frame's [{@code method: Frame.selectOption}]
    *
@@ -2513,6 +2979,14 @@ public interface Page extends AutoCloseable {
    * matching {@code selector}, the method throws an error.
    *
    * <p> Will wait until all specified options are present in the {@code <select>} element.
+   * <pre>{@code
+   * // single selection matching the value
+   * page.selectOption("select#colors", "blue");
+   * // single selection matching both the value and the label
+   * page.selectOption("select#colors", new SelectOption().withLabel("Blue"));
+   * // multiple selection
+   * page.selectOption("select#colors", new String[] {"red", "green", "blue"});
+   * }</pre>
    *
    * <p> Shortcut for main frame's [{@code method: Frame.selectOption}]
    *
@@ -2532,6 +3006,14 @@ public interface Page extends AutoCloseable {
    * matching {@code selector}, the method throws an error.
    *
    * <p> Will wait until all specified options are present in the {@code <select>} element.
+   * <pre>{@code
+   * // single selection matching the value
+   * page.selectOption("select#colors", "blue");
+   * // single selection matching both the value and the label
+   * page.selectOption("select#colors", new SelectOption().withLabel("Blue"));
+   * // multiple selection
+   * page.selectOption("select#colors", new String[] {"red", "green", "blue"});
+   * }</pre>
    *
    * <p> Shortcut for main frame's [{@code method: Frame.selectOption}]
    *
@@ -2549,6 +3031,14 @@ public interface Page extends AutoCloseable {
    * matching {@code selector}, the method throws an error.
    *
    * <p> Will wait until all specified options are present in the {@code <select>} element.
+   * <pre>{@code
+   * // single selection matching the value
+   * page.selectOption("select#colors", "blue");
+   * // single selection matching both the value and the label
+   * page.selectOption("select#colors", new SelectOption().withLabel("Blue"));
+   * // multiple selection
+   * page.selectOption("select#colors", new String[] {"red", "green", "blue"});
+   * }</pre>
    *
    * <p> Shortcut for main frame's [{@code method: Frame.selectOption}]
    *
@@ -2568,6 +3058,14 @@ public interface Page extends AutoCloseable {
    * matching {@code selector}, the method throws an error.
    *
    * <p> Will wait until all specified options are present in the {@code <select>} element.
+   * <pre>{@code
+   * // single selection matching the value
+   * page.selectOption("select#colors", "blue");
+   * // single selection matching both the value and the label
+   * page.selectOption("select#colors", new SelectOption().withLabel("Blue"));
+   * // multiple selection
+   * page.selectOption("select#colors", new String[] {"red", "green", "blue"});
+   * }</pre>
    *
    * <p> Shortcut for main frame's [{@code method: Frame.selectOption}]
    *
@@ -2585,6 +3083,14 @@ public interface Page extends AutoCloseable {
    * matching {@code selector}, the method throws an error.
    *
    * <p> Will wait until all specified options are present in the {@code <select>} element.
+   * <pre>{@code
+   * // single selection matching the value
+   * page.selectOption("select#colors", "blue");
+   * // single selection matching both the value and the label
+   * page.selectOption("select#colors", new SelectOption().withLabel("Blue"));
+   * // multiple selection
+   * page.selectOption("select#colors", new String[] {"red", "green", "blue"});
+   * }</pre>
    *
    * <p> Shortcut for main frame's [{@code method: Frame.selectOption}]
    *
@@ -2604,6 +3110,14 @@ public interface Page extends AutoCloseable {
    * matching {@code selector}, the method throws an error.
    *
    * <p> Will wait until all specified options are present in the {@code <select>} element.
+   * <pre>{@code
+   * // single selection matching the value
+   * page.selectOption("select#colors", "blue");
+   * // single selection matching both the value and the label
+   * page.selectOption("select#colors", new SelectOption().withLabel("Blue"));
+   * // multiple selection
+   * page.selectOption("select#colors", new String[] {"red", "green", "blue"});
+   * }</pre>
    *
    * <p> Shortcut for main frame's [{@code method: Frame.selectOption}]
    *
@@ -2621,6 +3135,14 @@ public interface Page extends AutoCloseable {
    * matching {@code selector}, the method throws an error.
    *
    * <p> Will wait until all specified options are present in the {@code <select>} element.
+   * <pre>{@code
+   * // single selection matching the value
+   * page.selectOption("select#colors", "blue");
+   * // single selection matching both the value and the label
+   * page.selectOption("select#colors", new SelectOption().withLabel("Blue"));
+   * // multiple selection
+   * page.selectOption("select#colors", new String[] {"red", "green", "blue"});
+   * }</pre>
    *
    * <p> Shortcut for main frame's [{@code method: Frame.selectOption}]
    *
@@ -2640,6 +3162,14 @@ public interface Page extends AutoCloseable {
    * matching {@code selector}, the method throws an error.
    *
    * <p> Will wait until all specified options are present in the {@code <select>} element.
+   * <pre>{@code
+   * // single selection matching the value
+   * page.selectOption("select#colors", "blue");
+   * // single selection matching both the value and the label
+   * page.selectOption("select#colors", new SelectOption().withLabel("Blue"));
+   * // multiple selection
+   * page.selectOption("select#colors", new String[] {"red", "green", "blue"});
+   * }</pre>
    *
    * <p> Shortcut for main frame's [{@code method: Frame.selectOption}]
    *
@@ -2657,6 +3187,14 @@ public interface Page extends AutoCloseable {
    * matching {@code selector}, the method throws an error.
    *
    * <p> Will wait until all specified options are present in the {@code <select>} element.
+   * <pre>{@code
+   * // single selection matching the value
+   * page.selectOption("select#colors", "blue");
+   * // single selection matching both the value and the label
+   * page.selectOption("select#colors", new SelectOption().withLabel("Blue"));
+   * // multiple selection
+   * page.selectOption("select#colors", new String[] {"red", "green", "blue"});
+   * }</pre>
    *
    * <p> Shortcut for main frame's [{@code method: Frame.selectOption}]
    *
@@ -2676,6 +3214,14 @@ public interface Page extends AutoCloseable {
    * matching {@code selector}, the method throws an error.
    *
    * <p> Will wait until all specified options are present in the {@code <select>} element.
+   * <pre>{@code
+   * // single selection matching the value
+   * page.selectOption("select#colors", "blue");
+   * // single selection matching both the value and the label
+   * page.selectOption("select#colors", new SelectOption().withLabel("Blue"));
+   * // multiple selection
+   * page.selectOption("select#colors", new String[] {"red", "green", "blue"});
+   * }</pre>
    *
    * <p> Shortcut for main frame's [{@code method: Frame.selectOption}]
    *
@@ -2702,12 +3248,14 @@ public interface Page extends AutoCloseable {
   void setContent(String html, SetContentOptions options);
   /**
    * This setting will change the default maximum navigation time for the following methods and related shortcuts:
-   * - [{@code method: Page.goBack}]
-   * - [{@code method: Page.goForward}]
-   * - [{@code method: Page.goto}]
-   * - [{@code method: Page.reload}]
-   * - [{@code method: Page.setContent}]
-   * - [{@code method: Page.waitForNavigation}]
+   * <ul>
+   * <li> [{@code method: Page.goBack}]</li>
+   * <li> [{@code method: Page.goForward}]</li>
+   * <li> [{@code method: Page.goto}]</li>
+   * <li> [{@code method: Page.reload}]</li>
+   * <li> [{@code method: Page.setContent}]</li>
+   * <li> [{@code method: Page.waitForNavigation}]</li>
+   * </ul>
    *
    * <p> <strong>NOTE:</strong> [{@code method: Page.setDefaultNavigationTimeout}] takes priority over [{@code method: Page.setDefaultTimeout}],
    * [{@code method: BrowserContext.setDefaultTimeout}] and [{@code method: BrowserContext.setDefaultNavigationTimeout}].
@@ -2833,16 +3381,23 @@ public interface Page extends AutoCloseable {
    *
    * <p> {@code page.setViewportSize} will resize the page. A lot of websites don't expect phones to change size, so you should set the
    * viewport size before navigating to the page.
+   * <pre>{@code
+   * Page page = browser.newPage();
+   * page.setViewportSize(640, 480);
+   * page.navigate("https://example.com");
+   * }</pre>
    */
   void setViewportSize(int width, int height);
   /**
    * This method taps an element matching {@code selector} by performing the following steps:
-   * 1. Find an element match matching {@code selector}. If there is none, wait until a matching element is attached to the DOM.
-   * 1. Wait for [actionability](./actionability.md) checks on the matched element, unless {@code force} option is set. If the
-   *    element is detached during the checks, the whole action is retried.
-   * 1. Scroll the element into view if needed.
-   * 1. Use [{@code property: Page.touchscreen}] to tap the center of the element, or the specified {@code position}.
-   * 1. Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.
+   * <ol>
+   * <li> Find an element match matching {@code selector}. If there is none, wait until a matching element is attached to the DOM.</li>
+   * <li> Wait for [actionability](./actionability.md) checks on the matched element, unless {@code force} option is set. If the element
+   * is detached during the checks, the whole action is retried.</li>
+   * <li> Scroll the element into view if needed.</li>
+   * <li> Use [{@code property: Page.touchscreen}] to tap the center of the element, or the specified {@code position}.</li>
+   * <li> Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.</li>
+   * </ol>
    *
    * <p> When all steps combined have not finished during the specified {@code timeout}, this method rejects with a {@code TimeoutError}.
    * Passing zero timeout disables this.
@@ -2859,12 +3414,14 @@ public interface Page extends AutoCloseable {
   }
   /**
    * This method taps an element matching {@code selector} by performing the following steps:
-   * 1. Find an element match matching {@code selector}. If there is none, wait until a matching element is attached to the DOM.
-   * 1. Wait for [actionability](./actionability.md) checks on the matched element, unless {@code force} option is set. If the
-   *    element is detached during the checks, the whole action is retried.
-   * 1. Scroll the element into view if needed.
-   * 1. Use [{@code property: Page.touchscreen}] to tap the center of the element, or the specified {@code position}.
-   * 1. Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.
+   * <ol>
+   * <li> Find an element match matching {@code selector}. If there is none, wait until a matching element is attached to the DOM.</li>
+   * <li> Wait for [actionability](./actionability.md) checks on the matched element, unless {@code force} option is set. If the element
+   * is detached during the checks, the whole action is retried.</li>
+   * <li> Scroll the element into view if needed.</li>
+   * <li> Use [{@code property: Page.touchscreen}] to tap the center of the element, or the specified {@code position}.</li>
+   * <li> Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.</li>
+   * </ol>
    *
    * <p> When all steps combined have not finished during the specified {@code timeout}, this method rejects with a {@code TimeoutError}.
    * Passing zero timeout disables this.
@@ -2903,6 +3460,12 @@ public interface Page extends AutoCloseable {
    * fine-grained keyboard events. To fill values in form fields, use [{@code method: Page.fill}].
    *
    * <p> To press a special key, like {@code Control} or {@code ArrowDown}, use [{@code method: Keyboard.press}].
+   * <pre>{@code
+   * // Types instantly
+   * page.type("#mytextarea", "Hello");
+   * // Types slower, like a user
+   * page.type("#mytextarea", "World", new Page.TypeOptions().withDelay(100));
+   * }</pre>
    *
    * <p> Shortcut for main frame's [{@code method: Frame.type}].
    *
@@ -2918,6 +3481,12 @@ public interface Page extends AutoCloseable {
    * fine-grained keyboard events. To fill values in form fields, use [{@code method: Page.fill}].
    *
    * <p> To press a special key, like {@code Control} or {@code ArrowDown}, use [{@code method: Keyboard.press}].
+   * <pre>{@code
+   * // Types instantly
+   * page.type("#mytextarea", "Hello");
+   * // Types slower, like a user
+   * page.type("#mytextarea", "World", new Page.TypeOptions().withDelay(100));
+   * }</pre>
    *
    * <p> Shortcut for main frame's [{@code method: Frame.type}].
    *
@@ -2928,15 +3497,17 @@ public interface Page extends AutoCloseable {
   void type(String selector, String text, TypeOptions options);
   /**
    * This method unchecks an element matching {@code selector} by performing the following steps:
-   * 1. Find an element match matching {@code selector}. If there is none, wait until a matching element is attached to the DOM.
-   * 1. Ensure that matched element is a checkbox or a radio input. If not, this method rejects. If the element is already
-   *    unchecked, this method returns immediately.
-   * 1. Wait for [actionability](./actionability.md) checks on the matched element, unless {@code force} option is set. If the
-   *    element is detached during the checks, the whole action is retried.
-   * 1. Scroll the element into view if needed.
-   * 1. Use [{@code property: Page.mouse}] to click in the center of the element.
-   * 1. Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.
-   * 1. Ensure that the element is now unchecked. If not, this method rejects.
+   * <ol>
+   * <li> Find an element match matching {@code selector}. If there is none, wait until a matching element is attached to the DOM.</li>
+   * <li> Ensure that matched element is a checkbox or a radio input. If not, this method rejects. If the element is already
+   * unchecked, this method returns immediately.</li>
+   * <li> Wait for [actionability](./actionability.md) checks on the matched element, unless {@code force} option is set. If the element
+   * is detached during the checks, the whole action is retried.</li>
+   * <li> Scroll the element into view if needed.</li>
+   * <li> Use [{@code property: Page.mouse}] to click in the center of the element.</li>
+   * <li> Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.</li>
+   * <li> Ensure that the element is now unchecked. If not, this method rejects.</li>
+   * </ol>
    *
    * <p> When all steps combined have not finished during the specified {@code timeout}, this method rejects with a {@code TimeoutError}.
    * Passing zero timeout disables this.
@@ -2951,15 +3522,17 @@ public interface Page extends AutoCloseable {
   }
   /**
    * This method unchecks an element matching {@code selector} by performing the following steps:
-   * 1. Find an element match matching {@code selector}. If there is none, wait until a matching element is attached to the DOM.
-   * 1. Ensure that matched element is a checkbox or a radio input. If not, this method rejects. If the element is already
-   *    unchecked, this method returns immediately.
-   * 1. Wait for [actionability](./actionability.md) checks on the matched element, unless {@code force} option is set. If the
-   *    element is detached during the checks, the whole action is retried.
-   * 1. Scroll the element into view if needed.
-   * 1. Use [{@code property: Page.mouse}] to click in the center of the element.
-   * 1. Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.
-   * 1. Ensure that the element is now unchecked. If not, this method rejects.
+   * <ol>
+   * <li> Find an element match matching {@code selector}. If there is none, wait until a matching element is attached to the DOM.</li>
+   * <li> Ensure that matched element is a checkbox or a radio input. If not, this method rejects. If the element is already
+   * unchecked, this method returns immediately.</li>
+   * <li> Wait for [actionability](./actionability.md) checks on the matched element, unless {@code force} option is set. If the element
+   * is detached during the checks, the whole action is retried.</li>
+   * <li> Scroll the element into view if needed.</li>
+   * <li> Use [{@code property: Page.mouse}] to click in the center of the element.</li>
+   * <li> Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.</li>
+   * <li> Ensure that the element is now unchecked. If not, this method rejects.</li>
+   * </ol>
    *
    * <p> When all steps combined have not finished during the specified {@code timeout}, this method rejects with a {@code TimeoutError}.
    * Passing zero timeout disables this.
@@ -3096,8 +3669,28 @@ public interface Page extends AutoCloseable {
    * Returns when the {@code expression} returns a truthy value. It resolves to a JSHandle of the truthy value.
    *
    * <p> The [{@code method: Page.waitForFunction}] can be used to observe viewport size change:
+   * <pre>{@code
+   * import com.microsoft.playwright.*;
+   *
+   * public class Example {
+   *   public static void main(String[] args) {
+   *     try (Playwright playwright = Playwright.create()) {
+   *       BrowserType webkit = playwright.webkit();
+   *       Browser browser = webkit.launch();
+   *       Page page = browser.newPage();
+   *       page.setViewportSize(50,  50);
+   *       page.waitForFunction("() => window.innerWidth < 100");
+   *       browser.close();
+   *     }
+   *   }
+   * }
+   * }</pre>
    *
    * <p> To pass an argument to the predicate of [{@code method: Page.waitForFunction}] function:
+   * <pre>{@code
+   * String selector = ".foo";
+   * page.waitForFunction("selector => !!document.querySelector(selector)", selector);
+   * }</pre>
    *
    * <p> Shortcut for main frame's [{@code method: Frame.waitForFunction}].
    *
@@ -3112,8 +3705,28 @@ public interface Page extends AutoCloseable {
    * Returns when the {@code expression} returns a truthy value. It resolves to a JSHandle of the truthy value.
    *
    * <p> The [{@code method: Page.waitForFunction}] can be used to observe viewport size change:
+   * <pre>{@code
+   * import com.microsoft.playwright.*;
+   *
+   * public class Example {
+   *   public static void main(String[] args) {
+   *     try (Playwright playwright = Playwright.create()) {
+   *       BrowserType webkit = playwright.webkit();
+   *       Browser browser = webkit.launch();
+   *       Page page = browser.newPage();
+   *       page.setViewportSize(50,  50);
+   *       page.waitForFunction("() => window.innerWidth < 100");
+   *       browser.close();
+   *     }
+   *   }
+   * }
+   * }</pre>
    *
    * <p> To pass an argument to the predicate of [{@code method: Page.waitForFunction}] function:
+   * <pre>{@code
+   * String selector = ".foo";
+   * page.waitForFunction("selector => !!document.querySelector(selector)", selector);
+   * }</pre>
    *
    * <p> Shortcut for main frame's [{@code method: Frame.waitForFunction}].
    *
@@ -3127,8 +3740,28 @@ public interface Page extends AutoCloseable {
    * Returns when the {@code expression} returns a truthy value. It resolves to a JSHandle of the truthy value.
    *
    * <p> The [{@code method: Page.waitForFunction}] can be used to observe viewport size change:
+   * <pre>{@code
+   * import com.microsoft.playwright.*;
+   *
+   * public class Example {
+   *   public static void main(String[] args) {
+   *     try (Playwright playwright = Playwright.create()) {
+   *       BrowserType webkit = playwright.webkit();
+   *       Browser browser = webkit.launch();
+   *       Page page = browser.newPage();
+   *       page.setViewportSize(50,  50);
+   *       page.waitForFunction("() => window.innerWidth < 100");
+   *       browser.close();
+   *     }
+   *   }
+   * }
+   * }</pre>
    *
    * <p> To pass an argument to the predicate of [{@code method: Page.waitForFunction}] function:
+   * <pre>{@code
+   * String selector = ".foo";
+   * page.waitForFunction("selector => !!document.querySelector(selector)", selector);
+   * }</pre>
    *
    * <p> Shortcut for main frame's [{@code method: Frame.waitForFunction}].
    *
@@ -3142,14 +3775,27 @@ public interface Page extends AutoCloseable {
    *
    * <p> This resolves when the page reaches a required load state, {@code load} by default. The navigation must have been committed
    * when this method is called. If current document has already reached the required state, resolves immediately.
+   * <pre>{@code
+   * page.click("button"); // Click triggers navigation.
+   * page.waitForLoadState(); // The promise resolves after "load" event.
+   * }</pre>
+   * <pre>{@code
+   * Page popup = page.waitForPopup(() -> {
+   *   page.click("button"); // Click triggers a popup.
+   * });
+   * popup.waitForLoadState(LoadState.DOMCONTENTLOADED);
+   * System.out.println(popup.title()); // Popup is ready to use.
+   * }</pre>
    *
    * <p> Shortcut for main frame's [{@code method: Frame.waitForLoadState}].
    *
    * @param state Optional load state to wait for, defaults to {@code load}. If the state has been already reached while loading current
    * document, the method resolves immediately. Can be one of:
-   * - {@code 'load'} - wait for the {@code load} event to be fired.
-   * - {@code 'domcontentloaded'} - wait for the {@code DOMContentLoaded} event to be fired.
-   * - {@code 'networkidle'} - wait until there are no network connections for at least {@code 500} ms.
+   * <ul>
+   * <li> {@code 'load'} - wait for the {@code load} event to be fired.</li>
+   * <li> {@code 'domcontentloaded'} - wait for the {@code DOMContentLoaded} event to be fired.</li>
+   * <li> {@code 'networkidle'} - wait until there are no network connections for at least {@code 500} ms.</li>
+   * </ul>
    */
   default void waitForLoadState(LoadState state) {
     waitForLoadState(state, null);
@@ -3159,6 +3805,17 @@ public interface Page extends AutoCloseable {
    *
    * <p> This resolves when the page reaches a required load state, {@code load} by default. The navigation must have been committed
    * when this method is called. If current document has already reached the required state, resolves immediately.
+   * <pre>{@code
+   * page.click("button"); // Click triggers navigation.
+   * page.waitForLoadState(); // The promise resolves after "load" event.
+   * }</pre>
+   * <pre>{@code
+   * Page popup = page.waitForPopup(() -> {
+   *   page.click("button"); // Click triggers a popup.
+   * });
+   * popup.waitForLoadState(LoadState.DOMCONTENTLOADED);
+   * System.out.println(popup.title()); // Popup is ready to use.
+   * }</pre>
    *
    * <p> Shortcut for main frame's [{@code method: Frame.waitForLoadState}].
    */
@@ -3170,14 +3827,27 @@ public interface Page extends AutoCloseable {
    *
    * <p> This resolves when the page reaches a required load state, {@code load} by default. The navigation must have been committed
    * when this method is called. If current document has already reached the required state, resolves immediately.
+   * <pre>{@code
+   * page.click("button"); // Click triggers navigation.
+   * page.waitForLoadState(); // The promise resolves after "load" event.
+   * }</pre>
+   * <pre>{@code
+   * Page popup = page.waitForPopup(() -> {
+   *   page.click("button"); // Click triggers a popup.
+   * });
+   * popup.waitForLoadState(LoadState.DOMCONTENTLOADED);
+   * System.out.println(popup.title()); // Popup is ready to use.
+   * }</pre>
    *
    * <p> Shortcut for main frame's [{@code method: Frame.waitForLoadState}].
    *
    * @param state Optional load state to wait for, defaults to {@code load}. If the state has been already reached while loading current
    * document, the method resolves immediately. Can be one of:
-   * - {@code 'load'} - wait for the {@code load} event to be fired.
-   * - {@code 'domcontentloaded'} - wait for the {@code DOMContentLoaded} event to be fired.
-   * - {@code 'networkidle'} - wait until there are no network connections for at least {@code 500} ms.
+   * <ul>
+   * <li> {@code 'load'} - wait for the {@code load} event to be fired.</li>
+   * <li> {@code 'domcontentloaded'} - wait for the {@code DOMContentLoaded} event to be fired.</li>
+   * <li> {@code 'networkidle'} - wait until there are no network connections for at least {@code 500} ms.</li>
+   * </ul>
    */
   void waitForLoadState(LoadState state, WaitForLoadStateOptions options);
   /**
@@ -3188,9 +3858,15 @@ public interface Page extends AutoCloseable {
    * <p> This resolves when the page navigates to a new URL or reloads. It is useful for when you run code which will indirectly
    * cause the page to navigate. e.g. The click target has an {@code onclick} handler that triggers navigation from a {@code setTimeout}.
    * Consider this example:
+   * <pre>{@code
+   * // The method returns after navigation has finished
+   * Response response = page.waitForNavigation(() -> {
+   *   page.click("a.delayed-navigation"); // Clicking the link will indirectly cause a navigation
+   * });
+   * }</pre>
    *
-   * <p> <strong>NOTE:</strong> Usage of the [History API](https://developer.mozilla.org/en-US/docs/Web/API/History_API) to change the URL is
-   * considered a navigation.
+   * <p> <strong>NOTE:</strong> Usage of the [History API](https://developer.mozilla.org/en-US/docs/Web/API/History_API) to change the URL is considered
+   * a navigation.
    *
    * <p> Shortcut for main frame's [{@code method: Frame.waitForNavigation}].
    *
@@ -3207,9 +3883,15 @@ public interface Page extends AutoCloseable {
    * <p> This resolves when the page navigates to a new URL or reloads. It is useful for when you run code which will indirectly
    * cause the page to navigate. e.g. The click target has an {@code onclick} handler that triggers navigation from a {@code setTimeout}.
    * Consider this example:
+   * <pre>{@code
+   * // The method returns after navigation has finished
+   * Response response = page.waitForNavigation(() -> {
+   *   page.click("a.delayed-navigation"); // Clicking the link will indirectly cause a navigation
+   * });
+   * }</pre>
    *
-   * <p> <strong>NOTE:</strong> Usage of the [History API](https://developer.mozilla.org/en-US/docs/Web/API/History_API) to change the URL is
-   * considered a navigation.
+   * <p> <strong>NOTE:</strong> Usage of the [History API](https://developer.mozilla.org/en-US/docs/Web/API/History_API) to change the URL is considered
+   * a navigation.
    *
    * <p> Shortcut for main frame's [{@code method: Frame.waitForNavigation}].
    *
@@ -3236,7 +3918,12 @@ public interface Page extends AutoCloseable {
   Page waitForPopup(WaitForPopupOptions options, Runnable callback);
   /**
    * Waits for the matching request and returns it.
-   *
+   * <pre>{@code
+   * Request firstRequest = page.waitForRequest("http://example.com/resource");
+   * Object finalRequest = page.waitForRequest(
+   *   request -> "http://example.com".equals(request.url()) && "GET".equals(request.method()), () -> {});
+   * return firstRequest.url();
+   * }</pre>
    *
    * @param urlOrPredicate Request URL string, regex or predicate receiving {@code Request} object.
    * @param callback Callback that performs the action triggering the event.
@@ -3246,7 +3933,12 @@ public interface Page extends AutoCloseable {
   }
   /**
    * Waits for the matching request and returns it.
-   *
+   * <pre>{@code
+   * Request firstRequest = page.waitForRequest("http://example.com/resource");
+   * Object finalRequest = page.waitForRequest(
+   *   request -> "http://example.com".equals(request.url()) && "GET".equals(request.method()), () -> {});
+   * return firstRequest.url();
+   * }</pre>
    *
    * @param urlOrPredicate Request URL string, regex or predicate receiving {@code Request} object.
    * @param callback Callback that performs the action triggering the event.
@@ -3254,7 +3946,12 @@ public interface Page extends AutoCloseable {
   Request waitForRequest(String urlOrPredicate, WaitForRequestOptions options, Runnable callback);
   /**
    * Waits for the matching request and returns it.
-   *
+   * <pre>{@code
+   * Request firstRequest = page.waitForRequest("http://example.com/resource");
+   * Object finalRequest = page.waitForRequest(
+   *   request -> "http://example.com".equals(request.url()) && "GET".equals(request.method()), () -> {});
+   * return firstRequest.url();
+   * }</pre>
    *
    * @param urlOrPredicate Request URL string, regex or predicate receiving {@code Request} object.
    * @param callback Callback that performs the action triggering the event.
@@ -3264,7 +3961,12 @@ public interface Page extends AutoCloseable {
   }
   /**
    * Waits for the matching request and returns it.
-   *
+   * <pre>{@code
+   * Request firstRequest = page.waitForRequest("http://example.com/resource");
+   * Object finalRequest = page.waitForRequest(
+   *   request -> "http://example.com".equals(request.url()) && "GET".equals(request.method()), () -> {});
+   * return firstRequest.url();
+   * }</pre>
    *
    * @param urlOrPredicate Request URL string, regex or predicate receiving {@code Request} object.
    * @param callback Callback that performs the action triggering the event.
@@ -3272,7 +3974,12 @@ public interface Page extends AutoCloseable {
   Request waitForRequest(Pattern urlOrPredicate, WaitForRequestOptions options, Runnable callback);
   /**
    * Waits for the matching request and returns it.
-   *
+   * <pre>{@code
+   * Request firstRequest = page.waitForRequest("http://example.com/resource");
+   * Object finalRequest = page.waitForRequest(
+   *   request -> "http://example.com".equals(request.url()) && "GET".equals(request.method()), () -> {});
+   * return firstRequest.url();
+   * }</pre>
    *
    * @param urlOrPredicate Request URL string, regex or predicate receiving {@code Request} object.
    * @param callback Callback that performs the action triggering the event.
@@ -3282,7 +3989,12 @@ public interface Page extends AutoCloseable {
   }
   /**
    * Waits for the matching request and returns it.
-   *
+   * <pre>{@code
+   * Request firstRequest = page.waitForRequest("http://example.com/resource");
+   * Object finalRequest = page.waitForRequest(
+   *   request -> "http://example.com".equals(request.url()) && "GET".equals(request.method()), () -> {});
+   * return firstRequest.url();
+   * }</pre>
    *
    * @param urlOrPredicate Request URL string, regex or predicate receiving {@code Request} object.
    * @param callback Callback that performs the action triggering the event.
@@ -3290,7 +4002,11 @@ public interface Page extends AutoCloseable {
   Request waitForRequest(Predicate<Request> urlOrPredicate, WaitForRequestOptions options, Runnable callback);
   /**
    * Returns the matched response.
-   *
+   * <pre>{@code
+   * Response firstResponse = page.waitForResponse("https://example.com/resource", () -> {});
+   * Response finalResponse = page.waitForResponse(response -> "https://example.com".equals(response.url()) && response.status() == 200, () -> {});
+   * return finalResponse.ok();
+   * }</pre>
    *
    * @param urlOrPredicate Request URL string, regex or predicate receiving {@code Response} object.
    * @param callback Callback that performs the action triggering the event.
@@ -3300,7 +4016,11 @@ public interface Page extends AutoCloseable {
   }
   /**
    * Returns the matched response.
-   *
+   * <pre>{@code
+   * Response firstResponse = page.waitForResponse("https://example.com/resource", () -> {});
+   * Response finalResponse = page.waitForResponse(response -> "https://example.com".equals(response.url()) && response.status() == 200, () -> {});
+   * return finalResponse.ok();
+   * }</pre>
    *
    * @param urlOrPredicate Request URL string, regex or predicate receiving {@code Response} object.
    * @param callback Callback that performs the action triggering the event.
@@ -3308,7 +4028,11 @@ public interface Page extends AutoCloseable {
   Response waitForResponse(String urlOrPredicate, WaitForResponseOptions options, Runnable callback);
   /**
    * Returns the matched response.
-   *
+   * <pre>{@code
+   * Response firstResponse = page.waitForResponse("https://example.com/resource", () -> {});
+   * Response finalResponse = page.waitForResponse(response -> "https://example.com".equals(response.url()) && response.status() == 200, () -> {});
+   * return finalResponse.ok();
+   * }</pre>
    *
    * @param urlOrPredicate Request URL string, regex or predicate receiving {@code Response} object.
    * @param callback Callback that performs the action triggering the event.
@@ -3318,7 +4042,11 @@ public interface Page extends AutoCloseable {
   }
   /**
    * Returns the matched response.
-   *
+   * <pre>{@code
+   * Response firstResponse = page.waitForResponse("https://example.com/resource", () -> {});
+   * Response finalResponse = page.waitForResponse(response -> "https://example.com".equals(response.url()) && response.status() == 200, () -> {});
+   * return finalResponse.ok();
+   * }</pre>
    *
    * @param urlOrPredicate Request URL string, regex or predicate receiving {@code Response} object.
    * @param callback Callback that performs the action triggering the event.
@@ -3326,7 +4054,11 @@ public interface Page extends AutoCloseable {
   Response waitForResponse(Pattern urlOrPredicate, WaitForResponseOptions options, Runnable callback);
   /**
    * Returns the matched response.
-   *
+   * <pre>{@code
+   * Response firstResponse = page.waitForResponse("https://example.com/resource", () -> {});
+   * Response finalResponse = page.waitForResponse(response -> "https://example.com".equals(response.url()) && response.status() == 200, () -> {});
+   * return finalResponse.ok();
+   * }</pre>
    *
    * @param urlOrPredicate Request URL string, regex or predicate receiving {@code Response} object.
    * @param callback Callback that performs the action triggering the event.
@@ -3336,7 +4068,11 @@ public interface Page extends AutoCloseable {
   }
   /**
    * Returns the matched response.
-   *
+   * <pre>{@code
+   * Response firstResponse = page.waitForResponse("https://example.com/resource", () -> {});
+   * Response finalResponse = page.waitForResponse(response -> "https://example.com".equals(response.url()) && response.status() == 200, () -> {});
+   * return finalResponse.ok();
+   * }</pre>
    *
    * @param urlOrPredicate Request URL string, regex or predicate receiving {@code Response} object.
    * @param callback Callback that performs the action triggering the event.
@@ -3351,7 +4087,25 @@ public interface Page extends AutoCloseable {
    * selector doesn't satisfy the condition for the {@code timeout} milliseconds, the function will throw.
    *
    * <p> This method works across navigations:
+   * <pre>{@code
+   * import com.microsoft.playwright.*;
    *
+   * public class Example {
+   *   public static void main(String[] args) {
+   *     try (Playwright playwright = Playwright.create()) {
+   *       BrowserType chromium = playwright.chromium();
+   *       Browser browser = chromium.launch();
+   *       Page page = browser.newPage();
+   *       for (String currentURL : Arrays.asList("https://google.com", "https://bbc.com")) {
+   *         page.navigate(currentURL);
+   *         ElementHandle element = page.waitForSelector("img");
+   *         System.out.println("Loaded image: " + element.getAttribute("src"));
+   *       }
+   *       browser.close();
+   *     }
+   *   }
+   * }
+   * }</pre>
    *
    * @param selector A selector to query for. See [working with selectors](./selectors.md) for more details.
    */
@@ -3367,7 +4121,25 @@ public interface Page extends AutoCloseable {
    * selector doesn't satisfy the condition for the {@code timeout} milliseconds, the function will throw.
    *
    * <p> This method works across navigations:
+   * <pre>{@code
+   * import com.microsoft.playwright.*;
    *
+   * public class Example {
+   *   public static void main(String[] args) {
+   *     try (Playwright playwright = Playwright.create()) {
+   *       BrowserType chromium = playwright.chromium();
+   *       Browser browser = chromium.launch();
+   *       Page page = browser.newPage();
+   *       for (String currentURL : Arrays.asList("https://google.com", "https://bbc.com")) {
+   *         page.navigate(currentURL);
+   *         ElementHandle element = page.waitForSelector("img");
+   *         System.out.println("Loaded image: " + element.getAttribute("src"));
+   *       }
+   *       browser.close();
+   *     }
+   *   }
+   * }
+   * }</pre>
    *
    * @param selector A selector to query for. See [working with selectors](./selectors.md) for more details.
    */
@@ -3377,6 +4149,10 @@ public interface Page extends AutoCloseable {
    *
    * <p> Note that {@code page.waitForTimeout()} should only be used for debugging. Tests using the timer in production are going to be
    * flaky. Use signals such as network events, selectors becoming visible and others instead.
+   * <pre>{@code
+   * // wait for 1 second
+   * page.waitForTimeout(1000);
+   * }</pre>
    *
    * <p> Shortcut for main frame's [{@code method: Frame.waitForTimeout}].
    *

--- a/playwright/src/main/java/com/microsoft/playwright/Playwright.java
+++ b/playwright/src/main/java/com/microsoft/playwright/Playwright.java
@@ -22,6 +22,22 @@ import java.util.*;
 /**
  * Playwright module provides a method to launch a browser instance. The following is a typical example of using Playwright
  * to drive automation:
+ * <pre>{@code
+ * import com.microsoft.playwright.*;
+ *
+ * public class Example {
+ *   public static void main(String[] args) {
+ *     try (Playwright playwright = Playwright.create()) {
+ *       BrowserType chromium = playwright.chromium();
+ *       Browser browser = chromium.launch();
+ *       Page page = browser.newPage();
+ *       page.navigate("http://example.com");
+ *       // other actions...
+ *       browser.close();
+ *     }
+ *   }
+ * }
+ * }</pre>
  */
 public interface Playwright extends AutoCloseable {
   /**

--- a/playwright/src/main/java/com/microsoft/playwright/Request.java
+++ b/playwright/src/main/java/com/microsoft/playwright/Request.java
@@ -21,15 +21,17 @@ import java.util.*;
 
 /**
  * Whenever the page sends a request for a network resource the following sequence of events are emitted by {@code Page}:
- * - [{@code event: Page.request}] emitted when the request is issued by the page.
- * - [{@code event: Page.response}] emitted when/if the response status and headers are received for the request.
- * - [{@code event: Page.requestFinished}] emitted when the response body is downloaded and the request is complete.
+ * <ul>
+ * <li> [{@code event: Page.request}] emitted when the request is issued by the page.</li>
+ * <li> [{@code event: Page.response}] emitted when/if the response status and headers are received for the request.</li>
+ * <li> [{@code event: Page.requestFinished}] emitted when the response body is downloaded and the request is complete.</li>
+ * </ul>
  *
  * <p> If request fails at some point, then instead of {@code 'requestfinished'} event (and possibly instead of 'response' event),
  * the  [{@code event: Page.requestFailed}] event is emitted.
  *
- * <p> <strong>NOTE:</strong> HTTP Error responses, such as 404 or 503, are still successful responses from HTTP standpoint, so request will
- * complete with {@code 'requestfinished'} event.
+ * <p> <strong>NOTE:</strong> HTTP Error responses, such as 404 or 503, are still successful responses from HTTP standpoint, so request will complete
+ * with {@code 'requestfinished'} event.
  *
  * <p> If request gets a 'redirect' response, the request is successfully finished with the 'requestfinished' event, and a new
  * request is  issued to a redirected url.
@@ -39,6 +41,11 @@ public interface Request {
    * The method returns {@code null} unless this request has failed, as reported by {@code requestfailed} event.
    *
    * <p> Example of logging of all the failed requests:
+   * <pre>{@code
+   * page.onRequestFailed(request -> {
+   *   System.out.println(request.url() + " " + request.failure());
+   * });
+   * }</pre>
    */
   String failure();
   /**
@@ -73,14 +80,25 @@ public interface Request {
    * construct the whole redirect chain by repeatedly calling {@code redirectedFrom()}.
    *
    * <p> For example, if the website {@code http://example.com} redirects to {@code https://example.com}:
+   * <pre>{@code
+   * Response response = page.navigate("http://example.com");
+   * System.out.println(response.request().redirectedFrom().url()); // "http://example.com"
+   * }</pre>
    *
    * <p> If the website {@code https://google.com} has no redirects:
+   * <pre>{@code
+   * Response response = page.navigate("https://google.com");
+   * System.out.println(response.request().redirectedFrom()); // null
+   * }</pre>
    */
   Request redirectedFrom();
   /**
    * New request issued by the browser if the server responded with redirect.
    *
    * <p> This method is the opposite of [{@code method: Request.redirectedFrom}]:
+   * <pre>{@code
+   * System.out.println(request.redirectedFrom().redirectedTo() == request); // true
+   * }</pre>
    */
   Request redirectedTo();
   /**
@@ -97,6 +115,13 @@ public interface Request {
    * Returns resource timing information for given request. Most of the timing values become available upon the response,
    * {@code responseEnd} becomes available when request finishes. Find more information at
    * [Resource Timing API](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceResourceTiming).
+   * <pre>{@code
+   * page.onRequestFinished(request -> {
+   *   Timing timing = request.timing();
+   *   System.out.println(timing.responseEnd - timing.startTime);
+   * });
+   * page.navigate("http://example.com");
+   * }</pre>
    */
   Timing timing();
   /**

--- a/playwright/src/main/java/com/microsoft/playwright/Route.java
+++ b/playwright/src/main/java/com/microsoft/playwright/Route.java
@@ -126,42 +126,94 @@ public interface Route {
    * Aborts the route's request.
    *
    * @param errorCode Optional error code. Defaults to {@code failed}, could be one of the following:
-   * - {@code 'aborted'} - An operation was aborted (due to user action)
-   * - {@code 'accessdenied'} - Permission to access a resource, other than the network, was denied
-   * - {@code 'addressunreachable'} - The IP address is unreachable. This usually means that there is no route to the specified
-   *   host or network.
-   * - {@code 'blockedbyclient'} - The client chose to block the request.
-   * - {@code 'blockedbyresponse'} - The request failed because the response was delivered along with requirements which are not
-   *   met ('X-Frame-Options' and 'Content-Security-Policy' ancestor checks, for instance).
-   * - {@code 'connectionaborted'} - A connection timed out as a result of not receiving an ACK for data sent.
-   * - {@code 'connectionclosed'} - A connection was closed (corresponding to a TCP FIN).
-   * - {@code 'connectionfailed'} - A connection attempt failed.
-   * - {@code 'connectionrefused'} - A connection attempt was refused.
-   * - {@code 'connectionreset'} - A connection was reset (corresponding to a TCP RST).
-   * - {@code 'internetdisconnected'} - The Internet connection has been lost.
-   * - {@code 'namenotresolved'} - The host name could not be resolved.
-   * - {@code 'timedout'} - An operation timed out.
-   * - {@code 'failed'} - A generic failure occurred.
+   * <ul>
+   * <li> {@code 'aborted'} - An operation was aborted (due to user action)</li>
+   * <li> {@code 'accessdenied'} - Permission to access a resource, other than the network, was denied</li>
+   * <li> {@code 'addressunreachable'} - The IP address is unreachable. This usually means that there is no route to the specified host
+   * or network.</li>
+   * <li> {@code 'blockedbyclient'} - The client chose to block the request.</li>
+   * <li> {@code 'blockedbyresponse'} - The request failed because the response was delivered along with requirements which are not met
+   * ('X-Frame-Options' and 'Content-Security-Policy' ancestor checks, for instance).</li>
+   * <li> {@code 'connectionaborted'} - A connection timed out as a result of not receiving an ACK for data sent.</li>
+   * <li> {@code 'connectionclosed'} - A connection was closed (corresponding to a TCP FIN).</li>
+   * <li> {@code 'connectionfailed'} - A connection attempt failed.</li>
+   * <li> {@code 'connectionrefused'} - A connection attempt was refused.</li>
+   * <li> {@code 'connectionreset'} - A connection was reset (corresponding to a TCP RST).</li>
+   * <li> {@code 'internetdisconnected'} - The Internet connection has been lost.</li>
+   * <li> {@code 'namenotresolved'} - The host name could not be resolved.</li>
+   * <li> {@code 'timedout'} - An operation timed out.</li>
+   * <li> {@code 'failed'} - A generic failure occurred.</li>
+   * </ul>
    */
   void abort(String errorCode);
   /**
    * Continues route's request with optional overrides.
+   * <pre>{@code
+   * page.route("**\/*", route -> {
+   *   // Override headers
+   *   Map<String, String> headers = new HashMap<>(route.request().headers());
+   *   headers.put("foo", "bar"); // set "foo" header
+   *   headers.remove("origin"); // remove "origin" header
+   *   route.resume(new Route.ResumeOptions().withHeaders(headers));
+   * });
+   * }</pre>
    */
   default void resume() {
     resume(null);
   }
   /**
    * Continues route's request with optional overrides.
+   * <pre>{@code
+   * page.route("**\/*", route -> {
+   *   // Override headers
+   *   Map<String, String> headers = new HashMap<>(route.request().headers());
+   *   headers.put("foo", "bar"); // set "foo" header
+   *   headers.remove("origin"); // remove "origin" header
+   *   route.resume(new Route.ResumeOptions().withHeaders(headers));
+   * });
+   * }</pre>
    */
   void resume(ResumeOptions options);
   /**
    * Fulfills route's request with given response.
+   *
+   * <p> An example of fulfilling all requests with 404 responses:
+   * <pre>{@code
+   * page.route("**\/*", route -> {
+   *   route.fulfill(new Route.FulfillOptions()
+   *     .withStatus(404)
+   *     .withContentType("text/plain")
+   *     .withBody("Not Found!"));
+   * });
+   * }</pre>
+   *
+   * <p> An example of serving static file:
+   * <pre>{@code
+   * page.route("**\/xhr_endpoint", route -> route.fulfill(
+   *   new Route.FulfillOptions().withPath(Paths.get("mock_data.json")));
+   * }</pre>
    */
   default void fulfill() {
     fulfill(null);
   }
   /**
    * Fulfills route's request with given response.
+   *
+   * <p> An example of fulfilling all requests with 404 responses:
+   * <pre>{@code
+   * page.route("**\/*", route -> {
+   *   route.fulfill(new Route.FulfillOptions()
+   *     .withStatus(404)
+   *     .withContentType("text/plain")
+   *     .withBody("Not Found!"));
+   * });
+   * }</pre>
+   *
+   * <p> An example of serving static file:
+   * <pre>{@code
+   * page.route("**\/xhr_endpoint", route -> route.fulfill(
+   *   new Route.FulfillOptions().withPath(Paths.get("mock_data.json")));
+   * }</pre>
    */
   void fulfill(FulfillOptions options);
   /**

--- a/playwright/src/main/java/com/microsoft/playwright/Selectors.java
+++ b/playwright/src/main/java/com/microsoft/playwright/Selectors.java
@@ -39,7 +39,31 @@ public interface Selectors {
   }
   /**
    * An example of registering selector engine that queries elements based on a tag name:
-   *
+   * <pre>{@code
+   * // Script that evaluates to a selector engine instance.
+   * String createTagNameEngine = "{\n" +
+   *   "  // Returns the first element matching given selector in the root's subtree.\n" +
+   *   "  query(root, selector) {\n" +
+   *   "    return root.querySelector(selector);\n" +
+   *   "  },\n" +
+   *   "  // Returns all elements matching given selector in the root's subtree.\n" +
+   *   "  queryAll(root, selector) {\n" +
+   *   "    return Array.from(root.querySelectorAll(selector));\n" +
+   *   "  }\n" +
+   *   "}";
+   * // Register the engine. Selectors will be prefixed with "tag=".
+   * playwright.selectors().register("tag", createTagNameEngine);
+   * Browser browser = playwright.firefox().launch();
+   * Page page = browser.newPage();
+   * page.setContent("<div><button>Click me</button></div>");
+   * // Use the selector prefixed with its name.
+   * ElementHandle button = page.querySelector("tag=button");
+   * // Combine it with other selector engines.
+   * page.click("tag=div >> text=\"Click me\"");
+   * // Can use it in any methods supporting selectors.
+   * int buttonCount = (int) page.evalOnSelectorAll("tag=button", "buttons => buttons.length");
+   * browser.close();
+   * }</pre>
    *
    * @param name Name that is used in selectors as a prefix, e.g. {@code {name: 'foo'}} enables {@code foo=myselectorbody} selectors. May only
    * contain {@code [a-zA-Z0-9_]} characters.
@@ -50,7 +74,31 @@ public interface Selectors {
   }
   /**
    * An example of registering selector engine that queries elements based on a tag name:
-   *
+   * <pre>{@code
+   * // Script that evaluates to a selector engine instance.
+   * String createTagNameEngine = "{\n" +
+   *   "  // Returns the first element matching given selector in the root's subtree.\n" +
+   *   "  query(root, selector) {\n" +
+   *   "    return root.querySelector(selector);\n" +
+   *   "  },\n" +
+   *   "  // Returns all elements matching given selector in the root's subtree.\n" +
+   *   "  queryAll(root, selector) {\n" +
+   *   "    return Array.from(root.querySelectorAll(selector));\n" +
+   *   "  }\n" +
+   *   "}";
+   * // Register the engine. Selectors will be prefixed with "tag=".
+   * playwright.selectors().register("tag", createTagNameEngine);
+   * Browser browser = playwright.firefox().launch();
+   * Page page = browser.newPage();
+   * page.setContent("<div><button>Click me</button></div>");
+   * // Use the selector prefixed with its name.
+   * ElementHandle button = page.querySelector("tag=button");
+   * // Combine it with other selector engines.
+   * page.click("tag=div >> text=\"Click me\"");
+   * // Can use it in any methods supporting selectors.
+   * int buttonCount = (int) page.evalOnSelectorAll("tag=button", "buttons => buttons.length");
+   * browser.close();
+   * }</pre>
    *
    * @param name Name that is used in selectors as a prefix, e.g. {@code {name: 'foo'}} enables {@code foo=myselectorbody} selectors. May only
    * contain {@code [a-zA-Z0-9_]} characters.
@@ -59,7 +107,31 @@ public interface Selectors {
   void register(String name, String script, RegisterOptions options);
   /**
    * An example of registering selector engine that queries elements based on a tag name:
-   *
+   * <pre>{@code
+   * // Script that evaluates to a selector engine instance.
+   * String createTagNameEngine = "{\n" +
+   *   "  // Returns the first element matching given selector in the root's subtree.\n" +
+   *   "  query(root, selector) {\n" +
+   *   "    return root.querySelector(selector);\n" +
+   *   "  },\n" +
+   *   "  // Returns all elements matching given selector in the root's subtree.\n" +
+   *   "  queryAll(root, selector) {\n" +
+   *   "    return Array.from(root.querySelectorAll(selector));\n" +
+   *   "  }\n" +
+   *   "}";
+   * // Register the engine. Selectors will be prefixed with "tag=".
+   * playwright.selectors().register("tag", createTagNameEngine);
+   * Browser browser = playwright.firefox().launch();
+   * Page page = browser.newPage();
+   * page.setContent("<div><button>Click me</button></div>");
+   * // Use the selector prefixed with its name.
+   * ElementHandle button = page.querySelector("tag=button");
+   * // Combine it with other selector engines.
+   * page.click("tag=div >> text=\"Click me\"");
+   * // Can use it in any methods supporting selectors.
+   * int buttonCount = (int) page.evalOnSelectorAll("tag=button", "buttons => buttons.length");
+   * browser.close();
+   * }</pre>
    *
    * @param name Name that is used in selectors as a prefix, e.g. {@code {name: 'foo'}} enables {@code foo=myselectorbody} selectors. May only
    * contain {@code [a-zA-Z0-9_]} characters.
@@ -70,7 +142,31 @@ public interface Selectors {
   }
   /**
    * An example of registering selector engine that queries elements based on a tag name:
-   *
+   * <pre>{@code
+   * // Script that evaluates to a selector engine instance.
+   * String createTagNameEngine = "{\n" +
+   *   "  // Returns the first element matching given selector in the root's subtree.\n" +
+   *   "  query(root, selector) {\n" +
+   *   "    return root.querySelector(selector);\n" +
+   *   "  },\n" +
+   *   "  // Returns all elements matching given selector in the root's subtree.\n" +
+   *   "  queryAll(root, selector) {\n" +
+   *   "    return Array.from(root.querySelectorAll(selector));\n" +
+   *   "  }\n" +
+   *   "}";
+   * // Register the engine. Selectors will be prefixed with "tag=".
+   * playwright.selectors().register("tag", createTagNameEngine);
+   * Browser browser = playwright.firefox().launch();
+   * Page page = browser.newPage();
+   * page.setContent("<div><button>Click me</button></div>");
+   * // Use the selector prefixed with its name.
+   * ElementHandle button = page.querySelector("tag=button");
+   * // Combine it with other selector engines.
+   * page.click("tag=div >> text=\"Click me\"");
+   * // Can use it in any methods supporting selectors.
+   * int buttonCount = (int) page.evalOnSelectorAll("tag=button", "buttons => buttons.length");
+   * browser.close();
+   * }</pre>
    *
    * @param name Name that is used in selectors as a prefix, e.g. {@code {name: 'foo'}} enables {@code foo=myselectorbody} selectors. May only
    * contain {@code [a-zA-Z0-9_]} characters.

--- a/playwright/src/main/java/com/microsoft/playwright/TimeoutError.java
+++ b/playwright/src/main/java/com/microsoft/playwright/TimeoutError.java
@@ -19,9 +19,7 @@ package com.microsoft.playwright;
 import java.util.*;
 
 /**
- * - extends: [Error]
- *
- * <p> TimeoutError is emitted whenever certain operations are terminated due to timeout, e.g. [{@code method: Page.waitForSelector}]
+ * TimeoutError is emitted whenever certain operations are terminated due to timeout, e.g. [{@code method: Page.waitForSelector}]
  * or [{@code method: BrowserType.launch}].
  */
 public interface TimeoutError {

--- a/playwright/src/main/java/com/microsoft/playwright/Video.java
+++ b/playwright/src/main/java/com/microsoft/playwright/Video.java
@@ -21,6 +21,9 @@ import java.util.*;
 
 /**
  * When browser context is created with the {@code videosPath} option, each page has a video object associated with it.
+ * <pre>{@code
+ * System.out.println(page.video().path());
+ * }</pre>
  */
 public interface Video {
   /**

--- a/playwright/src/main/java/com/microsoft/playwright/Worker.java
+++ b/playwright/src/main/java/com/microsoft/playwright/Worker.java
@@ -23,6 +23,15 @@ import java.util.function.Consumer;
  * The Worker class represents a [WebWorker](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API). {@code worker}
  * event is emitted on the page object to signal a worker creation. {@code close} event is emitted on the worker object when the
  * worker is gone.
+ * <pre>{@code
+ * page.onWorker(worker -> {
+ *   System.out.println("Worker created: " + worker.url());
+ *   worker.onClose(worker1 -> System.out.println("Worker destroyed: " + worker1.url()));
+ * });
+ * System.out.println("Current workers:");
+ * for (Worker worker : page.workers())
+ *   System.out.println("  " + worker.url());
+ * }</pre>
  */
 public interface Worker {
 


### PR DESCRIPTION
* Javadocs are now formatted from parsed md structures.
* Lists are properly formatted.
* Java snippets are preserved in javadocs.