### PR TITLE
fix: use default file system for relative path resolution

### DIFF
--- a/driver-bundle/src/main/java/com/microsoft/playwright/impl/DriverJar.java
+++ b/driver-bundle/src/main/java/com/microsoft/playwright/impl/DriverJar.java
@@ -61,8 +61,13 @@ public class DriverJar extends Driver {
     // Create zip filesystem if loading from jar.
     try (FileSystem fileSystem = "jar".equals(uri.getScheme()) ? FileSystems.newFileSystem(uri, Collections.emptyMap()) : null) {
       Path srcRoot = Paths.get(uri);
+      // jar file system's .relativize gives wrong results when used with
+      // spring-boot-maven-plugin, convert to the default filesystem to
+      // have predictable results.
+      // See https://github.com/microsoft/playwright-java/issues/306
+      Path srcRootDefaultFs = Paths.get(srcRoot.toString());
       Files.walk(srcRoot).forEach(fromPath -> {
-        Path relative = srcRoot.relativize(fromPath);
+        Path relative = srcRootDefaultFs.relativize(Paths.get(fromPath.toString()));
         Path toPath = driverTempDir.resolve(relative.toString());
         try {
           if (Files.isDirectory(fromPath)) {


### PR DESCRIPTION
When used with spring-boot-maven-plugin 'jar' file system's relative path resolution works in a way that
'/driver/mac/playwright.sh' relative to '/driver/mac/' is '../mac/playwright.sh' (see discussion in the bug and https://github.com/microsoft/playwright-java/issues/306#issuecomment-789665424 in particular). To work around that we convert to the default fs paths and do relative path resolution there.

Fixes #306