### PR TITLE
devops: adjust pushed Docker tags to be consistent with pw

### DIFF
--- a/.github/workflows/publish_canary_docker.yml
+++ b/.github/workflows/publish_canary_docker.yml
@@ -7,7 +7,6 @@ on:
 jobs:
   publish-canary-docker:
     name: "publish to DockerHub"
-    # We use `docker push --all-tags` to push all tags which is a newly addition to docker
     runs-on: ubuntu-20.04
     if: github.repository == 'microsoft/playwright-java'
     steps:

--- a/.github/workflows/publish_docker_release.yml
+++ b/.github/workflows/publish_docker_release.yml
@@ -8,7 +8,6 @@ on:
 jobs:
   publish-canary-docker:
     name: publish to DockerHub
-    # We use `docker push --all-tags` to push all tags which is a newly addition to docker
     runs-on: ubuntu-20.04
     if: github.repository == 'microsoft/playwright-java'
     steps:
@@ -34,4 +33,4 @@ jobs:
         ./scripts/tag_image_and_push.sh playwright-java:localbuild-focal playwright.azurecr.io/public/playwright/java:latest
         ./scripts/tag_image_and_push.sh playwright-java:localbuild-focal playwright.azurecr.io/public/playwright/java:focal
         ./scripts/tag_image_and_push.sh playwright-java:localbuild-focal playwright.azurecr.io/public/playwright/java:${TAG_NAME}
-        ./scripts/tag_image_and_push.sh playwright-java:localbuild-focal playwright.azurecr.io/public/playwright/java:focal-${TAG_NAME}
+        ./scripts/tag_image_and_push.sh playwright-java:localbuild-focal playwright.azurecr.io/public/playwright/java:${TAG_NAME}-focal


### PR DESCRIPTION
The comment which I've removed was obsolete, we used it in the past but then decided to not use this CLI argument anymore.

See here for reference of the upstream format, with this PR its then in sync.

https://github.com/microsoft/playwright/blob/master/.github/workflows/publish_release.yml#L76