### PR TITLE
fix: manually pipe messages from child process sdtout/stderr

### DIFF
--- a/driver-bundle/pom.xml
+++ b/driver-bundle/pom.xml
@@ -44,7 +44,9 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.0.0-M5</version>
+        <configuration>
+          <redirectTestOutputToFile>true</redirectTestOutputToFile>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/driver-bundle/src/main/java/com/microsoft/playwright/impl/DriverJar.java
+++ b/driver-bundle/src/main/java/com/microsoft/playwright/impl/DriverJar.java
@@ -48,6 +48,9 @@ public class DriverJar extends Driver {
       p.destroy();
       throw new RuntimeException("Timed out waiting for browsers to install");
     }
+    if (p.exitValue() != 0) {
+      throw new RuntimeException("Failed to install browsers, exit code: " + p.exitValue());
+    }
   }
 
   private static boolean isExecutable(Path filePath) {

--- a/driver-bundle/src/test/java/com/microsoft/playwright/TestInstall.java
+++ b/driver-bundle/src/test/java/com/microsoft/playwright/TestInstall.java
@@ -17,6 +17,7 @@
 package com.microsoft.playwright;
 
 import com.microsoft.playwright.impl.Driver;
+import com.microsoft.playwright.impl.StreamRedirectThread;
 import org.junit.jupiter.api.Test;
 
 import java.nio.file.Files;
@@ -36,11 +37,13 @@ public class TestInstall {
       assertTrue(Files.exists(cli));
 
       ProcessBuilder pb = new ProcessBuilder(cli.toString(), "install");
-      pb.redirectError(ProcessBuilder.Redirect.INHERIT);
-      pb.redirectOutput(ProcessBuilder.Redirect.INHERIT);
       Process p = pb.start();
+      StreamRedirectThread stdoutThread = new StreamRedirectThread(p.getInputStream(), System.out);
+      StreamRedirectThread stderrThread = new StreamRedirectThread(p.getErrorStream(), System.err);
       boolean result = p.waitFor(1, TimeUnit.MINUTES);
       assertTrue(result, "Timed out waiting for browsers to install");
+      stderrThread.interruptAndJoin();
+      stdoutThread.interruptAndJoin();
     } catch (Exception e) {
       e.printStackTrace();
       assertNull(e);

--- a/driver-bundle/src/test/java/com/microsoft/playwright/TestInstall.java
+++ b/driver-bundle/src/test/java/com/microsoft/playwright/TestInstall.java
@@ -42,8 +42,8 @@ public class TestInstall {
       StreamRedirectThread stderrThread = new StreamRedirectThread(p.getErrorStream(), System.err);
       boolean result = p.waitFor(1, TimeUnit.MINUTES);
       assertTrue(result, "Timed out waiting for browsers to install");
-      stderrThread.interruptAndJoin();
-      stdoutThread.interruptAndJoin();
+      stderrThread.terminateAndJoin();
+      stdoutThread.terminateAndJoin();
     } catch (Exception e) {
       e.printStackTrace();
       assertNull(e);

--- a/driver/pom.xml
+++ b/driver/pom.xml
@@ -40,6 +40,9 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <redirectTestOutputToFile>true</redirectTestOutputToFile>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/driver/src/main/java/com/microsoft/playwright/impl/StreamRedirectThread.java
+++ b/driver/src/main/java/com/microsoft/playwright/impl/StreamRedirectThread.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.microsoft.playwright.impl;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+// We manually copy stderr and stdout from child process as INHERIT for err/out streams
+// doesn't work well in Java Enterprise, see
+// https://github.com/microsoft/playwright-java/issues/418#issuecomment-832650650
+public class StreamRedirectThread extends Thread {
+  private final InputStream from;
+  private final OutputStream to;
+
+  public StreamRedirectThread(InputStream from, OutputStream to) {
+    this.from = from;
+    this.to = to;
+    start();
+  }
+
+  @Override
+  public void run() {
+    byte[] buffer = new byte[1<<14];
+    try {
+      while (true) {
+        while (from.available() != 0) {
+          int len = from.read(buffer);
+          if (len != -1) {
+            to.write(buffer);
+          }
+        }
+        if (isInterrupted()) {
+          break;
+        }
+      }
+    } catch (IOException e) {
+      e.printStackTrace(System.err);
+    }
+  }
+
+  public void interruptAndJoin() {
+    interrupt();
+    try {
+      join();
+    } catch (InterruptedException e) {
+      e.printStackTrace(System.err);
+    }
+  }
+}

--- a/driver/src/main/java/com/microsoft/playwright/impl/StreamRedirectThread.java
+++ b/driver/src/main/java/com/microsoft/playwright/impl/StreamRedirectThread.java
@@ -38,6 +38,10 @@ public class StreamRedirectThread extends Thread {
     byte[] buffer = new byte[1<<14];
     try {
       while (true) {
+        try {
+          Thread.sleep(100);
+        } catch (InterruptedException e) {
+        }
         while (from.available() != 0) {
           int len = from.read(buffer);
           if (len != -1) {

--- a/playwright/src/main/java/com/microsoft/playwright/impl/PlaywrightImpl.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/PlaywrightImpl.java
@@ -48,7 +48,7 @@ public class PlaywrightImpl extends ChannelOwner implements Playwright {
       throw new PlaywrightException("Failed to launch driver", e);
     } finally {
       if (stderrThread != null) {
-        stderrThread.interruptAndJoin();
+        stderrThread.terminateAndJoin();
       }
     }
   }
@@ -111,7 +111,7 @@ public class PlaywrightImpl extends ChannelOwner implements Playwright {
       if (!didClose) {
         System.err.println("WARNING: Timed out while waiting for driver process to exit");
       }
-      stderrThread.interruptAndJoin();
+      stderrThread.terminateAndJoin();
     } catch (IOException e) {
       throw new PlaywrightException("Failed to terminate", e);
     } catch (InterruptedException e) {


### PR DESCRIPTION
* Spawn a new dedicated thread to pump stderr/stdout from the driver child process to playwright process to mitigate possible problems with inheriting streams in Java Enterprise described in #418

* Close driver connection when reading from child process fails, this should help with  #347