### PR TITLE
test: use @TestInstance(PER_CLASS) instead of ThreadLocal

### DIFF
--- a/playwright/src/test/java/com/microsoft/playwright/TestBrowser.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestBrowser.java
@@ -30,22 +30,22 @@ public class TestBrowser extends TestBase {
 
   @Test
   void shouldCreateNewPage() {
-    Page page1 = getBrowser().newPage();
-    assertEquals(1, getBrowser().contexts().size());
+    Page page1 = browser.newPage();
+    assertEquals(1, browser.contexts().size());
 
-    Page page2 = getBrowser().newPage();
-    assertEquals(2, getBrowser().contexts().size());
+    Page page2 = browser.newPage();
+    assertEquals(2, browser.contexts().size());
 
     page1.close();
-    assertEquals(1, getBrowser().contexts().size());
+    assertEquals(1, browser.contexts().size());
 
     page2.close();
-    assertEquals(0, getBrowser().contexts().size());
+    assertEquals(0, browser.contexts().size());
   }
 
   @Test
   void shouldThrowUponSecondCreateNewPage() {
-    Page page = getBrowser().newPage();
+    Page page = browser.newPage();
     try {
       page.context().newPage();
       fail("newPage should throw");
@@ -58,12 +58,12 @@ public class TestBrowser extends TestBase {
   @Test
   void versionShouldWork() {
     if (isChromium()) {
-      assertTrue(Pattern.matches("^\\d+\\.\\d+\\.\\d+\\.\\d+$", getBrowser().version()));
+      assertTrue(Pattern.matches("^\\d+\\.\\d+\\.\\d+\\.\\d+$", browser.version()));
     } else if (isWebKit()) {
-      assertTrue(Pattern.matches("^\\d+\\.\\d+", getBrowser().version()));
+      assertTrue(Pattern.matches("^\\d+\\.\\d+", browser.version()));
     } else if (isFirefox()) {
       // It can be 85.0b1 in Firefox.
-      assertTrue(Pattern.matches("^\\d+\\.\\d+.*", getBrowser().version()));
+      assertTrue(Pattern.matches("^\\d+\\.\\d+.*", browser.version()));
     }
   }
 }

--- a/playwright/src/test/java/com/microsoft/playwright/TestBrowserContextAddCookies.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestBrowserContextAddCookies.java
@@ -34,15 +34,15 @@ import static org.junit.jupiter.api.Assertions.*;
 public class TestBrowserContextAddCookies extends TestBase {
   @Test
   void shouldWork() {
-    page.navigate(getServer().EMPTY_PAGE);
+    page.navigate(server.EMPTY_PAGE);
     context.addCookies(asList(
-      new Cookie("password", "123456").setUrl(getServer().EMPTY_PAGE)));
+      new Cookie("password", "123456").setUrl(server.EMPTY_PAGE)));
     assertEquals("password=123456", page.evaluate("document.cookie"));
   }
 
   @Test
   void shouldRoundtripCookie() {
-    page.navigate(getServer().EMPTY_PAGE);
+    page.navigate(server.EMPTY_PAGE);
     // @see https://en.wikipedia.org/wiki/Year_2038_problem
     Object documentCookie = page.evaluate("() => {\n" +
       "  const date = new Date('1/1/2038');\n" +
@@ -63,22 +63,22 @@ public class TestBrowserContextAddCookies extends TestBase {
 
   @Test
   void shouldSendCookieHeader() throws ExecutionException, InterruptedException {
-    Future<Server.Request> request = getServer().futureRequest("/empty.html");
+    Future<Server.Request> request = server.futureRequest("/empty.html");
     context.addCookies(asList(
-      new Cookie("cookie", "value").setUrl(getServer().EMPTY_PAGE)));
+      new Cookie("cookie", "value").setUrl(server.EMPTY_PAGE)));
     Page page = context.newPage();
-    page.navigate(getServer().EMPTY_PAGE);
+    page.navigate(server.EMPTY_PAGE);
     List<String> cookies = request.get().headers.get("cookie");
     assertEquals(singletonList("cookie=value"), cookies);
   }
 
   @Test
   void shouldIsolateCookiesInBrowserContexts() {
-    BrowserContext anotherContext = getBrowser().newContext();
+    BrowserContext anotherContext = browser.newContext();
     context.addCookies(asList(
-      new Cookie("isolatecookie", "page1value").setUrl(getServer().EMPTY_PAGE)));
+      new Cookie("isolatecookie", "page1value").setUrl(server.EMPTY_PAGE)));
     anotherContext.addCookies(asList(
-      new Cookie("isolatecookie", "page2value").setUrl(getServer().EMPTY_PAGE)));
+      new Cookie("isolatecookie", "page2value").setUrl(server.EMPTY_PAGE)));
     List<Cookie> cookies1 = context.cookies();
     List<Cookie> cookies2 = anotherContext.cookies();
     assertEquals(1, cookies1.size());
@@ -92,26 +92,26 @@ public class TestBrowserContextAddCookies extends TestBase {
 
   @Test
   void shouldIsolateSessionCookies() {
-    getServer().setRoute("/setcookie.html", exchange -> {
+    server.setRoute("/setcookie.html", exchange -> {
       exchange.getResponseHeaders().add("Set-Cookie", "session=value");
       exchange.sendResponseHeaders(200, 0);
       exchange.getResponseBody().close();
     });
     {
       Page page = context.newPage();
-      page.navigate(getServer().PREFIX + "/setcookie.html");
+      page.navigate(server.PREFIX + "/setcookie.html");
     }
     {
       Page page = context.newPage();
-      page.navigate(getServer().EMPTY_PAGE);
+      page.navigate(server.EMPTY_PAGE);
       List<Cookie> cookies = context.cookies();
       assertEquals(1, cookies.size());
       assertEquals("value", cookies.get(0).value);
     }
     {
-      BrowserContext context2 = getBrowser().newContext();
+      BrowserContext context2 = browser.newContext();
       Page page = context2.newPage();
-      page.navigate(getServer().EMPTY_PAGE);
+      page.navigate(server.EMPTY_PAGE);
       List<Cookie> cookies = context2.cookies();
       assertEquals(0, cookies.size());
       context2.close();
@@ -120,20 +120,20 @@ public class TestBrowserContextAddCookies extends TestBase {
 
   @Test
   void shouldIsolatePersistentCookies() {
-    getServer().setRoute("/setcookie.html", exchange -> {
+    server.setRoute("/setcookie.html", exchange -> {
       exchange.getResponseHeaders().add("Set-Cookie", "persistent=persistent-value; max-age=3600");
       exchange.sendResponseHeaders(200, 0);
       exchange.getResponseBody().close();
     });
     Page page = context.newPage();
-    page.navigate(getServer().PREFIX + "/setcookie.html");
+    page.navigate(server.PREFIX + "/setcookie.html");
 
     BrowserContext context1 = context;
-    BrowserContext context2 = getBrowser().newContext();
+    BrowserContext context2 = browser.newContext();
     Page page1 = context1.newPage();
     Page page2 = context2.newPage();
-    page1.navigate(getServer().EMPTY_PAGE);
-    page2.navigate(getServer().EMPTY_PAGE);
+    page1.navigate(server.EMPTY_PAGE);
+    page2.navigate(server.EMPTY_PAGE);
     List<Cookie> cookies1 = context1.cookies();
     List<Cookie> cookies2 = context2.cookies();
     assertEquals(1, cookies1.size());
@@ -146,19 +146,19 @@ public class TestBrowserContextAddCookies extends TestBase {
   @Test
   void shouldIsolateSendCookieHeader() throws ExecutionException, InterruptedException {
     context.addCookies(asList(
-      new Cookie("sendcookie", "value").setUrl(getServer().EMPTY_PAGE)));
+      new Cookie("sendcookie", "value").setUrl(server.EMPTY_PAGE)));
     {
       Page page = context.newPage();
-      Future<Server.Request> request = getServer().futureRequest("/empty.html");
-      page.navigate(getServer().EMPTY_PAGE);
+      Future<Server.Request> request = server.futureRequest("/empty.html");
+      page.navigate(server.EMPTY_PAGE);
       List<String> cookies = request.get().headers.get("cookie");
       assertEquals(asList("sendcookie=value"), cookies);
     }
     {
-      BrowserContext context = getBrowser().newContext();
+      BrowserContext context = browser.newContext();
       Page page = context.newPage();
-      Future<Server.Request> request = getServer().futureRequest("/empty.html");
-      page.navigate(getServer().EMPTY_PAGE);
+      Future<Server.Request> request = server.futureRequest("/empty.html");
+      page.navigate(server.EMPTY_PAGE);
       List<String> cookies = request.get().headers.get("cookie");
       assertNull(cookies);
       context.close();
@@ -168,15 +168,15 @@ public class TestBrowserContextAddCookies extends TestBase {
   void shouldIsolateCookiesBetweenLaunches() {
 //    test.slow();
 // TODO:  const browser1 = browserType.launch(browserOptions);
-    Browser browser1 = getBrowserType().launch();
+    Browser browser1 = browserType.launch();
     BrowserContext context1 = browser1.newContext();
     context1.addCookies(asList(new Cookie("cookie-in-context-1", "value")
-      .setUrl(getServer().EMPTY_PAGE)
+      .setUrl(server.EMPTY_PAGE)
       .setExpires(Instant.now().getEpochSecond() +  + 10000)));
     browser1.close();
 
 //  const browser2 = browserType.launch(browserOptions);
-    Browser browser2 = getBrowserType().launch();
+    Browser browser2 = browserType.launch();
     BrowserContext context2 = browser2.newContext();
     List<Cookie> cookies = context2.cookies();
     assertEquals(0, cookies.size());
@@ -185,10 +185,10 @@ public class TestBrowserContextAddCookies extends TestBase {
 
   @Test
   void shouldSetMultipleCookies() {
-    page.navigate(getServer().EMPTY_PAGE);
+    page.navigate(server.EMPTY_PAGE);
     context.addCookies(asList(
-      new Cookie("multiple-1", "123456").setUrl(getServer().EMPTY_PAGE),
-      new Cookie("multiple-2", "bar").setUrl(getServer().EMPTY_PAGE)
+      new Cookie("multiple-1", "123456").setUrl(server.EMPTY_PAGE),
+      new Cookie("multiple-2", "bar").setUrl(server.EMPTY_PAGE)
     ));
     assertEquals(asList("multiple-1=123456", "multiple-2=bar"), page.evaluate("() => {\n" +
       "  const cookies = document.cookie.split(';');\n" +
@@ -199,7 +199,7 @@ public class TestBrowserContextAddCookies extends TestBase {
   @Test
   void shouldHaveExpiresSetTo1ForSessionCookies() {
     context.addCookies(asList(
-      new Cookie("expires", "123456").setUrl(getServer().EMPTY_PAGE)));
+      new Cookie("expires", "123456").setUrl(server.EMPTY_PAGE)));
     List<Cookie> cookies = context.cookies();
     assertEquals(-1, cookies.get(0).expires);
   }
@@ -207,7 +207,7 @@ public class TestBrowserContextAddCookies extends TestBase {
   @Test
   void shouldSetCookieWithReasonableDefaults() {
     context.addCookies(asList(
-      new Cookie("defaults", "123456").setUrl(getServer().EMPTY_PAGE)));
+      new Cookie("defaults", "123456").setUrl(server.EMPTY_PAGE)));
     List<Cookie> cookies = context.cookies();
     assertJsonEquals("[{\n" +
       "  name: 'defaults',\n" +
@@ -223,7 +223,7 @@ public class TestBrowserContextAddCookies extends TestBase {
 
   @Test
   void shouldSetACookieWithAPath() {
-    page.navigate(getServer().PREFIX + "/grid.html");
+    page.navigate(server.PREFIX + "/grid.html");
     context.addCookies(asList(new Cookie("gridcookie", "GRID")
       .setDomain("localhost")
       .setPath("/grid.html")));
@@ -239,9 +239,9 @@ public class TestBrowserContextAddCookies extends TestBase {
       "  sameSite: 'NONE'\n" +
       "}]", cookies);
     assertEquals("gridcookie=GRID", page.evaluate("document.cookie"));
-    page.navigate(getServer().EMPTY_PAGE);
+    page.navigate(server.EMPTY_PAGE);
     assertEquals("", page.evaluate("document.cookie"));
-    page.navigate(getServer().PREFIX + "/grid.html");
+    page.navigate(server.PREFIX + "/grid.html");
     assertEquals("gridcookie=GRID", page.evaluate("document.cookie"));
   }
 
@@ -249,7 +249,7 @@ public class TestBrowserContextAddCookies extends TestBase {
   void shouldNotSetACookieWithBlankPageURL() {
     try {
       context.addCookies(asList(
-        new Cookie("example-cookie", "best").setUrl(getServer().EMPTY_PAGE),
+        new Cookie("example-cookie", "best").setUrl(server.EMPTY_PAGE),
         new Cookie("example-cookie-blank", "best").setUrl("about:blank")
       ));
       fail("did not throw");
@@ -272,7 +272,7 @@ public class TestBrowserContextAddCookies extends TestBase {
 
   @Test
   void shouldDefaultToSettingSecureCookieForHTTPSWebsites() {
-    page.navigate(getServer().EMPTY_PAGE);
+    page.navigate(server.EMPTY_PAGE);
     String SECURE_URL = "https://example.com";
     context.addCookies(asList(
       new Cookie("foo", "bar").setUrl(SECURE_URL)
@@ -284,7 +284,7 @@ public class TestBrowserContextAddCookies extends TestBase {
 
   @Test
   void shouldBeAbleToSetUnsecureCookieForHTTPWebsite() {
-    page.navigate(getServer().EMPTY_PAGE);
+    page.navigate(server.EMPTY_PAGE);
     String HTTP_URL = "http://example.com";
     context.addCookies(asList(
       new Cookie("foo", "bar").setUrl(HTTP_URL)
@@ -296,7 +296,7 @@ public class TestBrowserContextAddCookies extends TestBase {
 
   @Test
   void shouldSetACookieOnADifferentDomain() {
-    page.navigate(getServer().EMPTY_PAGE);
+    page.navigate(server.EMPTY_PAGE);
     context.addCookies(asList(
       new Cookie("example-cookie", "best").setUrl("https://www.example.com")
     ));
@@ -315,9 +315,9 @@ public class TestBrowserContextAddCookies extends TestBase {
 
   @Test
   void shouldSetCookiesForAFrame() {
-    page.navigate(getServer().EMPTY_PAGE);
+    page.navigate(server.EMPTY_PAGE);
     context.addCookies(asList(
-      new Cookie("frame-cookie", "value").setUrl(getServer().PREFIX)
+      new Cookie("frame-cookie", "value").setUrl(server.PREFIX)
     ));
     page.evaluate("src => {\n" +
       "  let fulfill;\n" +
@@ -327,13 +327,13 @@ public class TestBrowserContextAddCookies extends TestBase {
       "  iframe.onload = fulfill;\n" +
       "  iframe.src = src;\n" +
       "  return promise;\n" +
-      "}", getServer().PREFIX + "/grid.html");
+      "}", server.PREFIX + "/grid.html");
     assertEquals("frame-cookie=value", page.frames().get(1).evaluate("document.cookie"));
   }
 
   @Test
   void shouldNotBlockThirdPartyCookies() {
-    page.navigate(getServer().EMPTY_PAGE);
+    page.navigate(server.EMPTY_PAGE);
     page.evaluate("src => {\n" +
       "  let fulfill;\n" +
       "  const promise = new Promise(x => fulfill = x);\n" +
@@ -342,11 +342,11 @@ public class TestBrowserContextAddCookies extends TestBase {
       "  iframe.onload = fulfill;\n" +
       "  iframe.src = src;\n" +
       "  return promise;\n" +
-      "}", getServer().CROSS_PROCESS_PREFIX + "/grid.html");
+      "}", server.CROSS_PROCESS_PREFIX + "/grid.html");
     page.frames().get(1).evaluate("document.cookie = 'username=John Doe'");
     page.waitForTimeout(2000);
     boolean allowsThirdParty = isChromium() || isFirefox();
-    List<Cookie> cookies = context.cookies(getServer().CROSS_PROCESS_PREFIX + "/grid.html");
+    List<Cookie> cookies = context.cookies(server.CROSS_PROCESS_PREFIX + "/grid.html");
     if (allowsThirdParty) {
       assertJsonEquals("[{\n" +
         "  'domain': '127.0.0.1',\n" +

--- a/playwright/src/test/java/com/microsoft/playwright/TestBrowserContextClearCookies.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestBrowserContextClearCookies.java
@@ -26,9 +26,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class TestBrowserContextClearCookies extends TestBase {
   @Test
   void shouldClearCookies() {
-    page.navigate(getServer().EMPTY_PAGE);
+    page.navigate(server.EMPTY_PAGE);
     context.addCookies(asList(
-      new Cookie("cookie1", "1").setUrl(getServer().EMPTY_PAGE)));
+      new Cookie("cookie1", "1").setUrl(server.EMPTY_PAGE)));
     assertEquals("cookie1=1", page.evaluate("document.cookie"));
     context.clearCookies();
     assertEquals(emptyList(), context.cookies());
@@ -38,11 +38,11 @@ public class TestBrowserContextClearCookies extends TestBase {
 
   @Test
   void shouldIsolateCookiesWhenClearing() {
-    BrowserContext anotherContext = getBrowser().newContext();
+    BrowserContext anotherContext = browser.newContext();
     context.addCookies(asList(
-      new Cookie("page1cookie", "page1value").setUrl(getServer().EMPTY_PAGE)));
+      new Cookie("page1cookie", "page1value").setUrl(server.EMPTY_PAGE)));
     anotherContext.addCookies(asList(
-      new Cookie("page2cookie", "page2value").setUrl(getServer().EMPTY_PAGE)));
+      new Cookie("page2cookie", "page2value").setUrl(server.EMPTY_PAGE)));
 
     assertEquals(1, (context.cookies()).size());
     assertEquals(1, (anotherContext.cookies()).size());

--- a/playwright/src/test/java/com/microsoft/playwright/TestBrowserContextCookies.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestBrowserContextCookies.java
@@ -34,7 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class TestBrowserContextCookies extends TestBase {
   @Test
   void shouldGetACookie() {
-    page.navigate(getServer().EMPTY_PAGE);
+    page.navigate(server.EMPTY_PAGE);
     Object documentCookie = page.evaluate("() => {\n" +
       "  document.cookie = 'username=John Doe';\n" +
       "  return document.cookie;\n" +
@@ -56,7 +56,7 @@ public class TestBrowserContextCookies extends TestBase {
 
   @Test
   void shouldGetANonSessionCookie() {
-    page.navigate(getServer().EMPTY_PAGE);
+    page.navigate(server.EMPTY_PAGE);
     // @see https://en.wikipedia.org/wiki/Year_2038_problem
     Object documentCookie = page.evaluate("() => {\n" +
       "    const date= new Date('1/1/2038');\n" +
@@ -78,12 +78,12 @@ public class TestBrowserContextCookies extends TestBase {
 
   @Test
   void shouldProperlyReportHttpOnlyCookie() {
-    getServer().setRoute("/empty.html", exchange -> {
+    server.setRoute("/empty.html", exchange -> {
       exchange.getResponseHeaders().add("Set-Cookie", "name=value;HttpOnly; Path=/");
       exchange.sendResponseHeaders(200, 0);
       exchange.getResponseBody().close();
     });
-    page.navigate(getServer().EMPTY_PAGE);
+    page.navigate(server.EMPTY_PAGE);
     List<Cookie> cookies = context.cookies();
     assertEquals(1, cookies.size());
     assertTrue(cookies.get(0).httpOnly);
@@ -96,12 +96,12 @@ public class TestBrowserContextCookies extends TestBase {
   @Test
   @DisabledIf(value="isWebKitWindows", disabledReason="fail")
   void shouldProperlyReportStrictSameSiteCookie() {
-    getServer().setRoute("/empty.html", exchange -> {
+    server.setRoute("/empty.html", exchange -> {
       exchange.getResponseHeaders().add("Set-Cookie", "name=value;SameSite=Strict");
       exchange.sendResponseHeaders(200, 0);
       exchange.getResponseBody().close();
     });
-    page.navigate(getServer().EMPTY_PAGE);
+    page.navigate(server.EMPTY_PAGE);
     List<Cookie> cookies = context.cookies();
     assertEquals(1, cookies.size());
     assertEquals(SameSiteAttribute.STRICT, cookies.get(0).sameSite);
@@ -110,12 +110,12 @@ public class TestBrowserContextCookies extends TestBase {
   @Test
   @DisabledIf(value="isWebKitWindows", disabledReason="fail")
   void shouldProperlyReportLaxSameSiteCookie() {
-    getServer().setRoute("/empty.html", exchange -> {
+    server.setRoute("/empty.html", exchange -> {
       exchange.getResponseHeaders().add("Set-Cookie", "name=value;SameSite=Lax");
       exchange.sendResponseHeaders(200, 0);
       exchange.getResponseBody().close();
     });
-    page.navigate(getServer().EMPTY_PAGE);
+    page.navigate(server.EMPTY_PAGE);
     List<Cookie> cookies = context.cookies();
     assertEquals(1, cookies.size());
     assertEquals(SameSiteAttribute.LAX, cookies.get(0).sameSite);
@@ -123,7 +123,7 @@ public class TestBrowserContextCookies extends TestBase {
 
   @Test
   void shouldGetMultipleCookies() {
-    page.navigate(getServer().EMPTY_PAGE);
+    page.navigate(server.EMPTY_PAGE);
     Object documentCookie = page.evaluate("() => {\n" +
       "  document.cookie = 'username=John Doe';\n" +
       "  document.cookie = 'password=1234';\n" +
@@ -188,11 +188,11 @@ public class TestBrowserContextCookies extends TestBase {
   @Test
   void shouldAcceptSameSiteAttribute() {
     context.addCookies(asList(
-      new Cookie("one", "uno").setUrl(getServer().EMPTY_PAGE).setSameSite(SameSiteAttribute.LAX),
-      new Cookie("two", "dos").setUrl(getServer().EMPTY_PAGE).setSameSite(SameSiteAttribute.STRICT),
-      new Cookie("three", "tres").setUrl(getServer().EMPTY_PAGE).setSameSite(SameSiteAttribute.NONE)));
+      new Cookie("one", "uno").setUrl(server.EMPTY_PAGE).setSameSite(SameSiteAttribute.LAX),
+      new Cookie("two", "dos").setUrl(server.EMPTY_PAGE).setSameSite(SameSiteAttribute.STRICT),
+      new Cookie("three", "tres").setUrl(server.EMPTY_PAGE).setSameSite(SameSiteAttribute.NONE)));
 
-    page.navigate(getServer().EMPTY_PAGE);
+    page.navigate(server.EMPTY_PAGE);
     Object documentCookie = page.evaluate("document.cookie.split('; ').sort().join('; ')");
     assertEquals("one=uno; three=tres; two=dos", documentCookie);
 

--- a/playwright/src/test/java/com/microsoft/playwright/TestBrowserContextCredentials.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestBrowserContextCredentials.java
@@ -31,10 +31,10 @@ public class TestBrowserContextCredentials extends TestBase {
   @Test
   @DisabledIf(value="isChromiumHeadful", disabledReason="fail")
   void shouldFailWithoutCredentials() {
-    getServer().setAuth("/empty.html", "user", "pass");
-    BrowserContext context = getBrowser().newContext();
+    server.setAuth("/empty.html", "user", "pass");
+    BrowserContext context = browser.newContext();
     Page page = context.newPage();
-    Response response = page.navigate(getServer().EMPTY_PAGE);
+    Response response = page.navigate(server.EMPTY_PAGE);
     assertEquals(401, response.status());
     context.close();
   }
@@ -45,32 +45,32 @@ public class TestBrowserContextCredentials extends TestBase {
 
   @Test
   void shouldWorkWithCorrectCredentials() {
-    getServer().setAuth("/empty.html", "user", "pass");
-    BrowserContext context = getBrowser().newContext(new Browser.NewContextOptions()
+    server.setAuth("/empty.html", "user", "pass");
+    BrowserContext context = browser.newContext(new Browser.NewContextOptions()
       .setHttpCredentials("user", "pass"));
     Page page = context.newPage();
-    Response response = page.navigate(getServer().EMPTY_PAGE);
+    Response response = page.navigate(server.EMPTY_PAGE);
     assertEquals(200, response.status());
     context.close();
   }
 
   @Test
   void shouldFailWithWrongCredentials() {
-    getServer().setAuth("/empty.html", "user", "pass");
-    BrowserContext context = getBrowser().newContext(new Browser.NewContextOptions().setHttpCredentials("foo", "bar"));
+    server.setAuth("/empty.html", "user", "pass");
+    BrowserContext context = browser.newContext(new Browser.NewContextOptions().setHttpCredentials("foo", "bar"));
     Page page = context.newPage();
-    Response response = page.navigate(getServer().EMPTY_PAGE);
+    Response response = page.navigate(server.EMPTY_PAGE);
     assertEquals(401, response.status());
     context.close();
   }
 
   @Test
   void shouldReturnResourceBody() {
-    getServer().setAuth("/playground.html", "user", "pass");
-    BrowserContext context = getBrowser().newContext(new Browser.NewContextOptions()
+    server.setAuth("/playground.html", "user", "pass");
+    BrowserContext context = browser.newContext(new Browser.NewContextOptions()
       .setHttpCredentials("user", "pass"));
     Page page = context.newPage();
-    Response response = page.navigate(getServer().PREFIX + "/playground.html");
+    Response response = page.navigate(server.PREFIX + "/playground.html");
     assertEquals(200, response.status());
     assertEquals("Playground", page.title());
     assertTrue(new String(response.body()).contains("Playground"));

--- a/playwright/src/test/java/com/microsoft/playwright/TestBrowserContextLocale.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestBrowserContextLocale.java
@@ -28,17 +28,17 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class TestBrowserContextLocale extends TestBase {
   @Test
   void shouldAffectAcceptLanguageHeader() throws ExecutionException, InterruptedException {
-    BrowserContext context = getBrowser().newContext(new Browser.NewContextOptions().setLocale("fr-CH"));
+    BrowserContext context = browser.newContext(new Browser.NewContextOptions().setLocale("fr-CH"));
     Page page = context.newPage();
-    Future<Server.Request> request = getServer().futureRequest("/empty.html");
-    page.navigate(getServer().EMPTY_PAGE);
+    Future<Server.Request> request = server.futureRequest("/empty.html");
+    page.navigate(server.EMPTY_PAGE);
     assertEquals("fr-CH", request.get().headers.get("accept-language").get(0).substring(0, 5));
     context.close();
   }
 
   @Test
   void shouldAffectNavigatorLanguage() {
-    BrowserContext context = getBrowser().newContext(new Browser.NewContextOptions().setLocale("fr-CH"));
+    BrowserContext context = browser.newContext(new Browser.NewContextOptions().setLocale("fr-CH"));
     Page page = context.newPage();
     assertEquals("fr-CH", page.evaluate("() => navigator.language"));
     context.close();
@@ -48,16 +48,16 @@ public class TestBrowserContextLocale extends TestBase {
   @Test
   void shouldFormatNumber() {
     {
-      BrowserContext context = getBrowser().newContext(new Browser.NewContextOptions().setLocale("en-US"));
+      BrowserContext context = browser.newContext(new Browser.NewContextOptions().setLocale("en-US"));
       Page page = context.newPage();
-      page.navigate(getServer().EMPTY_PAGE);
+      page.navigate(server.EMPTY_PAGE);
       assertEquals("1,000,000.5", page.evaluate("() => (1000000.50).toLocaleString()"));
       context.close();
     }
     {
-      BrowserContext context = getBrowser().newContext(new Browser.NewContextOptions().setLocale("fr-CH"));
+      BrowserContext context = browser.newContext(new Browser.NewContextOptions().setLocale("fr-CH"));
       Page page = context.newPage();
-      page.navigate(getServer().EMPTY_PAGE);
+      page.navigate(server.EMPTY_PAGE);
       assertEquals("1 000 000,5", page.evaluate("() => (1000000.50).toLocaleString().replace(/\\s/g, ' ')"));
       context.close();
     }
@@ -66,19 +66,19 @@ public class TestBrowserContextLocale extends TestBase {
   @Test
   void shouldFormatDate() {
     {
-      BrowserContext context = getBrowser().newContext(new Browser.NewContextOptions()
+      BrowserContext context = browser.newContext(new Browser.NewContextOptions()
         .setLocale("en-US").setTimezoneId("America/Los_Angeles"));
       Page page = context.newPage();
-      page.navigate(getServer().EMPTY_PAGE);
+      page.navigate(server.EMPTY_PAGE);
       String formatted = "Sat Nov 19 2016 10:12:34 GMT-0800 (Pacific Standard Time)";
       assertEquals(formatted, page.evaluate("new Date(1479579154987).toString()"));
       context.close();
     }
     {
-      BrowserContext context = getBrowser().newContext(new Browser.NewContextOptions()
+      BrowserContext context = browser.newContext(new Browser.NewContextOptions()
         .setLocale("de-DE").setTimezoneId("Europe/Berlin"));
       Page page = context.newPage();
-      page.navigate(getServer().EMPTY_PAGE);
+      page.navigate(server.EMPTY_PAGE);
       assertEquals("Sat Nov 19 2016 19:12:34 GMT+0100 (Mitteleuropäische Normalzeit)",
         page.evaluate("new Date(1479579154987).toString()"));
       context.close();
@@ -87,11 +87,11 @@ public class TestBrowserContextLocale extends TestBase {
 
   @Test
   void shouldFormatNumberInPopups() {
-    BrowserContext context = getBrowser().newContext(new Browser.NewContextOptions().setLocale("fr-CH"));
+    BrowserContext context = browser.newContext(new Browser.NewContextOptions().setLocale("fr-CH"));
     Page page = context.newPage();
-    page.navigate(getServer().EMPTY_PAGE);
+    page.navigate(server.EMPTY_PAGE);
     Page popup = page.waitForPopup(() -> page.evaluate(
-      "url => window.open(url)", getServer().PREFIX + "/formatted-number.html"));
+      "url => window.open(url)", server.PREFIX + "/formatted-number.html"));
     popup.waitForLoadState(LoadState.DOMCONTENTLOADED);
     Object result = popup.evaluate("window['result']");
     assertEquals("1 000 000,5", result);
@@ -100,11 +100,11 @@ public class TestBrowserContextLocale extends TestBase {
 
   @Test
   void shouldAffectNavigatorLanguageInPopups() {
-    BrowserContext context = getBrowser().newContext(new Browser.NewContextOptions().setLocale("fr-CH"));
+    BrowserContext context = browser.newContext(new Browser.NewContextOptions().setLocale("fr-CH"));
     Page page = context.newPage();
-    page.navigate(getServer().EMPTY_PAGE);
+    page.navigate(server.EMPTY_PAGE);
     Page popup = page.waitForPopup(() -> page.evaluate(
-      "url => window.open(url)", getServer().PREFIX + "/formatted-number.html"));
+      "url => window.open(url)", server.PREFIX + "/formatted-number.html"));
     popup.waitForLoadState(LoadState.DOMCONTENTLOADED);
     Object result = popup.evaluate("window.initialNavigatorLanguage");
     assertEquals("fr-CH", result);
@@ -113,24 +113,24 @@ public class TestBrowserContextLocale extends TestBase {
 
   @Test
   void shouldWorkForMultiplePagesSharingSameProcess() {
-    BrowserContext context = getBrowser().newContext(new Browser.NewContextOptions().setLocale("ru-RU"));
+    BrowserContext context = browser.newContext(new Browser.NewContextOptions().setLocale("ru-RU"));
     Page page = context.newPage();
-    page.navigate(getServer().EMPTY_PAGE);
+    page.navigate(server.EMPTY_PAGE);
     Page popup = page.waitForPopup(() -> page.evaluate(
-      "url => window.open(url)", getServer().EMPTY_PAGE));
+      "url => window.open(url)", server.EMPTY_PAGE));
     popup = page.waitForPopup(() -> page.evaluate(
-      "url => window.open(url)", getServer().EMPTY_PAGE));
+      "url => window.open(url)", server.EMPTY_PAGE));
     context.close();
   }
 
   @Test
   void shouldBeIsolatedBetweenContexts() {
-    BrowserContext context1 = getBrowser().newContext(new Browser.NewContextOptions().setLocale("en-US"));
+    BrowserContext context1 = browser.newContext(new Browser.NewContextOptions().setLocale("en-US"));
     // By default firefox limits number of child web processes to 8.
     for (int i = 0; i < 8; i++)
       context1.newPage();
 
-    BrowserContext context2 = getBrowser().newContext(new Browser.NewContextOptions().setLocale("ru-RU"));
+    BrowserContext context2 = browser.newContext(new Browser.NewContextOptions().setLocale("ru-RU"));
     Page page2 = context2.newPage();
 
     String localeNumber = "(1000000.50).toLocaleString()";
@@ -151,18 +151,18 @@ public class TestBrowserContextLocale extends TestBase {
 
     String defaultLocale;
     {
-      BrowserContext context = getBrowser().newContext();
+      BrowserContext context = browser.newContext();
       defaultLocale = getContextLocale.apply(context);
       context.close();
     }
     String localeOverride = "ru-RU".equals(defaultLocale) ? "de-DE" : "ru-RU";
     {
-      BrowserContext context = getBrowser().newContext(new Browser.NewContextOptions().setLocale(localeOverride));
+      BrowserContext context = browser.newContext(new Browser.NewContextOptions().setLocale(localeOverride));
       assertEquals(localeOverride, getContextLocale.apply(context));
       context.close();
     }
     {
-      BrowserContext context = getBrowser().newContext();
+      BrowserContext context = browser.newContext();
       assertEquals(defaultLocale, getContextLocale.apply(context));
       context.close();
     }

--- a/playwright/src/test/java/com/microsoft/playwright/TestBrowserContextNetworkEvents.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestBrowserContextNetworkEvents.java
@@ -29,36 +29,36 @@ public class TestBrowserContextNetworkEvents extends TestBase {
   void BrowserContextEventsRequest() {
     List<String> requests = new ArrayList<>();
     context.onRequest(request -> requests.add(request.url()));
-    page.navigate(getServer().EMPTY_PAGE);
+    page.navigate(server.EMPTY_PAGE);
     page.setContent("<a target=_blank rel=noopener href='/one-style.html'>yo</a>");
     Page page1 = context.waitForPage(() -> page.click("a"));
     page1.waitForLoadState();
     assertEquals(asList(
-      getServer().EMPTY_PAGE,
-      getServer().PREFIX + "/one-style.html",
-      getServer().PREFIX + "/one-style.css"), requests);
+      server.EMPTY_PAGE,
+      server.PREFIX + "/one-style.html",
+      server.PREFIX + "/one-style.css"), requests);
   }
 
   @Test
   void BrowserContextEventsResponse() {
     List<String> responses = new ArrayList<>();
     context.onResponse(response -> responses.add(response.url()));
-    page.navigate(getServer().EMPTY_PAGE);
+    page.navigate(server.EMPTY_PAGE);
     page.setContent("<a target=_blank rel=noopener href='/one-style.html'>yo</a>");
     Page page1 = context.waitForPage(() -> page.click("a"));
     page1.waitForLoadState();
     assertEquals(asList(
-      getServer().EMPTY_PAGE,
-      getServer().PREFIX + "/one-style.html",
-      getServer().PREFIX + "/one-style.css"), responses);
+      server.EMPTY_PAGE,
+      server.PREFIX + "/one-style.html",
+      server.PREFIX + "/one-style.css"), responses);
   }
 
   @Test
   void BrowserContextEventsRequestFailed() {
-    getServer().setRoute("/one-style.css", exchange -> exchange.getResponseBody().close());
+    server.setRoute("/one-style.css", exchange -> exchange.getResponseBody().close());
     List<Request> failedRequests = new ArrayList<>();
     context.onRequestFailed(request -> failedRequests.add(request));
-    page.navigate(getServer().PREFIX + "/one-style.html");
+    page.navigate(server.PREFIX + "/one-style.html");
     assertEquals(1, failedRequests.size());
     assertTrue(failedRequests.get(0).url().contains("one-style.css"));
     assertNull(failedRequests.get(0).response());
@@ -71,12 +71,12 @@ public class TestBrowserContextNetworkEvents extends TestBase {
   void BrowserContextEventsRequestFinished() {
     Request[] requestRef = {null};
     context.onRequestFinished(r -> requestRef[0] = r);
-    Response response = page.navigate(getServer().EMPTY_PAGE);
+    Response response = page.navigate(server.EMPTY_PAGE);
     Request request = response.request();
-    assertEquals(getServer().EMPTY_PAGE, request.url());
+    assertEquals(server.EMPTY_PAGE, request.url());
     assertNotNull(request.response());
     assertEquals(request.frame(), page.mainFrame());
-    assertEquals(getServer().EMPTY_PAGE, request.frame().url());
+    assertEquals(server.EMPTY_PAGE, request.frame().url());
     assertNull(request.failure());
   }
 
@@ -86,7 +86,7 @@ public class TestBrowserContextNetworkEvents extends TestBase {
     context.onRequest(r -> events.add("request"));
     context.onResponse(r -> events.add("response"));
     context.onRequestFinished(r -> events.add("requestfinished"));
-    Response response = page.navigate(getServer().EMPTY_PAGE);
+    Response response = page.navigate(server.EMPTY_PAGE);
     assertNull(response.finished());
     assertEquals(asList("request", "response", "requestfinished"), events);
   }

--- a/playwright/src/test/java/com/microsoft/playwright/TestBrowserContextProxy.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestBrowserContextProxy.java
@@ -30,9 +30,10 @@ import static org.junit.jupiter.api.Assertions.*;
 
 public class TestBrowserContextProxy extends TestBase {
 
+  @Override
   @BeforeAll
   // Hide base class method to provide extra option.
-  static void launchBrowser() {
+  void launchBrowser() {
     BrowserType.LaunchOptions options = createLaunchOptions();
     options.setProxy(new Proxy("per-context"));
     launchBrowser(options);
@@ -45,8 +46,8 @@ public class TestBrowserContextProxy extends TestBase {
   @Test
   @EnabledIf(value="isChromiumWindows", disabledReason="Platform-specific")
   void shouldThrowForMissingGlobalProxyOnChromiumWindows() {
-    try (Browser browser = getBrowserType().launch(createLaunchOptions())) {
-      browser.newContext(new Browser.NewContextOptions().setProxy("localhost:" + getServer().PORT));
+    try (Browser browser = browserType.launch(createLaunchOptions())) {
+      browser.newContext(new Browser.NewContextOptions().setProxy("localhost:" + server.PORT));
       fail("did not throw");
     } catch (PlaywrightException e) {
       assertTrue(e.getMessage().contains("Browser needs to be launched with the global proxy"));
@@ -59,13 +60,13 @@ public class TestBrowserContextProxy extends TestBase {
 
   @Test
   void shouldUseProxy() {
-    getServer().setRoute("/target.html", exchange -> {
+    server.setRoute("/target.html", exchange -> {
       exchange.sendResponseHeaders(200, 0);
       try (OutputStreamWriter writer = new OutputStreamWriter(exchange.getResponseBody())) {
         writer.write("<html><title>Served by the proxy</title></html>");
       }
     });
-    BrowserContext context = getBrowser().newContext(new Browser.NewContextOptions().setProxy("localhost:" + getServer().PORT));
+    BrowserContext context = browser.newContext(new Browser.NewContextOptions().setProxy("localhost:" + server.PORT));
     Page page = context.newPage();
     page.navigate("http://non-existent.com/target.html");
     assertEquals("Served by the proxy", page.title());
@@ -74,14 +75,14 @@ public class TestBrowserContextProxy extends TestBase {
 
   @Test
   void shouldUseProxyTwice() {
-    getServer().setRoute("/target.html", exchange -> {
+    server.setRoute("/target.html", exchange -> {
       exchange.sendResponseHeaders(200, 0);
       try (OutputStreamWriter writer = new OutputStreamWriter(exchange.getResponseBody())) {
         writer.write("<html><title>Served by the proxy</title></html>");
       }
     });
-    BrowserContext context = getBrowser().newContext(new Browser.NewContextOptions().setProxy(
-      new Proxy("localhost:" + getServer().PORT)));
+    BrowserContext context = browser.newContext(new Browser.NewContextOptions().setProxy(
+      new Proxy("localhost:" + server.PORT)));
     Page page = context.newPage();
     page.navigate("http://non-existent.com/target.html");
     page.navigate("http://non-existent-2.com/target.html");
@@ -91,14 +92,14 @@ public class TestBrowserContextProxy extends TestBase {
 
   @Test
   void shouldUseProxyForSecondPage() {
-    getServer().setRoute("/target.html", exchange -> {
+    server.setRoute("/target.html", exchange -> {
       exchange.sendResponseHeaders(200, 0);
       try (OutputStreamWriter writer = new OutputStreamWriter(exchange.getResponseBody())) {
         writer.write("<html><title>Served by the proxy</title></html>");
       }
     });
-    BrowserContext context = getBrowser().newContext(new Browser.NewContextOptions().setProxy(
-      new Proxy("localhost:" + getServer().PORT)));
+    BrowserContext context = browser.newContext(new Browser.NewContextOptions().setProxy(
+      new Proxy("localhost:" + server.PORT)));
 
     Page page = context.newPage();
     page.navigate("http://non-existent.com/target.html");
@@ -113,14 +114,14 @@ public class TestBrowserContextProxy extends TestBase {
 
   @Test
   void shouldWorkWithIPPORTNotion() {
-    getServer().setRoute("/target.html", exchange -> {
+    server.setRoute("/target.html", exchange -> {
       exchange.sendResponseHeaders(200, 0);
       try (OutputStreamWriter writer = new OutputStreamWriter(exchange.getResponseBody())) {
         writer.write("<html><title>Served by the proxy</title></html>");
       }
     });
-    BrowserContext context = getBrowser().newContext(new Browser.NewContextOptions().setProxy(
-      new Proxy("127.0.0.1:" + getServer().PORT)));
+    BrowserContext context = browser.newContext(new Browser.NewContextOptions().setProxy(
+      new Proxy("127.0.0.1:" + server.PORT)));
 
     Page page = context.newPage();
     page.navigate("http://non-existent.com/target.html");
@@ -130,7 +131,7 @@ public class TestBrowserContextProxy extends TestBase {
 
   @Test
   void shouldAuthenticate() {
-    getServer().setRoute("/target.html", exchange -> {
+    server.setRoute("/target.html", exchange -> {
       List<String> auth = exchange.getRequestHeaders().get("proxy-authorization");
       if (auth == null) {
         exchange.getResponseHeaders().add("Proxy-Authenticate", "Basic realm='Access to internal site'");
@@ -143,8 +144,8 @@ public class TestBrowserContextProxy extends TestBase {
         writer.write("<html><title>" + auth.get(0) + "</title></html>");
       }
     });
-    BrowserContext context = getBrowser().newContext(new Browser.NewContextOptions().setProxy(
-      new Proxy("localhost:" + getServer().PORT)
+    BrowserContext context = browser.newContext(new Browser.NewContextOptions().setProxy(
+      new Proxy("localhost:" + server.PORT)
       .setUsername("user")
       .setPassword("secret")));
     Page page = context.newPage();
@@ -160,14 +161,14 @@ public class TestBrowserContextProxy extends TestBase {
   @Test
   @DisabledIf(value="isChromiumHeadful", disabledReason="fixme")
   void shouldExcludePatterns() {
-    getServer().setRoute("/target.html", exchange -> {
+    server.setRoute("/target.html", exchange -> {
       exchange.sendResponseHeaders(200, 0);
       try (OutputStreamWriter writer = new OutputStreamWriter(exchange.getResponseBody())) {
         writer.write("<html><title>Served by the proxy</title></html>");
       }
     });
-    BrowserContext context = getBrowser().newContext(new Browser.NewContextOptions().setProxy(
-      new Proxy("127.0.0.1:" + getServer().PORT)
+    BrowserContext context = browser.newContext(new Browser.NewContextOptions().setProxy(
+      new Proxy("127.0.0.1:" + server.PORT)
       // FYI: using long and weird domain names to avoid ATT DNS hijacking
       // that resolves everything to some weird search results page.
       //
@@ -212,7 +213,7 @@ public class TestBrowserContextProxy extends TestBase {
 
   @Test
   void doesLaunchWithoutAPort() {
-    BrowserContext context = getBrowser().newContext(new Browser.NewContextOptions().setProxy(
+    BrowserContext context = browser.newContext(new Browser.NewContextOptions().setProxy(
       new Proxy("http://localhost")));
     context.close();
   }

--- a/playwright/src/test/java/com/microsoft/playwright/TestBrowserContextRoute.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestBrowserContextRoute.java
@@ -29,7 +29,7 @@ public class TestBrowserContextRoute extends TestBase {
 
   @Test
   void shouldIntercept() {
-    BrowserContext context = getBrowser().newContext();
+    BrowserContext context = browser.newContext();
     boolean[] intercepted = {false};
     Page page = context.newPage();
     context.route("**/empty.html", route -> {
@@ -45,7 +45,7 @@ public class TestBrowserContextRoute extends TestBase {
       assertEquals("about:blank", request.frame().url());
       route.resume();
     });
-    Response response = page.navigate(getServer().EMPTY_PAGE);
+    Response response = page.navigate(server.EMPTY_PAGE);
     assertTrue(response.ok());
     assertTrue(intercepted[0]);
     context.close();
@@ -53,7 +53,7 @@ public class TestBrowserContextRoute extends TestBase {
 
   @Test
   void shouldUnroute() {
-    BrowserContext context = getBrowser().newContext();
+    BrowserContext context = browser.newContext();
     Page page = context.newPage();
 
     List<Integer> intercepted = new ArrayList<>();
@@ -74,17 +74,17 @@ public class TestBrowserContextRoute extends TestBase {
       intercepted.add(4);
       route.resume();
     });
-    page.navigate(getServer().EMPTY_PAGE);
+    page.navigate(server.EMPTY_PAGE);
     assertEquals(asList(1), intercepted);
 
     intercepted.clear();
     context.unroute("**/empty.html", handler1);
-    page.navigate(getServer().EMPTY_PAGE);
+    page.navigate(server.EMPTY_PAGE);
     assertEquals(asList(2), intercepted);
 
     intercepted.clear();
     context.unroute("**/empty.html");
-    page.navigate(getServer().EMPTY_PAGE);
+    page.navigate(server.EMPTY_PAGE);
     assertEquals(asList(4), intercepted);
 
     context.close();
@@ -92,7 +92,7 @@ public class TestBrowserContextRoute extends TestBase {
 
   @Test
   void shouldYieldToPageRoute() {
-    BrowserContext context = getBrowser().newContext();
+    BrowserContext context = browser.newContext();
     context.route("**/empty.html", route -> {
       route.fulfill(new Route.FulfillOptions().setStatus(200).setBody("context"));
     });
@@ -100,7 +100,7 @@ public class TestBrowserContextRoute extends TestBase {
     page.route("**/empty.html", route -> {
       route.fulfill(new Route.FulfillOptions().setStatus(200).setBody("page"));
     });
-    Response response = page.navigate(getServer().EMPTY_PAGE);
+    Response response = page.navigate(server.EMPTY_PAGE);
     assertTrue(response.ok());
     assertEquals("page", response.text());
     context.close();
@@ -108,7 +108,7 @@ public class TestBrowserContextRoute extends TestBase {
 
   @Test
   void shouldFallBackToContextRoute() {
-    BrowserContext context = getBrowser().newContext();
+    BrowserContext context = browser.newContext();
     context.route("**/empty.html", route -> {
       route.fulfill(new Route.FulfillOptions().setStatus(200).setBody("context"));
     });
@@ -116,7 +116,7 @@ public class TestBrowserContextRoute extends TestBase {
     page.route("**/non-empty.html", route -> {
       route.fulfill(new Route.FulfillOptions().setStatus(200).setBody("page"));
     });
-    Response response = page.navigate(getServer().EMPTY_PAGE);
+    Response response = page.navigate(server.EMPTY_PAGE);
     assertTrue(response.ok());
     assertEquals("context", response.text());
     context.close();

--- a/playwright/src/test/java/com/microsoft/playwright/TestBrowserContextStorageState.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestBrowserContextStorageState.java
@@ -73,7 +73,7 @@ public class TestBrowserContextStorageState extends TestBase {
       "    }\n" +
       "  ]\n" +
       "}";
-    BrowserContext context = getBrowser().newContext(new Browser.NewContextOptions().setStorageState(storageState));
+    BrowserContext context = browser.newContext(new Browser.NewContextOptions().setStorageState(storageState));
     Page page = context.newPage();
     page.route("**/*", route -> {
       route.fulfill(new Route.FulfillOptions().setBody("<html></html>"));
@@ -124,7 +124,7 @@ public class TestBrowserContextStorageState extends TestBase {
     try (InputStreamReader reader = new InputStreamReader(new FileInputStream(path.toFile()), StandardCharsets.UTF_8)) {
       assertEquals(expected, new Gson().fromJson(reader, JsonObject.class));
     }
-    BrowserContext context2 = getBrowser().newContext(new Browser.NewContextOptions().setStorageStatePath(path));
+    BrowserContext context2 = browser.newContext(new Browser.NewContextOptions().setStorageStatePath(path));
     Page page2 = context2.newPage();
     page2.route("**/*", route -> {
       route.fulfill(new Route.FulfillOptions().setBody("<html></html>"));

--- a/playwright/src/test/java/com/microsoft/playwright/TestBrowserContextViewport.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestBrowserContextViewport.java
@@ -88,9 +88,9 @@ public class TestBrowserContextViewport extends TestBase {
 
   @Test
   void shouldNotHaveTouchByDefault() {
-    page.navigate(getServer().PREFIX + "/mobile.html");
+    page.navigate(server.PREFIX + "/mobile.html");
     assertEquals(false, page.evaluate("() => 'ontouchstart' in window"));
-    page.navigate(getServer().PREFIX + "/detect-touch.html");
+    page.navigate(server.PREFIX + "/detect-touch.html");
     assertEquals("NO", page.evaluate("() => document.body.textContent.trim()"));
   }
 
@@ -98,9 +98,9 @@ public class TestBrowserContextViewport extends TestBase {
   void shouldSupportTouchWithNullViewport() {
     Browser.NewContextOptions options = new Browser.NewContextOptions()
       .setHasTouch(true).setViewportSize(null);
-    BrowserContext context = getBrowser().newContext(options);
+    BrowserContext context = browser.newContext(options);
     Page page = context.newPage();
-    page.navigate(getServer().PREFIX + "/mobile.html");
+    page.navigate(server.PREFIX + "/mobile.html");
     assertEquals(true, page.evaluate("() => 'ontouchstart' in window"));
     context.close();
   }
@@ -108,7 +108,7 @@ public class TestBrowserContextViewport extends TestBase {
   @Test
   void shouldReportNullViewPortSizeWhenGivenNullViewport() {
     Browser.NewContextOptions options = new Browser.NewContextOptions().setViewportSize(null);
-    BrowserContext context = getBrowser().newContext(options);
+    BrowserContext context = browser.newContext(options);
     Page page = context.newPage();
     assertNull(page.viewportSize());
     context.close();

--- a/playwright/src/test/java/com/microsoft/playwright/TestBrowserTypeBasic.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestBrowserTypeBasic.java
@@ -31,20 +31,20 @@ public class TestBrowserTypeBasic extends TestBase {
   void browserTypeExecutablePathShouldWork() {
     Assumptions.assumeTrue(getBrowserChannelFromEnv() == null);
     Assumptions.assumeTrue(createLaunchOptions().executablePath == null, "Skip with custom executable path");
-    String executablePath = getBrowserType().executablePath();
+    String executablePath = browserType.executablePath();
     assertTrue(Files.exists(Paths.get(executablePath)));
   }
 
   @Test
   void browserTypeNameShouldWork() {
-    assertEquals(getBrowserNameFromEnv(), getBrowserType().name());
+    assertEquals(getBrowserNameFromEnv(), browserType.name());
   }
 
   @Test
   @DisabledIf(value="com.microsoft.playwright.TestBase#isChromium", disabledReason="Non-chromium behavior")
   void shouldThrowWhenTryingToConnectWithNotChromium() {
     try {
-      getBrowserType().connectOverCDP("foo");
+      browserType.connectOverCDP("foo");
       fail("did not throw");
     } catch (PlaywrightException e) {
       assertTrue(e.getMessage().contains("Connecting over CDP is only supported in Chromium."));

--- a/playwright/src/test/java/com/microsoft/playwright/TestChromium.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestChromium.java
@@ -55,9 +55,9 @@ public class TestChromium extends TestBase {
   @Test
   void shouldConnectToAnExistingCdpSession() throws IOException {
     int port = nextPort++;
-    try (Browser browserServer = getBrowserType().launch(createLaunchOptions()
+    try (Browser browserServer = browserType.launch(createLaunchOptions()
         .setArgs(asList("--remote-debugging-port=" + port)))) {
-      Browser cdpBrowser = getBrowserType().connectOverCDP("http://localhost:" + port);
+      Browser cdpBrowser = browserType.connectOverCDP("http://localhost:" + port);
       List<BrowserContext> contexts = cdpBrowser.contexts();
       assertEquals(1, contexts.size());
       cdpBrowser.close();
@@ -67,20 +67,20 @@ public class TestChromium extends TestBase {
   @Test
   void shouldConnectToAnExistingCdpSessionTwice() throws IOException {
     int port = nextPort++;
-    try (Browser browserServer = getBrowserType().launch(createLaunchOptions()
+    try (Browser browserServer = browserType.launch(createLaunchOptions()
         .setArgs(asList("--remote-debugging-port=" + port)))) {
       String endpointUrl = "http://localhost:" + port;
-      Browser cdpBrowser1 = getBrowserType().connectOverCDP(endpointUrl);
-      Browser cdpBrowser2 = getBrowserType().connectOverCDP(endpointUrl);
+      Browser cdpBrowser1 = browserType.connectOverCDP(endpointUrl);
+      Browser cdpBrowser2 = browserType.connectOverCDP(endpointUrl);
       List<BrowserContext> contexts1 = cdpBrowser1.contexts();
       assertEquals(1, contexts1.size());
       Page page1 = contexts1.get(0).newPage();
-      page1.navigate(getServer().EMPTY_PAGE);
+      page1.navigate(server.EMPTY_PAGE);
 
       List<BrowserContext> contexts2 = cdpBrowser2.contexts();
       assertEquals(1, contexts2.size());
       Page page2 = contexts2.get(0).newPage();
-      page2.navigate(getServer().EMPTY_PAGE);
+      page2.navigate(server.EMPTY_PAGE);
 
       assertEquals(2, contexts1.get(0).pages().size());
       assertEquals(2, contexts2.get(0).pages().size());
@@ -93,16 +93,16 @@ public class TestChromium extends TestBase {
   @Test
   void shouldConnectOverAWsEndpoint() throws IOException {
     int port = nextPort++;
-    try (Browser browserServer = getBrowserType().launch(createLaunchOptions()
+    try (Browser browserServer = browserType.launch(createLaunchOptions()
         .setArgs(asList("--remote-debugging-port=" + port)))) {
       String wsEndpoint = wsEndpointFromUrl("http://localhost:" + port + "/json/version/");
 
-      Browser cdpBrowser1 = getBrowserType().connectOverCDP(wsEndpoint);
+      Browser cdpBrowser1 = browserType.connectOverCDP(wsEndpoint);
       List<BrowserContext> contexts1 = cdpBrowser1.contexts();
       assertEquals(1, contexts1.size());
       cdpBrowser1.close();
 
-      Browser cdpBrowser2 = getBrowserType().connectOverCDP(wsEndpoint);
+      Browser cdpBrowser2 = browserType.connectOverCDP(wsEndpoint);
       List<BrowserContext> contexts2 = cdpBrowser2.contexts();
       assertEquals(1, contexts2.size());
       cdpBrowser2.close();
@@ -113,7 +113,7 @@ public class TestChromium extends TestBase {
   void shouldSendExtraHeadersWithConnectRequest() throws Exception {
     try (WebSocketServerImpl webSocketServer = WebSocketServerImpl.create()) {
       try {
-        getBrowserType().connectOverCDP("ws://localhost:" + webSocketServer.getPort() + "/ws",
+        browserType.connectOverCDP("ws://localhost:" + webSocketServer.getPort() + "/ws",
           new BrowserType.ConnectOverCDPOptions().setHeaders(mapOf("User-Agent", "Playwright", "foo", "bar")));
       } catch (Exception e) {
       }

--- a/playwright/src/test/java/com/microsoft/playwright/TestChromiumTracing.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestChromiumTracing.java
@@ -35,36 +35,36 @@ import static org.junit.jupiter.api.Assertions.*;
 public class TestChromiumTracing extends TestBase {
   @Test
   void shouldOutputATrace(@TempDir Path tempDir) {
-    Page page = getBrowser().newPage();
+    Page page = browser.newPage();
     Path outputTraceFile = tempDir.resolve("trace.json");
-    getBrowser().startTracing(page, new Browser.StartTracingOptions()
+    browser.startTracing(page, new Browser.StartTracingOptions()
       .setScreenshots(true).setPath(outputTraceFile));
-    page.navigate(getServer().PREFIX + "/grid.html");
-    getBrowser().stopTracing();
+    page.navigate(server.PREFIX + "/grid.html");
+    browser.stopTracing();
     assertTrue(Files.exists(outputTraceFile));
     page.close();
   }
 
   @Test
   void shouldCreateDirectoriesAsNeeded(@TempDir Path tempDir) {
-    Page page = getBrowser().newPage();
+    Page page = browser.newPage();
     Path filePath = tempDir.resolve("these/are/directories/trace.json");
-    getBrowser().startTracing(page, new Browser.StartTracingOptions()
+    browser.startTracing(page, new Browser.StartTracingOptions()
       .setScreenshots(true).setPath(filePath));
-    page.navigate(getServer().PREFIX + "/grid.html");
-    getBrowser().stopTracing();
+    page.navigate(server.PREFIX + "/grid.html");
+    browser.stopTracing();
     assertTrue(Files.exists(filePath));
     page.close();
   }
 
   @Test
   void shouldRunWithCustomCategoriesIfProvided(@TempDir Path tempDir) throws IOException {
-    Page page = getBrowser().newPage();
+    Page page = browser.newPage();
     Path outputTraceFile = tempDir.resolve("trace.json");
-    getBrowser().startTracing(page, new Browser.StartTracingOptions()
+    browser.startTracing(page, new Browser.StartTracingOptions()
       .setPath(outputTraceFile)
       .setCategories(asList("disabled-by-default-v8.cpu_profiler.hires")));
-    getBrowser().stopTracing();
+    browser.stopTracing();
     byte[] data = Files.readAllBytes(outputTraceFile);
     JsonObject traceJson = new Gson().fromJson(new FileReader(outputTraceFile.toFile()), JsonObject.class);
     assertTrue(traceJson.getAsJsonObject("metadata").get("trace-config")
@@ -74,30 +74,30 @@ public class TestChromiumTracing extends TestBase {
 
   @Test
   void shouldThrowIfTracingOnTwoPages(@TempDir Path tempDir) {
-    Page page = getBrowser().newPage();
+    Page page = browser.newPage();
     Path outputTraceFile = tempDir.resolve("trace.json");
-    getBrowser().startTracing(page, new Browser.StartTracingOptions()
+    browser.startTracing(page, new Browser.StartTracingOptions()
         .setPath(outputTraceFile));
-    Page newPage = getBrowser().newPage();
+    Page newPage = browser.newPage();
     try {
-      getBrowser().startTracing(newPage, new Browser.StartTracingOptions()
+      browser.startTracing(newPage, new Browser.StartTracingOptions()
         .setPath(outputTraceFile));
       fail("did not throw");
     } catch (PlaywrightException e) {
     }
     newPage.close();
-    getBrowser().stopTracing();
+    browser.stopTracing();
     page.close();
   }
 
   @Test
   void shouldReturnABuffer(@TempDir Path tempDir) throws IOException {
-    Page page = getBrowser().newPage();
+    Page page = browser.newPage();
     Path outputTraceFile = tempDir.resolve("trace.json");
-    getBrowser().startTracing(page, new Browser.StartTracingOptions()
+    browser.startTracing(page, new Browser.StartTracingOptions()
       .setScreenshots(true).setPath(outputTraceFile));
-    page.navigate(getServer().PREFIX + "/grid.html");
-    byte[] trace = getBrowser().stopTracing();
+    page.navigate(server.PREFIX + "/grid.html");
+    byte[] trace = browser.stopTracing();
     byte[] buf = Files.readAllBytes(outputTraceFile);
     assertArrayEquals(buf, trace);
     page.close();
@@ -105,20 +105,20 @@ public class TestChromiumTracing extends TestBase {
 
   @Test
   void shouldWorkWithoutOptions() {
-    Page page = getBrowser().newPage();
-    getBrowser().startTracing(page);
-    page.navigate(getServer().PREFIX + "/grid.html");
-    byte[] trace = getBrowser().stopTracing();
+    Page page = browser.newPage();
+    browser.startTracing(page);
+    page.navigate(server.PREFIX + "/grid.html");
+    byte[] trace = browser.stopTracing();
     assertNotNull(trace);
     page.close();
   }
 
   @Test
   void shouldSupportABufferWithoutAPath() {
-    Page page = getBrowser().newPage();
-    getBrowser().startTracing(page, new Browser.StartTracingOptions().setScreenshots(true));
-    page.navigate(getServer().PREFIX + "/grid.html");
-    byte[] trace = getBrowser().stopTracing();
+    Page page = browser.newPage();
+    browser.startTracing(page, new Browser.StartTracingOptions().setScreenshots(true));
+    page.navigate(server.PREFIX + "/grid.html");
+    byte[] trace = browser.stopTracing();
     assertTrue(new String(trace, StandardCharsets.UTF_8).contains("screenshot"));
     page.close();
   }

--- a/playwright/src/test/java/com/microsoft/playwright/TestClick.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestClick.java
@@ -33,7 +33,7 @@ public class TestClick extends TestBase {
 
   @Test
   void shouldClickTheButton() {
-    page.navigate(getServer().PREFIX + "/input/button.html");
+    page.navigate(server.PREFIX + "/input/button.html");
     page.click("button");
     assertEquals("Clicked", page.evaluate("result"));
   }
@@ -49,7 +49,7 @@ public class TestClick extends TestBase {
 
   @Test
   void shouldClickTheButtonIfWindowNodeIsRemoved() {
-    page.navigate(getServer().PREFIX + "/input/button.html");
+    page.navigate(server.PREFIX + "/input/button.html");
     page.evaluate("() => delete window.Node");
     page.click("button");
     assertEquals("Clicked", page.evaluate("result"));
@@ -82,31 +82,31 @@ public class TestClick extends TestBase {
 
   @Test
   void shouldClickTheButtonAfterNavigation() {
-    page.navigate(getServer().PREFIX + "/input/button.html");
+    page.navigate(server.PREFIX + "/input/button.html");
     page.click("button");
-    page.navigate(getServer().PREFIX + "/input/button.html");
+    page.navigate(server.PREFIX + "/input/button.html");
     page.click("button");
     assertEquals("Clicked", page.evaluate("result"));
   }
 
   @Test
   void shouldClickTheButtonAfterACrossOriginNavigation() {
-    page.navigate(getServer().PREFIX + "/input/button.html");
+    page.navigate(server.PREFIX + "/input/button.html");
     page.click("button");
-    page.navigate(getServer().CROSS_PROCESS_PREFIX + "/input/button.html");
+    page.navigate(server.CROSS_PROCESS_PREFIX + "/input/button.html");
     page.click("button");
     assertEquals("Clicked", page.evaluate("result"));
   }
 
   @Test
   void shouldClickWithDisabledJavascript() {
-    BrowserContext context = getBrowser().newContext(new Browser.NewContextOptions().setJavaScriptEnabled(false));
+    BrowserContext context = browser.newContext(new Browser.NewContextOptions().setJavaScriptEnabled(false));
     Page page = context.newPage();
-    page.navigate(getServer().PREFIX + "/wrappedlink.html");
+    page.navigate(server.PREFIX + "/wrappedlink.html");
 
     page.waitForNavigation(() -> page.click("a"));
 
-    assertEquals(getServer().PREFIX + "/wrappedlink.html#clicked", page.url());
+    assertEquals(server.PREFIX + "/wrappedlink.html#clicked", page.url());
     context.close();
   }
 
@@ -126,7 +126,7 @@ public class TestClick extends TestBase {
 
   @Test
   void shouldSelectTheTextByTripleClicking() {
-    page.navigate(getServer().PREFIX + "/input/textarea.html");
+    page.navigate(server.PREFIX + "/input/textarea.html");
     String text = "This is the text that we are going to try to select. Let's see how it goes.";
     page.fill("textarea", text);
     page.click("textarea", new Page.ClickOptions().setClickCount(3));
@@ -138,7 +138,7 @@ public class TestClick extends TestBase {
 
   @Test
   void shouldClickOffscreenButtons() {
-    page.navigate(getServer().PREFIX + "/offscreenbuttons.html");
+    page.navigate(server.PREFIX + "/offscreenbuttons.html");
     List<String> messages = new ArrayList<>();
     page.onConsoleMessage(message -> messages.add(message.text()));
     for (int i = 0; i < 11; ++i) {
@@ -163,14 +163,14 @@ public class TestClick extends TestBase {
 
   @Test
   void shouldWaitForVisibleWhenAlreadyVisible() {
-    page.navigate(getServer().PREFIX + "/input/button.html");
+    page.navigate(server.PREFIX + "/input/button.html");
     page.click("button");
     assertEquals("Clicked", page.evaluate("result"));
   }
 
   @Test
   void shouldNotWaitWithForce() {
-    page.navigate(getServer().PREFIX + "/input/button.html");
+    page.navigate(server.PREFIX + "/input/button.html");
     page.evalOnSelector("button", "b => b.style.display = 'none'");
     Exception exception = null;
     try {
@@ -197,14 +197,14 @@ public class TestClick extends TestBase {
 
   @Test
   void shouldClickWrappedLinks() {
-    page.navigate(getServer().PREFIX + "/wrappedlink.html");
+    page.navigate(server.PREFIX + "/wrappedlink.html");
     page.click("a");
     assertTrue((Boolean) page.evaluate("__clicked"));
   }
 
   @Test
   void shouldClickOnCheckboxInputAndToggle() {
-    page.navigate(getServer().PREFIX + "/input/checkbox.html");
+    page.navigate(server.PREFIX + "/input/checkbox.html");
     assertNull(page.evaluate("() => window['result'].check"));
     page.click("input#agree");
     assertTrue((Boolean) page.evaluate("() => window['result'].check"));
@@ -224,7 +224,7 @@ public class TestClick extends TestBase {
 
   @Test
   void shouldClickOnCheckboxLabelAndToggle() {
-    page.navigate(getServer().PREFIX + "/input/checkbox.html");
+    page.navigate(server.PREFIX + "/input/checkbox.html");
     assertNull(page.evaluate("() => window['result'].check"));
     page.click("label[for='agree']");
     assertTrue((Boolean) page.evaluate("() => window['result'].check"));
@@ -240,7 +240,7 @@ public class TestClick extends TestBase {
   @Test
   void shouldNotHangWithTouchEnabledViewports() {
     // @see https://github.com/GoogleChrome/puppeteer/issues/161
-    BrowserContext context = getBrowser().newContext(new Browser.NewContextOptions()
+    BrowserContext context = browser.newContext(new Browser.NewContextOptions()
       .setViewportSize(375, 667)
       .setHasTouch(true));
     Page page = context.newPage();
@@ -252,7 +252,7 @@ public class TestClick extends TestBase {
 
   @Test
   void shouldScrollAndClickTheButton() {
-    page.navigate(getServer().PREFIX + "/input/scrollable.html");
+    page.navigate(server.PREFIX + "/input/scrollable.html");
     page.click("#button-5");
     assertEquals("clicked", page.evaluate("() => document.querySelector('#button-5').textContent"));
     page.click("#button-80");
@@ -261,7 +261,7 @@ public class TestClick extends TestBase {
 
   @Test
   void shouldDoubleClickTheButton() {
-    page.navigate(getServer().PREFIX + "/input/button.html");
+    page.navigate(server.PREFIX + "/input/button.html");
     page.evaluate("() => {\n" +
       "  window['double'] = false;\n" +
       "  const button = document.querySelector('button');\n" +
@@ -276,7 +276,7 @@ public class TestClick extends TestBase {
 
   @Test
   void shouldClickAPartiallyObscuredButton() {
-    page.navigate(getServer().PREFIX + "/input/button.html");
+    page.navigate(server.PREFIX + "/input/button.html");
     page.evaluate("() => {\n" +
       "  const button = document.querySelector('button');\n" +
       "  button.textContent = 'Some really long text that will go offscreen';\n" +
@@ -289,14 +289,14 @@ public class TestClick extends TestBase {
 
   @Test
   void shouldClickARotatedButton() {
-    page.navigate(getServer().PREFIX + "/input/rotatedButton.html");
+    page.navigate(server.PREFIX + "/input/rotatedButton.html");
     page.click("button");
     assertEquals("Clicked", page.evaluate("result"));
   }
 
   @Test
   void shouldFireContextmenuEventOnRightClick() {
-    page.navigate(getServer().PREFIX + "/input/scrollable.html");
+    page.navigate(server.PREFIX + "/input/scrollable.html");
     page.click("#button-8", new Page.ClickOptions().setButton(RIGHT));
     assertEquals("context menu", page.evaluate("() => document.querySelector('#button-8').textContent"));
   }
@@ -304,16 +304,16 @@ public class TestClick extends TestBase {
   @Test
   void shouldClickLinksWhichCauseNavigation() {
     // @see https://github.com/GoogleChrome/puppeteer/issues/206
-    page.setContent("<a href=" + getServer().EMPTY_PAGE + ">empty.html</a>");
+    page.setContent("<a href=" + server.EMPTY_PAGE + ">empty.html</a>");
     // This should not hang.
     page.click("a");
   }
 
   @Test
   void shouldClickTheButtonInsideAnIframe() {
-    page.navigate(getServer().EMPTY_PAGE);
+    page.navigate(server.EMPTY_PAGE);
     page.setContent("<div style='width:100px;height:100px'>spacer</div>");
-    Utils.attachFrame(page, "button-test", getServer().PREFIX + "/input/button.html");
+    Utils.attachFrame(page, "button-test", server.PREFIX + "/input/button.html");
     Frame frame = page.frames().get(1);
     ElementHandle button = frame.querySelector("button");
     button.click();
@@ -326,10 +326,10 @@ public class TestClick extends TestBase {
     // @see https://github.com/GoogleChrome/puppeteer/issues/4110
     // @see https://bugs.chromium.org/p/chromium/issues/detail?id=986390
     // @see https://chromium-review.googlesource.com/c/chromium/src/+/1742784
-    page.navigate(getServer().EMPTY_PAGE);
+    page.navigate(server.EMPTY_PAGE);
     page.setViewportSize(500, 500);
     page.setContent("<div style='width:100px;height:2000px'>spacer</div>");
-    Utils.attachFrame(page, "button-test", getServer().CROSS_PROCESS_PREFIX + "/input/button.html");
+    Utils.attachFrame(page, "button-test", server.CROSS_PROCESS_PREFIX + "/input/button.html");
     Frame frame = page.frames().get(1);
     frame.evalOnSelector("button", "button => button.style.setProperty('position', 'fixed')");
     frame.click("button");
@@ -339,13 +339,13 @@ public class TestClick extends TestBase {
 
   @Test
   void shouldClickTheButtonWithDeviceScaleFactorSet() {
-    BrowserContext context = getBrowser().newContext(new Browser.NewContextOptions()
+    BrowserContext context = browser.newContext(new Browser.NewContextOptions()
       .setViewportSize(400, 400)
       .setDeviceScaleFactor(5.0));
     Page page = context.newPage();
     assertEquals(5, page.evaluate("() => window.devicePixelRatio"));
     page.setContent("<div style='width:100px;height:100px'>spacer</div>");
-    Utils.attachFrame(page, "button-test", getServer().PREFIX + "/input/button.html");
+    Utils.attachFrame(page, "button-test", server.PREFIX + "/input/button.html");
     Frame frame = page.frames().get(1);
     ElementHandle button = frame.querySelector("button");
     button.click();
@@ -355,7 +355,7 @@ public class TestClick extends TestBase {
 
   @Test
   void shouldClickTheButtonWithPxBorderWithOffset() {
-    page.navigate(getServer().PREFIX + "/input/button.html");
+    page.navigate(server.PREFIX + "/input/button.html");
     page.evalOnSelector("button", "button => button.style.borderWidth = '8px'");
     page.click("button", new Page.ClickOptions().setPosition(20, 10));
     assertEquals(page.evaluate("result"), "Clicked");
@@ -366,7 +366,7 @@ public class TestClick extends TestBase {
 
   @Test
   void shouldClickTheButtonWithEmBorderWithOffset() {
-    page.navigate(getServer().PREFIX + "/input/button.html");
+    page.navigate(server.PREFIX + "/input/button.html");
     page.evalOnSelector("button", "button => button.style.borderWidth = '2em'");
     page.evalOnSelector("button", "button => button.style.fontSize = '12px'");
     page.click("button", new Page.ClickOptions().setPosition(20, 10));
@@ -378,7 +378,7 @@ public class TestClick extends TestBase {
 
   @Test
   void shouldClickAVeryLargeButtonWithOffset() {
-    page.navigate(getServer().PREFIX + "/input/button.html");
+    page.navigate(server.PREFIX + "/input/button.html");
     page.evalOnSelector("button", "button => button.style.borderWidth = '8px'");
     page.evalOnSelector("button", "button => button.style.height = button.style.width = '2000px'");
     page.click("button", new Page.ClickOptions().setPosition(1900, 1910));
@@ -390,7 +390,7 @@ public class TestClick extends TestBase {
 
   @Test
   void shouldClickAButtonInScrollingContainerWithOffset() {
-    page.navigate(getServer().PREFIX + "/input/button.html");
+    page.navigate(server.PREFIX + "/input/button.html");
     page.evalOnSelector("button", "button => {\n" +
       "  const container = document.createElement('div');\n" +
       "  container.style.overflow = 'auto';\n" +
@@ -412,11 +412,11 @@ public class TestClick extends TestBase {
   @Test
   @DisabledIf(value="com.microsoft.playwright.TestBase#isFirefox", disabledReason="skip")
   void shouldClickTheButtonWithOffsetWithPageScale() {
-    BrowserContext context = getBrowser().newContext(new Browser.NewContextOptions()
+    BrowserContext context = browser.newContext(new Browser.NewContextOptions()
       .setViewportSize(400, 400)
       .setIsMobile(true));
     Page page = context.newPage();
-    page.navigate(getServer().PREFIX + "/input/button.html");
+    page.navigate(server.PREFIX + "/input/button.html");
     page.evalOnSelector("button", "button => {\n" +
       "  button.style.borderWidth = '8px';\n" +
       "  document.body.style.margin = '0';\n" +
@@ -442,7 +442,7 @@ public class TestClick extends TestBase {
 
   @Test
   void shouldWaitForStablePosition() {
-    page.navigate(getServer().PREFIX + "/input/button.html");
+    page.navigate(server.PREFIX + "/input/button.html");
     page.evalOnSelector("button", "button => {\n" +
       "  button.style.transition = 'margin 500ms linear 0s';\n" +
       "  button.style.marginLeft = '200px';\n" +
@@ -466,7 +466,7 @@ public class TestClick extends TestBase {
 
   @Test
   void shouldFailWhenObscuredAndNotWaitingForHitTarget() {
-    page.navigate(getServer().PREFIX + "/input/button.html");
+    page.navigate(server.PREFIX + "/input/button.html");
     ElementHandle button = page.querySelector("button");
     page.evaluate("() => {\n" +
       "  document.body.style.position = 'relative';\n" +
@@ -532,7 +532,7 @@ public class TestClick extends TestBase {
 
   @Test
   void shouldUpdateModifiersCorrectly() {
-    page.navigate(getServer().PREFIX + "/input/button.html");
+    page.navigate(server.PREFIX + "/input/button.html");
     page.click("button", new Page.ClickOptions().setModifiers(asList(SHIFT)));
     assertEquals(true, page.evaluate("shiftKey"));
     page.click("button", new Page.ClickOptions().setModifiers(emptyList()));
@@ -560,7 +560,7 @@ public class TestClick extends TestBase {
 
   @Test
   void shouldReportNiceErrorWhenElementIsDetachedAndForceClicked() {
-    page.navigate(getServer().PREFIX + "/input/animating-button.html");
+    page.navigate(server.PREFIX + "/input/animating-button.html");
     page.evaluate("addButton()");
     ElementHandle handle = page.querySelector("button");
     page.evaluate("stopButton(true)");
@@ -610,7 +610,7 @@ public class TestClick extends TestBase {
 
   @Test
   void shouldClickTheButtonWhenWindowInnerWidthIsCorrupted() {
-    page.navigate(getServer().PREFIX + "/input/button.html");
+    page.navigate(server.PREFIX + "/input/button.html");
     page.evaluate("() => Object.defineProperty(window, 'innerWidth', {value: 0})");
     page.click("button");
     assertEquals("Clicked", page.evaluate("result"));

--- a/playwright/src/test/java/com/microsoft/playwright/TestDefaultBrowserContext2.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestDefaultBrowserContext2.java
@@ -43,14 +43,14 @@ public class TestDefaultBrowserContext2 extends TestBase {
       throw new RuntimeException(e);
     }
     assertNull(persistentContext);
-    persistentContext = getBrowserType().launchPersistentContext(userDataDir, options);
+    persistentContext = browserType.launchPersistentContext(userDataDir, options);
     return persistentContext.pages().get(0);
   }
 
   @Test
   void shouldSupportHasTouchOption() {
     Page page = launchPersistent(new BrowserType.LaunchPersistentContextOptions().setHasTouch(true));
-    page.navigate(getServer().PREFIX + "/mobile.html");
+    page.navigate(server.PREFIX + "/mobile.html");
     assertEquals(true, page.evaluate("() => 'ontouchstart' in window"));
   }
 
@@ -60,7 +60,7 @@ public class TestDefaultBrowserContext2 extends TestBase {
     // Firefox does not support mobile.
     Page page = launchPersistent(new BrowserType.LaunchPersistentContextOptions()
       .setViewportSize(320, 480).setIsMobile(true));
-    page.navigate(getServer().PREFIX + "/empty.html");
+    page.navigate(server.PREFIX + "/empty.html");
     assertEquals(980, page.evaluate("() => window.innerWidth"));
   }
 
@@ -91,7 +91,7 @@ public class TestDefaultBrowserContext2 extends TestBase {
     Page page = launchPersistent(new BrowserType.LaunchPersistentContextOptions()
       .setGeolocation(new Geolocation(10, 10))
       .setPermissions(asList("geolocation")));
-    page.navigate(getServer().EMPTY_PAGE);
+    page.navigate(server.EMPTY_PAGE);
     Object geolocation = page.evaluate("() => new Promise(resolve => navigator.geolocation.getCurrentPosition(position => {\n" +
       "  resolve({latitude: position.coords.latitude, longitude: position.coords.longitude});\n" +
       "}))");
@@ -110,8 +110,8 @@ public class TestDefaultBrowserContext2 extends TestBase {
   void shouldSupportExtraHTTPHeadersOption() throws ExecutionException, InterruptedException {
 //   TODO: test.flaky(browserName === "firefox" && headful && platform === "linux", "Intermittent timeout on bots");
     Page page = launchPersistent(new BrowserType.LaunchPersistentContextOptions().setExtraHTTPHeaders(mapOf("foo", "bar")));
-    Future<Server.Request> request = getServer().futureRequest("/empty.html");
-    page.navigate(getServer().EMPTY_PAGE);
+    Future<Server.Request> request = server.futureRequest("/empty.html");
+    page.navigate(server.EMPTY_PAGE);
     assertEquals(asList("bar"), request.get().headers.get("foo"));
   }
 
@@ -119,7 +119,7 @@ public class TestDefaultBrowserContext2 extends TestBase {
   void shouldAcceptUserDataDir() throws IOException {
 // TODO:   test.flaky(browserName === "chromium");
     Path userDataDir = Files.createTempDirectory("user-data-dir-");
-    BrowserContext context = getBrowserType().launchPersistentContext(userDataDir);
+    BrowserContext context = browserType.launchPersistentContext(userDataDir);
     assertTrue(userDataDir.toFile().listFiles().length > 0);
     context.close();
     assertTrue(userDataDir.toFile().listFiles().length > 0);
@@ -130,22 +130,22 @@ public class TestDefaultBrowserContext2 extends TestBase {
 //  TODO:  test.slow();
     Path userDataDir = Files.createTempDirectory("user-data-dir-");
     BrowserType.LaunchPersistentContextOptions browserOptions = null;
-    BrowserContext browserContext = getBrowserType().launchPersistentContext(userDataDir, browserOptions);
+    BrowserContext browserContext = browserType.launchPersistentContext(userDataDir, browserOptions);
     Page page = browserContext.newPage();
-    page.navigate(getServer().EMPTY_PAGE);
+    page.navigate(server.EMPTY_PAGE);
     page.evaluate("() => localStorage.hey = 'hello'");
     browserContext.close();
 
-    BrowserContext browserContext2 = getBrowserType().launchPersistentContext(userDataDir, browserOptions);
+    BrowserContext browserContext2 = browserType.launchPersistentContext(userDataDir, browserOptions);
     Page page2 = browserContext2.newPage();
-    page2.navigate(getServer().EMPTY_PAGE);
+    page2.navigate(server.EMPTY_PAGE);
     assertEquals("hello", page2.evaluate("localStorage.hey"));
     browserContext2.close();
 
     Path userDataDir2 = Files.createTempDirectory("user-data-dir-");
-    BrowserContext browserContext3 = getBrowserType().launchPersistentContext(userDataDir2, browserOptions);
+    BrowserContext browserContext3 = browserType.launchPersistentContext(userDataDir2, browserOptions);
     Page page3 = browserContext3.newPage();
-    page3.navigate(getServer().EMPTY_PAGE);
+    page3.navigate(server.EMPTY_PAGE);
     assertNotEquals("hello", page3.evaluate("localStorage.hey"));
     browserContext3.close();
   }
@@ -155,9 +155,9 @@ public class TestDefaultBrowserContext2 extends TestBase {
 // TODO:   test.flaky(browserName === "chromium");
     Path userDataDir = Files.createTempDirectory("user-data-dir-");
     BrowserType.LaunchPersistentContextOptions browserOptions = null;
-    BrowserContext browserContext = getBrowserType().launchPersistentContext(userDataDir, browserOptions);
+    BrowserContext browserContext = browserType.launchPersistentContext(userDataDir, browserOptions);
     Page page = browserContext.newPage();
-    page.navigate(getServer().EMPTY_PAGE);
+    page.navigate(server.EMPTY_PAGE);
     Object documentCookie = page.evaluate("() => {\n" +
       "    document.cookie = 'doSomethingOnlyOnce=true; expires=Fri, 31 Dec 9999 23:59:59 GMT';\n" +
       "    return document.cookie;\n" +
@@ -165,16 +165,16 @@ public class TestDefaultBrowserContext2 extends TestBase {
     assertEquals("doSomethingOnlyOnce=true", documentCookie);
     browserContext.close();
 
-    BrowserContext browserContext2 = getBrowserType().launchPersistentContext(userDataDir, browserOptions);
+    BrowserContext browserContext2 = browserType.launchPersistentContext(userDataDir, browserOptions);
     Page page2 = browserContext2.newPage();
-    page2.navigate(getServer().EMPTY_PAGE);
+    page2.navigate(server.EMPTY_PAGE);
     assertEquals("doSomethingOnlyOnce=true", page2.evaluate("() => document.cookie"));
     browserContext2.close();
 
     Path userDataDir2 = Files.createTempDirectory("user-data-dir-");
-    BrowserContext browserContext3 = getBrowserType().launchPersistentContext(userDataDir2, browserOptions);
+    BrowserContext browserContext3 = browserType.launchPersistentContext(userDataDir2, browserOptions);
     Page page3 = browserContext3.newPage();
-    page3.navigate(getServer().EMPTY_PAGE);
+    page3.navigate(server.EMPTY_PAGE);
     assertNotEquals("doSomethingOnlyOnce=true", page3.evaluate("() => document.cookie"));
     browserContext3.close();
   }
@@ -190,10 +190,10 @@ public class TestDefaultBrowserContext2 extends TestBase {
   @DisabledIf(value="com.microsoft.playwright.TestBase#isFirefox", disabledReason="skip")
   void shouldThrowIfPageArgumentIsPassed() throws IOException {
     BrowserType.LaunchPersistentContextOptions options = new BrowserType.LaunchPersistentContextOptions()
-      .setArgs(asList(getServer().EMPTY_PAGE));
+      .setArgs(asList(server.EMPTY_PAGE));
     Path userDataDir = Files.createTempDirectory("user-data-dir-");
     try {
-      getBrowserType().launchPersistentContext(userDataDir, options);
+      browserType.launchPersistentContext(userDataDir, options);
       fail("did not throw");
     } catch (PlaywrightException e) {
       assertTrue(e.getMessage().contains("can not specify page"));
@@ -204,7 +204,7 @@ public class TestDefaultBrowserContext2 extends TestBase {
   void shouldWorkWithIgnoreDefaultArgs() {
     // Ignore arguments by name.
     BrowserType.LaunchOptions options = new BrowserType.LaunchOptions().setIgnoreDefaultArgs(asList("foo"));
-    Browser browser = getBrowserType().launch(options);
+    Browser browser = browserType.launch(options);
     Page page = browser.newPage();
     browser.close();
     // Check that there is a way to ignore all arguments.
@@ -249,7 +249,7 @@ public class TestDefaultBrowserContext2 extends TestBase {
       "    return Array.from(root.querySelectorAll(selector));\n" +
       "  }\n" +
       "}";
-    getPlaywright().selectors().register("defaultContextCSS", defaultContextCSS);
+    playwright.selectors().register("defaultContextCSS", defaultContextCSS);
 
     page.setContent("<div>hello</div>");
     assertEquals("hello", page.innerHTML("css=div"));

--- a/playwright/src/test/java/com/microsoft/playwright/TestDialog.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestDialog.java
@@ -97,7 +97,7 @@ public class TestDialog extends TestBase {
   @Test
   @DisabledIf(value="isWebKitMac", disabledReason="fixme")
   void shouldBeAbleToCloseContextWithOpenAlert() {
-    BrowserContext context = getBrowser().newContext();
+    BrowserContext context = browser.newContext();
     Page page = context.newPage();
     boolean[] didShowDialog = {false};
     page.onDialog(dialog -> didShowDialog[0] = true);

--- a/playwright/src/test/java/com/microsoft/playwright/TestDispatchEvent.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestDispatchEvent.java
@@ -26,14 +26,14 @@ public class TestDispatchEvent extends TestBase {
 
   @Test
   void shouldDispatchClickEvent() {
-    page.navigate(getServer().PREFIX + "/input/button.html");
+    page.navigate(server.PREFIX + "/input/button.html");
     page.dispatchEvent("button", "click");
     assertEquals("Clicked", page.evaluate("() => window['result']"));
   }
 
   @Test
   void shouldDispatchClickEventProperties() {
-    page.navigate(getServer().PREFIX + "/input/button.html");
+    page.navigate(server.PREFIX + "/input/button.html");
     page.dispatchEvent("button", "click");
     assertNotNull(page.evaluate("bubbles"));
     assertNotNull(page.evaluate("cancelable"));
@@ -63,18 +63,18 @@ public class TestDispatchEvent extends TestBase {
 
   @Test
   void shouldDispatchClickAfterNavigation() {
-    page.navigate(getServer().PREFIX + "/input/button.html");
+    page.navigate(server.PREFIX + "/input/button.html");
     page.dispatchEvent("button", "click");
-    page.navigate(getServer().PREFIX + "/input/button.html");
+    page.navigate(server.PREFIX + "/input/button.html");
     page.dispatchEvent("button", "click");
     assertEquals("Clicked", page.evaluate("() => window['result']"));
   }
 
   @Test
   void shouldDispatchClickAfterACrossOriginNavigation() {
-    page.navigate(getServer().PREFIX + "/input/button.html");
+    page.navigate(server.PREFIX + "/input/button.html");
     page.dispatchEvent("button", "click");
-    page.navigate(getServer().CROSS_PROCESS_PREFIX + "/input/button.html");
+    page.navigate(server.CROSS_PROCESS_PREFIX + "/input/button.html");
     page.dispatchEvent("button", "click");
     assertEquals("Clicked", page.evaluate("() => window['result']"));
   }
@@ -97,7 +97,7 @@ public class TestDispatchEvent extends TestBase {
 
   @Test
   void shouldDispatchClickWhenNodeIsAddedInShadowDom() {
-    page.navigate(getServer().EMPTY_PAGE);
+    page.navigate(server.EMPTY_PAGE);
     page.evaluate("() => {\n" +
       "  const div = document.createElement('div');\n" +
       "  div.attachShadow({mode: 'open'});\n" +
@@ -122,7 +122,7 @@ public class TestDispatchEvent extends TestBase {
 
   @Test
   void shouldDispatchDragDropEvents() {
-    page.navigate(getServer().PREFIX + "/drag-n-drop.html");
+    page.navigate(server.PREFIX + "/drag-n-drop.html");
     JSHandle dataTransfer = page.evaluateHandle("() => new DataTransfer()");
     page.dispatchEvent("#source", "dragstart", mapOf("dataTransfer", dataTransfer));
     page.dispatchEvent("#target", "drop", mapOf("dataTransfer", dataTransfer));
@@ -135,7 +135,7 @@ public class TestDispatchEvent extends TestBase {
 
   @Test
   void shouldDispatchDragDropEventsOnHandle() {
-    page.navigate(getServer().PREFIX + "/drag-n-drop.html");
+    page.navigate(server.PREFIX + "/drag-n-drop.html");
     JSHandle dataTransfer = page.evaluateHandle("() => new DataTransfer()");
     ElementHandle source = page.querySelector("#source");
     source.dispatchEvent("dragstart", mapOf("dataTransfer", dataTransfer));
@@ -148,7 +148,7 @@ public class TestDispatchEvent extends TestBase {
 
   @Test
   void shouldDispatchClickEventOnHandle() {
-    page.navigate(getServer().PREFIX + "/input/button.html");
+    page.navigate(server.PREFIX + "/input/button.html");
     ElementHandle button = page.querySelector("button");
     button.dispatchEvent("click");
     assertEquals("Clicked", page.evaluate("() => window['result']"));

--- a/playwright/src/test/java/com/microsoft/playwright/TestDownload.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestDownload.java
@@ -42,7 +42,7 @@ public class TestDownload extends TestBase {
 
   @BeforeEach
   void addRoutes() {
-    getServer().setRoute("/download", exchange -> {
+    server.setRoute("/download", exchange -> {
       exchange.getResponseHeaders().add("Content-Type", "application/octet-stream");
       exchange.getResponseHeaders().add("Content-Disposition", "attachment");
       exchange.sendResponseHeaders(200, 0);
@@ -50,7 +50,7 @@ public class TestDownload extends TestBase {
         writer.write("Hello world");
       }
     });
-    getServer().setRoute("/downloadWithFilename", exchange -> {
+    server.setRoute("/downloadWithFilename", exchange -> {
       exchange.getResponseHeaders().add("Content-Type", "application/octet-stream");
       exchange.getResponseHeaders().add("Content-Disposition", "attachment; filename=file.txt");
       exchange.sendResponseHeaders(200, 0);
@@ -62,9 +62,9 @@ public class TestDownload extends TestBase {
 
   @Test
   void shouldReportDownloadsWithAcceptDownloadsFalse() {
-    page.setContent("<a href='" + getServer().PREFIX + "/downloadWithFilename'>download</a>");
+    page.setContent("<a href='" + server.PREFIX + "/downloadWithFilename'>download</a>");
     Download download = page.waitForDownload(() -> page.click("a"));
-    assertEquals(getServer().PREFIX + "/downloadWithFilename", download.url());
+    assertEquals(server.PREFIX + "/downloadWithFilename", download.url());
     assertEquals("file.txt", download.suggestedFilename());
     try {
       download.path();
@@ -76,8 +76,8 @@ public class TestDownload extends TestBase {
   }
   @Test
   void shouldReportDownloadsWithAcceptDownloadsTrue() throws IOException {
-    Page page = getBrowser().newPage(new Browser.NewPageOptions().setAcceptDownloads(true));
-    page.setContent("<a href='" + getServer().PREFIX + "/download'>download</a>");
+    Page page = browser.newPage(new Browser.NewPageOptions().setAcceptDownloads(true));
+    page.setContent("<a href='" + server.PREFIX + "/download'>download</a>");
     Download download = page.waitForDownload(() -> page.click("a"));
     Path path = download.path();
     assertTrue(Files.exists(path));
@@ -88,8 +88,8 @@ public class TestDownload extends TestBase {
 
   @Test
   void shouldSaveToUserSpecifiedPath() throws IOException {
-    Page page = getBrowser().newPage(new Browser.NewPageOptions().setAcceptDownloads(true));
-    page.setContent("<a href='" + getServer().PREFIX + "/download'>download</a>");
+    Page page = browser.newPage(new Browser.NewPageOptions().setAcceptDownloads(true));
+    page.setContent("<a href='" + server.PREFIX + "/download'>download</a>");
     Download download = page.waitForDownload(() -> page.click("a"));
 
     Path userFile = Files.createTempFile("download-", ".txt");
@@ -102,8 +102,8 @@ public class TestDownload extends TestBase {
 
   @Test
   void shouldSaveToUserSpecifiedPathWithoutUpdatingOriginalPath() throws IOException {
-    Page page = getBrowser().newPage(new Browser.NewPageOptions().setAcceptDownloads(true));
-    page.setContent("<a href='" + getServer().PREFIX + "/download'>download</a>");
+    Page page = browser.newPage(new Browser.NewPageOptions().setAcceptDownloads(true));
+    page.setContent("<a href='" + server.PREFIX + "/download'>download</a>");
     Download download = page.waitForDownload(() -> page.click("a"));
 
     Path userFile = Files.createTempFile("download-", ".txt");
@@ -125,8 +125,8 @@ public class TestDownload extends TestBase {
 
   @Test
   void shouldSaveToTwoDifferentPathsWithMultipleSaveAsCalls() throws IOException {
-    Page page = getBrowser().newPage(new Browser.NewPageOptions().setAcceptDownloads(true));
-    page.setContent("<a href='" + getServer().PREFIX + "/download'>download</a>");
+    Page page = browser.newPage(new Browser.NewPageOptions().setAcceptDownloads(true));
+    page.setContent("<a href='" + server.PREFIX + "/download'>download</a>");
     Download download = page.waitForDownload(() -> page.click("a"));
     {
       Path userFile = Files.createTempFile("download-", ".txt");
@@ -147,8 +147,8 @@ public class TestDownload extends TestBase {
 
   @Test
   void shouldSaveToOverwrittenFilepath() throws IOException {
-    Page page = getBrowser().newPage(new Browser.NewPageOptions().setAcceptDownloads(true));
-    page.setContent("<a href='" + getServer().PREFIX + "/download'>download</a>");
+    Page page = browser.newPage(new Browser.NewPageOptions().setAcceptDownloads(true));
+    page.setContent("<a href='" + server.PREFIX + "/download'>download</a>");
     Download download = page.waitForDownload(() -> page.click("a"));
     Path userFile = Files.createTempFile("download-", ".txt");
     {
@@ -168,8 +168,8 @@ public class TestDownload extends TestBase {
 
   @Test
   void shouldCreateSubdirectoriesWhenSavingToNonExistentUserSpecifiedPath() throws IOException {
-    Page page = getBrowser().newPage(new Browser.NewPageOptions().setAcceptDownloads(true));
-    page.setContent("<a href='" + getServer().PREFIX + "/download'>download</a>");
+    Page page = browser.newPage(new Browser.NewPageOptions().setAcceptDownloads(true));
+    page.setContent("<a href='" + server.PREFIX + "/download'>download</a>");
     Download download = page.waitForDownload(() -> page.click("a"));
 
     Path downloads = Files.createTempDirectory("downloads");
@@ -187,8 +187,8 @@ public class TestDownload extends TestBase {
 
   @Test
   void shouldErrorWhenSavingWithDownloadsDisabled() throws IOException {
-    Page page = getBrowser().newPage(new Browser.NewPageOptions().setAcceptDownloads(false));
-    page.setContent("<a href='" + getServer().PREFIX + "/download'>download</a>");
+    Page page = browser.newPage(new Browser.NewPageOptions().setAcceptDownloads(false));
+    page.setContent("<a href='" + server.PREFIX + "/download'>download</a>");
     Download download = page.waitForDownload(() -> page.click("a"));
 
     Path userPath = Files.createTempFile("download-", ".txt");
@@ -203,8 +203,8 @@ public class TestDownload extends TestBase {
 
   @Test
   void shouldErrorWhenSavingAfterDeletion() throws IOException {
-    Page page = getBrowser().newPage(new Browser.NewPageOptions().setAcceptDownloads(true));
-    page.setContent("<a href='" + getServer().PREFIX + "/download'>download</a>");
+    Page page = browser.newPage(new Browser.NewPageOptions().setAcceptDownloads(true));
+    page.setContent("<a href='" + server.PREFIX + "/download'>download</a>");
     Download download = page.waitForDownload(() -> page.click("a"));
 
     Path userPath = Files.createTempFile("download-", ".txt");
@@ -225,7 +225,7 @@ public class TestDownload extends TestBase {
   @Test
   void shouldReportNonNavigationDownloads() throws IOException {
     // Mac WebKit embedder does not download in this case, although Safari does.
-    getServer().setRoute("/download", exchange -> {
+    server.setRoute("/download", exchange -> {
       exchange.getResponseHeaders().add("Content-Type", "application/octet-stream");
       exchange.sendResponseHeaders(200, 0);
       try (OutputStreamWriter writer = new OutputStreamWriter(exchange.getResponseBody())) {
@@ -233,9 +233,9 @@ public class TestDownload extends TestBase {
       }
     });
 
-    Page page = getBrowser().newPage(new Browser.NewPageOptions().setAcceptDownloads(true));
-    page.navigate(getServer().EMPTY_PAGE);
-    page.setContent("<a download='file.txt' href='" + getServer().PREFIX + "/download'>download</a>");
+    Page page = browser.newPage(new Browser.NewPageOptions().setAcceptDownloads(true));
+    page.navigate(server.EMPTY_PAGE);
+    page.setContent("<a download='file.txt' href='" + server.PREFIX + "/download'>download</a>");
     Download download = page.waitForDownload(() -> page.click("a"));
 
     assertEquals("file.txt", download.suggestedFilename());
@@ -248,8 +248,8 @@ public class TestDownload extends TestBase {
 
   @Test
   void shouldReportDownloadPathWithinPageOnDownloadHandlerForFiles() throws IOException {
-    Page page = getBrowser().newPage(new Browser.NewPageOptions().setAcceptDownloads(true));
-    page.setContent("<a href='" + getServer().PREFIX + "/download'>download</a>");
+    Page page = browser.newPage(new Browser.NewPageOptions().setAcceptDownloads(true));
+    page.setContent("<a href='" + server.PREFIX + "/download'>download</a>");
     @SuppressWarnings("unchecked")
     Download[] download = {null};
     page.onDownload(d -> download[0] = d);
@@ -268,11 +268,11 @@ public class TestDownload extends TestBase {
 
   @Test
   void shouldReportDownloadPathWithinPageOnDownloadHandlerForBlobs() throws IOException {
-    Page page = getBrowser().newPage(new Browser.NewPageOptions().setAcceptDownloads(true));
+    Page page = browser.newPage(new Browser.NewPageOptions().setAcceptDownloads(true));
     @SuppressWarnings("unchecked")
     Download[] download = {null};
     page.onDownload(d -> download[0] = d);
-    page.navigate(getServer().PREFIX + "/download-blob.html");
+    page.navigate(server.PREFIX + "/download-blob.html");
     page.click("a");
     Instant start = Instant.now();
     while (download[0] == null) {
@@ -291,15 +291,15 @@ public class TestDownload extends TestBase {
   void shouldReportAltClickDownloads() throws IOException {
     // Firefox does not download on alt-click by default.
     // Our WebKit embedder does not download on alt-click, although Safari does.
-    getServer().setRoute("/download", exchange -> {
+    server.setRoute("/download", exchange -> {
       exchange.getResponseHeaders().add("Content-Type", "application/octet-stream");
       exchange.sendResponseHeaders(200, 0);
       try (OutputStreamWriter writer = new OutputStreamWriter(exchange.getResponseBody())) {
         writer.write("Hello world");
       }
     });
-    Page page = getBrowser().newPage(new Browser.NewPageOptions().setAcceptDownloads(true));
-    page.setContent("<a href='" + getServer().PREFIX + "/download'>download</a>");
+    Page page = browser.newPage(new Browser.NewPageOptions().setAcceptDownloads(true));
+    page.setContent("<a href='" + server.PREFIX + "/download'>download</a>");
     Download download = page.waitForDownload(() -> page.click("a", new Page.ClickOptions().setModifiers(asList(ALT))));
     Path path = download.path();
     assertTrue(Files.exists(path));
@@ -319,8 +319,8 @@ public class TestDownload extends TestBase {
     // TODO: - the test fails in headful Chromium as the popup page gets closed along
     // with the session before download completed event arrives.
     // - WebKit doesn't close the popup page
-    Page page = getBrowser().newPage(new Browser.NewPageOptions().setAcceptDownloads(true));
-    page.setContent("<a target=_blank href='" + getServer().PREFIX + "/download'>download</a>");
+    Page page = browser.newPage(new Browser.NewPageOptions().setAcceptDownloads(true));
+    page.setContent("<a target=_blank href='" + server.PREFIX + "/download'>download</a>");
     Download download = page.waitForDownload(() -> page.click("a"));
     Path path = download.path();
     assertTrue(Files.exists(path));
@@ -331,8 +331,8 @@ public class TestDownload extends TestBase {
 
   @Test
   void shouldDeleteFile() {
-    Page page = getBrowser().newPage(new Browser.NewPageOptions().setAcceptDownloads(true));
-    page.setContent("<a href='" + getServer().PREFIX + "/download'>download</a>");
+    Page page = browser.newPage(new Browser.NewPageOptions().setAcceptDownloads(true));
+    page.setContent("<a href='" + server.PREFIX + "/download'>download</a>");
     Download download = page.waitForDownload(() -> page.click("a"));
     Path path = download.path();
     assertTrue(Files.exists(path));
@@ -343,8 +343,8 @@ public class TestDownload extends TestBase {
 
   @Test
   void shouldExposeStream() throws IOException {
-    Page page = getBrowser().newPage(new Browser.NewPageOptions().setAcceptDownloads(true));
-    page.setContent("<a href='" + getServer().PREFIX + "/download'>download</a>");
+    Page page = browser.newPage(new Browser.NewPageOptions().setAcceptDownloads(true));
+    page.setContent("<a href='" + server.PREFIX + "/download'>download</a>");
     Download download = page.waitForDownload(() -> page.click("a"));
 
     InputStream stream = download.createReadStream();
@@ -356,8 +356,8 @@ public class TestDownload extends TestBase {
 
   @Test
   void shouldDeleteDownloadsOnContextDestruction() {
-    Page page = getBrowser().newPage(new Browser.NewPageOptions().setAcceptDownloads(true));
-    page.setContent("<a href='" + getServer().PREFIX + "/download'>download</a>");
+    Page page = browser.newPage(new Browser.NewPageOptions().setAcceptDownloads(true));
+    page.setContent("<a href='" + server.PREFIX + "/download'>download</a>");
     Download download1 = page.waitForDownload(() -> page.click("a"));
     Download download2 = page.waitForDownload(() -> page.click("a"));
     Path path1 = download1.path();
@@ -371,9 +371,9 @@ public class TestDownload extends TestBase {
 
   @Test
   void shouldDeleteDownloadsOnBrowserGone() {
-    Browser browser = getBrowserType().launch();
+    Browser browser = browserType.launch();
     Page page = browser.newPage(new Browser.NewPageOptions().setAcceptDownloads(true));
-    page.setContent("<a href='" + getServer().PREFIX + "/download'>download</a>");
+    page.setContent("<a href='" + server.PREFIX + "/download'>download</a>");
     Download download1 = page.waitForDownload(() -> page.click("a"));
     Download download2 = page.waitForDownload(() -> page.click("a"));
     Path path1 = download1.path();

--- a/playwright/src/test/java/com/microsoft/playwright/TestElementHandleBoundingBox.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestElementHandleBoundingBox.java
@@ -34,7 +34,7 @@ public class TestElementHandleBoundingBox extends TestBase {
   @DisabledIf(value="isFirefoxHeadful", disabledReason="fail")
   void shouldWork() {
     page.setViewportSize(500, 500);
-    page.navigate(getServer().PREFIX + "/grid.html");
+    page.navigate(server.PREFIX + "/grid.html");
     ElementHandle elementHandle = page.querySelector(".box:nth-of-type(13)");
     BoundingBox box = elementHandle.boundingBox();
     assertEquals(100, box.x);
@@ -46,7 +46,7 @@ public class TestElementHandleBoundingBox extends TestBase {
   @Test
   void shouldHandleNestedFrames() {
     page.setViewportSize(500, 500);
-    page.navigate(getServer().PREFIX + "/frames/nested-frames.html");
+    page.navigate(server.PREFIX + "/frames/nested-frames.html");
     Frame nestedFrame = page.frame("dos");
     assertNotNull(nestedFrame);
     ElementHandle elementHandle = nestedFrame.querySelector("div");
@@ -98,10 +98,10 @@ public class TestElementHandleBoundingBox extends TestBase {
   @Test
   @DisabledIf(value="com.microsoft.playwright.TestBase#isFirefox", disabledReason="skip")
   void shouldWorkWithPageScale() {
-    BrowserContext context = getBrowser().newContext(new Browser.NewContextOptions()
+    BrowserContext context = browser.newContext(new Browser.NewContextOptions()
       .setViewportSize(400, 400).setIsMobile(true));
     Page page = context.newPage();
-    page.navigate(getServer().PREFIX + "/input/button.html");
+    page.navigate(server.PREFIX + "/input/button.html");
     ElementHandle button = page.querySelector("button");
     button.evaluate("button => {\n" +
       "  document.body.style.margin = '0';\n" +

--- a/playwright/src/test/java/com/microsoft/playwright/TestElementHandleClick.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestElementHandleClick.java
@@ -24,7 +24,7 @@ public class TestElementHandleClick extends TestBase {
 
   @Test
   void shouldWork() {
-    page.navigate(getServer().PREFIX + "/input/button.html");
+    page.navigate(server.PREFIX + "/input/button.html");
     ElementHandle button = page.querySelector("button");
     button.click();
     assertEquals("Clicked", page.evaluate("() => window['result']"));
@@ -32,7 +32,7 @@ public class TestElementHandleClick extends TestBase {
 
   @Test
   void shouldWorkWithNodeRemoved() {
-    page.navigate(getServer().PREFIX + "/input/button.html");
+    page.navigate(server.PREFIX + "/input/button.html");
     page.evaluate("() => delete window['Node']");
     ElementHandle button  = page.querySelector("button");
     button.click();
@@ -41,7 +41,7 @@ public class TestElementHandleClick extends TestBase {
 
   @Test
   void shouldWorkForShadowDOMV1() {
-    page.navigate(getServer().PREFIX + "/shadow.html");
+    page.navigate(server.PREFIX + "/shadow.html");
     ElementHandle buttonHandle = page.evaluateHandle("() => window['button']").asElement();
     buttonHandle.click();
     assertEquals(true, page.evaluate("clicked"));
@@ -49,7 +49,7 @@ public class TestElementHandleClick extends TestBase {
 
   @Test
   void shouldWorkForTextNodes() {
-    page.navigate(getServer().PREFIX + "/input/button.html");
+    page.navigate(server.PREFIX + "/input/button.html");
     ElementHandle buttonTextNode = page.evaluateHandle("() => document.querySelector('button').firstChild").asElement();
     buttonTextNode.click();
     assertEquals("Clicked", page.evaluate("() => window['result']"));
@@ -57,7 +57,7 @@ public class TestElementHandleClick extends TestBase {
 
   @Test
   void shouldThrowForDetachedNodes() {
-    page.navigate(getServer().PREFIX + "/input/button.html");
+    page.navigate(server.PREFIX + "/input/button.html");
     ElementHandle button = page.querySelector("button");
     page.evaluate("button => button.remove()", button);
     try {
@@ -70,7 +70,7 @@ public class TestElementHandleClick extends TestBase {
 
   @Test
   void shouldThrowForHiddenNodesWithForce() {
-    page.navigate(getServer().PREFIX + "/input/button.html");
+    page.navigate(server.PREFIX + "/input/button.html");
     ElementHandle button = page.querySelector("button");
     page.evaluate("button => button.style.display = 'none'", button);
     try {
@@ -83,7 +83,7 @@ public class TestElementHandleClick extends TestBase {
 
   @Test
   void shouldThrowForRecursivelyHiddenNodesWithForce() {
-    page.navigate(getServer().PREFIX + "/input/button.html");
+    page.navigate(server.PREFIX + "/input/button.html");
     ElementHandle button = page.querySelector("button");
     page.evaluate("button => button.parentElement.style.display = 'none'", button);
     try {
@@ -108,7 +108,7 @@ public class TestElementHandleClick extends TestBase {
 
   @Test
   void shouldDoubleClickTheButton() {
-    page.navigate(getServer().PREFIX + "/input/button.html");
+    page.navigate(server.PREFIX + "/input/button.html");
     page.evaluate("() => {\n" +
       "  window['double'] = false;\n" +
       "  const button = document.querySelector('button');\n" +

--- a/playwright/src/test/java/com/microsoft/playwright/TestElementHandleContentFrame.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestElementHandleContentFrame.java
@@ -25,8 +25,8 @@ public class TestElementHandleContentFrame extends TestBase {
 
   @Test
   void shouldWork() {
-    page.navigate(getServer().EMPTY_PAGE);
-    attachFrame(page, "frame1", getServer().EMPTY_PAGE);
+    page.navigate(server.EMPTY_PAGE);
+    attachFrame(page, "frame1", server.EMPTY_PAGE);
     ElementHandle elementHandle = page.querySelector("#frame1");
     Frame frame = elementHandle.contentFrame();
     assertEquals(page.frames().get(1), frame);
@@ -34,8 +34,8 @@ public class TestElementHandleContentFrame extends TestBase {
 
   @Test
   void shouldWorkForCrossProcessIframes() {
-    page.navigate(getServer().EMPTY_PAGE);
-    attachFrame(page, "frame1", getServer().CROSS_PROCESS_PREFIX + "/empty.html");
+    page.navigate(server.EMPTY_PAGE);
+    attachFrame(page, "frame1", server.CROSS_PROCESS_PREFIX + "/empty.html");
     ElementHandle elementHandle = page.querySelector("#frame1");
     Frame frame = elementHandle.contentFrame();
     assertEquals(page.frames().get(1), frame);
@@ -43,8 +43,8 @@ public class TestElementHandleContentFrame extends TestBase {
 
   @Test
   void shouldWorkForCrossFrameEvaluations() {
-    page.navigate(getServer().EMPTY_PAGE);
-    attachFrame(page, "frame1", getServer().EMPTY_PAGE);
+    page.navigate(server.EMPTY_PAGE);
+    attachFrame(page, "frame1", server.EMPTY_PAGE);
     Frame frame = page.frames().get(1);
     JSHandle jsHandle = frame.evaluateHandle("() => window.top.document.querySelector('#frame1')");
     ElementHandle elementHandle = jsHandle.asElement();
@@ -54,8 +54,8 @@ public class TestElementHandleContentFrame extends TestBase {
 
   @Test
   void shouldReturnNullForNonIframes() {
-    page.navigate(getServer().EMPTY_PAGE);
-    attachFrame(page, "frame1", getServer().EMPTY_PAGE);
+    page.navigate(server.EMPTY_PAGE);
+    attachFrame(page, "frame1", server.EMPTY_PAGE);
     Frame frame = page.frames().get(1);
     JSHandle jsHandle = frame.evaluateHandle("() => document.body");
     ElementHandle elementHandle = jsHandle.asElement();
@@ -65,8 +65,8 @@ public class TestElementHandleContentFrame extends TestBase {
 
   @Test
   void shouldReturnNullForDocumentDocumentElement() {
-    page.navigate(getServer().EMPTY_PAGE);
-    attachFrame(page, "frame1", getServer().EMPTY_PAGE);
+    page.navigate(server.EMPTY_PAGE);
+    attachFrame(page, "frame1", server.EMPTY_PAGE);
     Frame frame = page.frames().get(1);
     JSHandle jsHandle = frame.evaluateHandle("() => document.documentElement");
     ElementHandle elementHandle = jsHandle.asElement();

--- a/playwright/src/test/java/com/microsoft/playwright/TestElementHandleConvenience.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestElementHandleConvenience.java
@@ -23,7 +23,7 @@ import static org.junit.jupiter.api.Assertions.*;
 public class TestElementHandleConvenience extends TestBase {
   @Test
   void shouldHaveANicePreview() {
-    page.navigate(getServer().PREFIX + "/dom.html");
+    page.navigate(server.PREFIX + "/dom.html");
     ElementHandle outer = page.querySelector("#outer");
     ElementHandle inner = page.querySelector("#inner");
     ElementHandle check = page.querySelector("#check");
@@ -37,7 +37,7 @@ public class TestElementHandleConvenience extends TestBase {
 
   @Test
   void getAttributeShouldWork() {
-    page.navigate(getServer().PREFIX + "/dom.html");
+    page.navigate(server.PREFIX + "/dom.html");
     ElementHandle handle = page.querySelector("#outer");
     assertEquals("value", handle.getAttribute("name"));
     assertNull(handle.getAttribute("foo"));
@@ -47,7 +47,7 @@ public class TestElementHandleConvenience extends TestBase {
 
   @Test
   void innerHTMLShouldWork() {
-    page.navigate(getServer().PREFIX + "/dom.html");
+    page.navigate(server.PREFIX + "/dom.html");
     ElementHandle handle = page.querySelector("#outer");
     assertEquals("<div id=\"inner\">Text,\nmore text</div>", handle.innerHTML());
     assertEquals("<div id=\"inner\">Text,\nmore text</div>", page.innerHTML("#outer"));
@@ -55,7 +55,7 @@ public class TestElementHandleConvenience extends TestBase {
 
   @Test
   void innerTextShouldWork() {
-    page.navigate(getServer().PREFIX + "/dom.html");
+    page.navigate(server.PREFIX + "/dom.html");
     ElementHandle handle = page.querySelector("#inner");
     assertEquals("Text, more text", handle.innerText());
     assertEquals("Text, more text", page.innerText("#inner"));
@@ -81,7 +81,7 @@ public class TestElementHandleConvenience extends TestBase {
 
   @Test
   void textContentShouldWork() {
-    page.navigate(getServer().PREFIX + "/dom.html");
+    page.navigate(server.PREFIX + "/dom.html");
     ElementHandle handle = page.querySelector("#inner");
     assertEquals("Text,\nmore text", handle.textContent());
     assertEquals("Text,\nmore text", page.textContent("#inner"));
@@ -103,7 +103,7 @@ public class TestElementHandleConvenience extends TestBase {
       "    return result;\n" +
       "  }\n" +
       "}\n";
-    getPlaywright().selectors().register("textContent", createDummySelector);
+    playwright.selectors().register("textContent", createDummySelector);
     page.setContent("<div>Hello</div>");
     String tc = page.textContent("textContent=div");
     assertEquals("Hello", tc);
@@ -126,7 +126,7 @@ public class TestElementHandleConvenience extends TestBase {
       "    return result;\n" +
       "  }\n" +
       "}\n";
-    getPlaywright().selectors().register("innerText", createDummySelector);
+    playwright.selectors().register("innerText", createDummySelector);
     page.setContent("<div>Hello</div>");
     String tc = page.innerText("innerText=div");
     assertEquals("Hello", tc);
@@ -149,7 +149,7 @@ public class TestElementHandleConvenience extends TestBase {
       "    return result;\n" +
       "  }\n" +
       "}\n";
-    getPlaywright().selectors().register("innerHTML", createDummySelector);
+    playwright.selectors().register("innerHTML", createDummySelector);
     page.setContent("<div>Hello<span>world</span></div>");
     String tc = page.innerHTML("innerHTML=div");
     assertEquals("Hello<span>world</span>", tc);
@@ -172,7 +172,7 @@ public class TestElementHandleConvenience extends TestBase {
       "    return result;\n" +
       "  }\n" +
       "}\n";
-    getPlaywright().selectors().register("getAttribute", createDummySelector);
+    playwright.selectors().register("getAttribute", createDummySelector);
     page.setContent("<div foo=hello></div>");
     String tc = page.getAttribute("getAttribute=div", "foo");
     assertEquals("hello", tc);

--- a/playwright/src/test/java/com/microsoft/playwright/TestElementHandleOwnerFrame.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestElementHandleOwnerFrame.java
@@ -26,8 +26,8 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 public class TestElementHandleOwnerFrame extends TestBase {
   @Test
   void shouldWork() {
-    page.navigate(getServer().EMPTY_PAGE);
-    attachFrame(page, "frame1", getServer().EMPTY_PAGE);
+    page.navigate(server.EMPTY_PAGE);
+    attachFrame(page, "frame1", server.EMPTY_PAGE);
     Frame frame = page.frames().get(1);
     JSHandle jsHandle = frame.evaluateHandle("() => document.body");
     ElementHandle elementHandle = jsHandle.asElement();
@@ -37,8 +37,8 @@ public class TestElementHandleOwnerFrame extends TestBase {
 
   @Test
   void shouldWorkForCrossProcessIframes() {
-    page.navigate(getServer().EMPTY_PAGE);
-    attachFrame(page, "frame1", getServer().CROSS_PROCESS_PREFIX + "/empty.html");
+    page.navigate(server.EMPTY_PAGE);
+    attachFrame(page, "frame1", server.CROSS_PROCESS_PREFIX + "/empty.html");
     Frame frame = page.frames().get(1);
     JSHandle jsHandle = frame.evaluateHandle("() => document.body");
     ElementHandle elementHandle = jsHandle.asElement();
@@ -49,8 +49,8 @@ public class TestElementHandleOwnerFrame extends TestBase {
   @Test
   void shouldWorkForDocument() {
     // TODO: test.flaky(platform === "win32" && browserName === "webkit");
-    page.navigate(getServer().EMPTY_PAGE);
-    attachFrame(page, "frame1", getServer().EMPTY_PAGE);
+    page.navigate(server.EMPTY_PAGE);
+    attachFrame(page, "frame1", server.EMPTY_PAGE);
     Frame frame = page.frames().get(1);
     JSHandle jsHandle = frame.evaluateHandle("document");
     ElementHandle elementHandle = jsHandle.asElement();
@@ -60,8 +60,8 @@ public class TestElementHandleOwnerFrame extends TestBase {
 
   @Test
   void shouldWorkForIframeElements() {
-    page.navigate(getServer().EMPTY_PAGE);
-    attachFrame(page, "frame1", getServer().EMPTY_PAGE);
+    page.navigate(server.EMPTY_PAGE);
+    attachFrame(page, "frame1", server.EMPTY_PAGE);
     Frame frame = page.mainFrame();
     JSHandle jsHandle = frame.evaluateHandle("() => document.querySelector('#frame1')");
     ElementHandle elementHandle = jsHandle.asElement();
@@ -71,8 +71,8 @@ public class TestElementHandleOwnerFrame extends TestBase {
 
   @Test
   void shouldWorkForCrossFrameEvaluations() {
-    page.navigate(getServer().EMPTY_PAGE);
-    attachFrame(page, "frame1", getServer().EMPTY_PAGE);
+    page.navigate(server.EMPTY_PAGE);
+    attachFrame(page, "frame1", server.EMPTY_PAGE);
     Frame frame = page.mainFrame();
     JSHandle elementHandle = frame.evaluateHandle(  "() => document.querySelector('iframe').contentWindow.document.body");
     assertEquals(frame.childFrames().get(0), elementHandle.asElement().ownerFrame());
@@ -80,7 +80,7 @@ public class TestElementHandleOwnerFrame extends TestBase {
 
   @Test
   void shouldWorkForDetachedElements() {
-    page.navigate(getServer().EMPTY_PAGE);
+    page.navigate(server.EMPTY_PAGE);
     JSHandle divHandle = page.evaluateHandle("() => {\n" +
       "  const div = document.createElement('div');\n" +
       "  document.body.appendChild(div);\n" +
@@ -96,9 +96,8 @@ public class TestElementHandleOwnerFrame extends TestBase {
 
   @Test
   void shouldWorkForAdoptedElements() {
-    page.navigate(getServer().EMPTY_PAGE);
-    Page popup = page.waitForPopup(() ->
-      page.evaluate("url => window['__popup'] = window.open(url)", getServer().EMPTY_PAGE));
+    page.navigate(server.EMPTY_PAGE);
+    Page popup = page.waitForPopup(() -> page.evaluate("url => window['__popup'] = window.open(url)", server.EMPTY_PAGE));
     JSHandle divHandle = page.evaluateHandle("() => {\n" +
      "  const div = document.createElement('div');\n" +
      "  document.body.appendChild(div);\n" +

--- a/playwright/src/test/java/com/microsoft/playwright/TestElementHandleQuerySelector.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestElementHandleQuerySelector.java
@@ -12,7 +12,7 @@ import static org.junit.jupiter.api.Assertions.*;
 public class TestElementHandleQuerySelector extends TestBase {
   @Test
   void shouldQueryExistingElement() {
-    page.navigate(getServer().PREFIX + "/playground.html");
+    page.navigate(server.PREFIX + "/playground.html");
     page.setContent("<html><body><div class=\"second\"><div class=\"inner\">A</div></div></body></html>");
     ElementHandle html = page.querySelector("html");
     ElementHandle second = html.querySelector(".second");
@@ -31,9 +31,9 @@ public class TestElementHandleQuerySelector extends TestBase {
 
   @Test
   void shouldWorkForAdoptedElements() {
-    page.navigate(getServer().EMPTY_PAGE);
+    page.navigate(server.EMPTY_PAGE);
     Page popup = page.waitForPopup(() -> page.evaluate(
-      "url => window['__popup'] = window.open(url)", getServer().EMPTY_PAGE));
+      "url => window['__popup'] = window.open(url)", server.EMPTY_PAGE));
     // Test JSHandle
     JSHandle divHandle = page.evaluateHandle("() => {\n" +
       "    const div = document.createElement('div');\n" +
@@ -78,7 +78,7 @@ public class TestElementHandleQuerySelector extends TestBase {
 
   @Test
   void xpathShouldQueryExistingElement() {
-    page.navigate(getServer().PREFIX + "/playground.html");
+    page.navigate(server.PREFIX + "/playground.html");
     page.setContent("<html><body><div class=\"second\"><div class=\"inner\">A</div></div></body></html>");
     ElementHandle html = page.querySelector("html");
     List<ElementHandle> second = html.querySelectorAll("xpath=./body/div[contains(@class, 'second')]");

--- a/playwright/src/test/java/com/microsoft/playwright/TestElementHandleSelectText.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestElementHandleSelectText.java
@@ -8,7 +8,7 @@ public class TestElementHandleSelectText extends TestBase {
 
   @Test
   void shouldSelectTextarea() {
-    page.navigate(getServer().PREFIX + "/input/textarea.html");
+    page.navigate(server.PREFIX + "/input/textarea.html");
     ElementHandle textarea = page.querySelector("textarea");
     textarea.evaluate("textarea => textarea.value = 'some value'");
     textarea.selectText();
@@ -22,7 +22,7 @@ public class TestElementHandleSelectText extends TestBase {
 
   @Test
   void shouldSelectInput() {
-    page.navigate(getServer().PREFIX + "/input/textarea.html");
+    page.navigate(server.PREFIX + "/input/textarea.html");
     ElementHandle input = page.querySelector("input");
     input.evaluate("input => input.value = 'some value'");
     input.selectText();
@@ -36,7 +36,7 @@ public class TestElementHandleSelectText extends TestBase {
 
   @Test
   void shouldSelectPlainDiv() {
-    page.navigate(getServer().PREFIX + "/input/textarea.html");
+    page.navigate(server.PREFIX + "/input/textarea.html");
     ElementHandle div = page.querySelector("div.plain");
     div.selectText();
     assertEquals("Plain div", page.evaluate("() => window.getSelection().toString()"));
@@ -44,7 +44,7 @@ public class TestElementHandleSelectText extends TestBase {
 
   @Test
   void shouldTimeoutWaitingForInvisibleElement() {
-    page.navigate(getServer().PREFIX + "/input/textarea.html");
+    page.navigate(server.PREFIX + "/input/textarea.html");
     ElementHandle textarea = page.querySelector("textarea");
     textarea.evaluate("e => e.style.display = 'none'");
     try {

--- a/playwright/src/test/java/com/microsoft/playwright/TestElementHandleWaitForElementState.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestElementHandleWaitForElementState.java
@@ -134,7 +134,7 @@ public class TestElementHandleWaitForElementState extends TestBase {
   @Test
   @DisabledIf(value="isFirefoxLinux", disabledReason="fixme")
   void shouldWaitForStablePosition() {
-    page.navigate(getServer().PREFIX + "/input/button.html");
+    page.navigate(server.PREFIX + "/input/button.html");
     ElementHandle button = page.querySelector("button");
     page.evalOnSelector("button", "button => {\n" +
       "  button.style.transition = 'margin 10000ms linear 0s';\n" +

--- a/playwright/src/test/java/com/microsoft/playwright/TestEvalOnSelector.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestEvalOnSelector.java
@@ -143,7 +143,7 @@ public class TestEvalOnSelector extends TestBase {
 
   @Test
   void shouldSupportSpacesWithSyntax() {
-    page.navigate(getServer().PREFIX + "/deep-shadow.html");
+    page.navigate(server.PREFIX + "/deep-shadow.html");
     Object text = page.evalOnSelector(" css = div >>css=div>>css   = span  ", "e => e.textContent");
     assertEquals("Hello from root2", text);
   }

--- a/playwright/src/test/java/com/microsoft/playwright/TestFirefoxLauncher.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestFirefoxLauncher.java
@@ -26,9 +26,10 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 public class TestFirefoxLauncher extends TestBase {
 
+  @Override
   @BeforeAll
   // Hide base class method to not launch browser.
-  static void launchBrowser() {
+  void launchBrowser() {
   }
 
   @Override
@@ -45,7 +46,7 @@ public class TestFirefoxLauncher extends TestBase {
         "network.proxy.http", "127.0.0.1",
         "network.proxy.http_port", 3333));
     launchBrowser(options);
-    Page page = getBrowser().newPage();
+    Page page = browser.newPage();
     try {
       page.navigate("http://example.com");
       fail("did not throw");

--- a/playwright/src/test/java/com/microsoft/playwright/TestFrameNavigate.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestFrameNavigate.java
@@ -26,11 +26,11 @@ public class TestFrameNavigate extends TestBase {
 
   @Test
   void shouldNavigateSubframes() {
-    page.navigate(getServer().PREFIX + "/frames/one-frame.html");
+    page.navigate(server.PREFIX + "/frames/one-frame.html");
     assertTrue(page.frames().get(0).url().contains("/frames/one-frame.html"));
     assertTrue(page.frames().get(1).url().contains("/frames/frame.html"));
 
-    Response response = page.frames().get(1).navigate(getServer().EMPTY_PAGE);
+    Response response = page.frames().get(1).navigate(server.EMPTY_PAGE);
     assertTrue(response.ok());
     assertEquals(page.frames().get(1), response.frame());
   }
@@ -41,8 +41,8 @@ public class TestFrameNavigate extends TestBase {
 
   @Test
   void shouldContinueAfterClientRedirect() {
-    getServer().setRoute("/frames/script.js", (httpExchange) -> {});
-    String url = getServer().PREFIX + "/frames/child-redirect.html";
+    server.setRoute("/frames/script.js", (httpExchange) -> {});
+    String url = server.PREFIX + "/frames/child-redirect.html";
     try {
       page.navigate(url, new Page.NavigateOptions().setTimeout(5000).setWaitUntil(NETWORKIDLE));
     } catch (TimeoutError e) {

--- a/playwright/src/test/java/com/microsoft/playwright/TestGeolocation.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestGeolocation.java
@@ -31,7 +31,7 @@ public class TestGeolocation extends TestBase {
   @Test
   void shouldWork() {
     context.grantPermissions(asList("geolocation"));
-    page.navigate(getServer().EMPTY_PAGE);
+    page.navigate(server.EMPTY_PAGE);
     context.setGeolocation(new Geolocation(10, 10));
     Object geolocation = page.evaluate("() => new Promise(resolve => navigator.geolocation.getCurrentPosition(position => {\n" +
       "  resolve({latitude: position.coords.latitude, longitude: position.coords.longitude});\n" +
@@ -52,13 +52,13 @@ public class TestGeolocation extends TestBase {
   void shouldIsolateContexts() {
     context.grantPermissions(asList("geolocation"));
     context.setGeolocation(new Geolocation(10, 10));
-    page.navigate(getServer().EMPTY_PAGE);
+    page.navigate(server.EMPTY_PAGE);
 
-    BrowserContext context2 = getBrowser().newContext(new Browser.NewContextOptions()
+    BrowserContext context2 = browser.newContext(new Browser.NewContextOptions()
       .setPermissions(asList("geolocation"))
       .setGeolocation(new Geolocation(20, 20)));
     Page page2 = context2.newPage();
-    page2.navigate(getServer().EMPTY_PAGE);
+    page2.navigate(server.EMPTY_PAGE);
 
     Object geolocation = page.evaluate("() => new Promise(resolve => navigator.geolocation.getCurrentPosition(position => {\n" +
       "  resolve({latitude: position.coords.latitude, longitude: position.coords.longitude});\n" +
@@ -80,7 +80,7 @@ public class TestGeolocation extends TestBase {
   void shouldNotModifyPassedDefaultOptionsObject() {
     Geolocation geolocation = new Geolocation(10, 10);
     Browser.NewContextOptions options = new Browser.NewContextOptions().setGeolocation(geolocation);
-    BrowserContext context = getBrowser().newContext(options);
+    BrowserContext context = browser.newContext(options);
     context.setGeolocation(new Geolocation(20, 20));
     assertEquals(geolocation, options.geolocation);
     context.close();
@@ -95,9 +95,9 @@ public class TestGeolocation extends TestBase {
     Browser.NewContextOptions options = new Browser.NewContextOptions()
       .setGeolocation(new Geolocation(10, 10))
       .setPermissions(asList("geolocation"));
-    BrowserContext context = getBrowser().newContext(options);
+    BrowserContext context = browser.newContext(options);
     Page page = context.newPage();
-    page.navigate(getServer().EMPTY_PAGE);
+    page.navigate(server.EMPTY_PAGE);
     Object geolocation = page.evaluate("() => new Promise(resolve => navigator.geolocation.getCurrentPosition(position => {\n" +
       "  resolve({latitude: position.coords.latitude, longitude: position.coords.longitude});\n" +
       "}))");
@@ -108,7 +108,7 @@ public class TestGeolocation extends TestBase {
   @Test
   void watchPositionShouldBeNotified() {
     context.grantPermissions(asList("geolocation"));
-    page.navigate(getServer().EMPTY_PAGE);
+    page.navigate(server.EMPTY_PAGE);
     List<String> messages = new ArrayList<>();
     page.onConsoleMessage(message -> messages.add(message.text()));
     context.setGeolocation(new Geolocation(0, 0));
@@ -150,7 +150,7 @@ public class TestGeolocation extends TestBase {
     context.grantPermissions(asList("geolocation"));
     context.setGeolocation(new Geolocation(10, 10));
     Page popup = page.waitForPopup(() -> page.evaluate(
-      "url => window['_popup'] = window.open(url)", getServer().PREFIX + "/geolocation.html"));
+      "url => window['_popup'] = window.open(url)", server.PREFIX + "/geolocation.html"));
     popup.waitForLoadState();
     Object geolocation = popup.evaluate("window['geolocationPromise']");
     assertEquals(mapOf("longitude", 10, "latitude", 10), geolocation);

--- a/playwright/src/test/java/com/microsoft/playwright/TestHar.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestHar.java
@@ -42,7 +42,7 @@ public class TestHar extends TestBase {
 
     PageWithHar() throws IOException {
       harFile = Files.createTempFile("test-", ".har");
-      context = getBrowser().newContext(new Browser.NewContextOptions()
+      context = browser.newContext(new Browser.NewContextOptions()
         .setRecordHarPath(harFile).setIgnoreHTTPSErrors(true));
       page = context.newPage();
     }
@@ -76,7 +76,7 @@ public class TestHar extends TestBase {
 
   @Test
   void shouldHaveVersionAndCreator() throws IOException {
-    pageWithHar.page.navigate(getServer().EMPTY_PAGE);
+    pageWithHar.page.navigate(server.EMPTY_PAGE);
     JsonObject log = pageWithHar.log();
     assertEquals("1.2", log.get("version").getAsString());
     assertEquals("Playwright", log.getAsJsonObject("creator").get("name").getAsString());
@@ -84,10 +84,10 @@ public class TestHar extends TestBase {
 
   @Test
   void shouldHaveBrowser() throws IOException {
-    pageWithHar.page.navigate(getServer().EMPTY_PAGE);
+    pageWithHar.page.navigate(server.EMPTY_PAGE);
     JsonObject log = pageWithHar.log();
-    assertEquals(getBrowserType().name(), log.getAsJsonObject("browser").get("name").getAsString().toLowerCase());
-    assertEquals(getBrowser().version(), log.getAsJsonObject("browser").get("version").getAsString());
+    assertEquals(browserType.name(), log.getAsJsonObject("browser").get("name").getAsString().toLowerCase());
+    assertEquals(browser.version(), log.getAsJsonObject("browser").get("version").getAsString());
   }
 
   @Test
@@ -110,7 +110,7 @@ public class TestHar extends TestBase {
   void shouldHavePagesInPersistentContext() throws IOException {
     Path harPath = pageWithHar.harFile;
     Path userDataDir = Files.createTempDirectory("user-data-dir-");
-    BrowserContext context = getBrowserType().launchPersistentContext(userDataDir,
+    BrowserContext context = browserType.launchPersistentContext(userDataDir,
       new BrowserType.LaunchPersistentContextOptions()
         .setRecordHarPath(harPath).setIgnoreHTTPSErrors(true));
     Page page = context.pages().get(0);
@@ -131,12 +131,12 @@ public class TestHar extends TestBase {
 
   @Test
   void shouldIncludeRequest() throws IOException {
-    pageWithHar.page.navigate(getServer().EMPTY_PAGE);
+    pageWithHar.page.navigate(server.EMPTY_PAGE);
     JsonObject log = pageWithHar.log();
     assertEquals(1, log.getAsJsonArray("entries").size());
     JsonObject entry = log.getAsJsonArray("entries").get(0).getAsJsonObject();
     assertEquals("page_0", entry.get("pageref").getAsString());
-    assertEquals(getServer().EMPTY_PAGE, entry.getAsJsonObject("request").get("url").getAsString());
+    assertEquals(server.EMPTY_PAGE, entry.getAsJsonObject("request").get("url").getAsString());
     assertEquals("GET", entry.getAsJsonObject("request").get("method").getAsString());
     assertEquals("HTTP/1.1", entry.getAsJsonObject("request").get("httpVersion").getAsString());
     assertTrue(entry.getAsJsonObject("request").get("headers").getAsJsonArray().size() > 1);
@@ -152,7 +152,7 @@ public class TestHar extends TestBase {
 
   @Test
   void shouldIncludeResponse() throws IOException {
-    pageWithHar.page.navigate(getServer().EMPTY_PAGE);
+    pageWithHar.page.navigate(server.EMPTY_PAGE);
     JsonObject log = pageWithHar.log();
     JsonObject entry = log.getAsJsonArray("entries").get(0).getAsJsonObject();
     assertEquals(200, entry.getAsJsonObject("response").get("status").getAsInt());

--- a/playwright/src/test/java/com/microsoft/playwright/TestLaunch.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestLaunch.java
@@ -23,9 +23,10 @@ import static com.microsoft.playwright.Utils.mapOf;
 
 public class TestLaunch extends TestBase {
 
+  @Override
   @BeforeAll
   // Hide base class method to not launch browser.
-  static void launchBrowser() {
+  void launchBrowser() {
   }
 
   @Override

--- a/playwright/src/test/java/com/microsoft/playwright/TestNetworkPostData.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestNetworkPostData.java
@@ -29,7 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class TestNetworkPostData extends TestBase {
   @Test
   void shouldReturnCorrectPostDataBufferForUtf8Body() {
-    page.navigate(getServer().EMPTY_PAGE);
+    page.navigate(server.EMPTY_PAGE);
     String value = "baẞ";
     Request request = page.waitForRequest("**", () -> {
       page.evaluate("({url, value}) => {\n" +
@@ -39,7 +39,7 @@ public class TestNetworkPostData extends TestBase {
         "  });\n" +
         "  request.headers.set('content-type', 'application/json;charset=UTF-8');\n" +
         "  return fetch(request);\n" +
-        "}", mapOf("url", getServer().PREFIX + "/title.html", "value", value));
+        "}", mapOf("url", server.PREFIX + "/title.html", "value", value));
     });
     assertTrue(Arrays.equals(new Gson().toJson(value).getBytes(StandardCharsets.UTF_8), request.postDataBuffer()));
     assertEquals(new Gson().toJson(value), request.postData());
@@ -47,7 +47,7 @@ public class TestNetworkPostData extends TestBase {
 
   @Test
   void shouldReturnPostDataWOContentType() {
-    page.navigate(getServer().EMPTY_PAGE);
+    page.navigate(server.EMPTY_PAGE);
     Request request = page.waitForRequest("**", () -> {
       page.evaluate("({url}) => {\n" +
         "  const request = new Request(url, {\n" +
@@ -56,7 +56,7 @@ public class TestNetworkPostData extends TestBase {
         "  });\n" +
         "  request.headers.set('content-type', '');\n" +
         "  return fetch(request);\n" +
-        "}", mapOf("url", getServer().PREFIX + "/title.html"));
+        "}", mapOf("url", server.PREFIX + "/title.html"));
     });
     assertEquals(new Gson().toJson(mapOf("value", 42)), request.postData());
   }
@@ -67,7 +67,7 @@ public class TestNetworkPostData extends TestBase {
 
   @Test
   void shouldReturnPostDataForPUTRequests() {
-    page.navigate(getServer().EMPTY_PAGE);
+    page.navigate(server.EMPTY_PAGE);
     Request request = page.waitForRequest("**", () -> {
       page.evaluate("({url}) => {\n" +
         "  const request = new Request(url, {\n" +
@@ -75,7 +75,7 @@ public class TestNetworkPostData extends TestBase {
         "    body: JSON.stringify({ value: 42 }),\n" +
         "  });\n" +
         "  return fetch(request);\n" +
-        "}", mapOf("url", getServer().PREFIX + "/title.html"));
+        "}", mapOf("url", server.PREFIX + "/title.html"));
     });
     assertEquals(new Gson().toJson(mapOf("value", 42)), request.postData());
   }

--- a/playwright/src/test/java/com/microsoft/playwright/TestNetworkRequest.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestNetworkRequest.java
@@ -37,24 +37,24 @@ public class TestNetworkRequest extends TestBase {
   void shouldWorkForMainFrameNavigationRequest() {
     List<Request> requests = new ArrayList<>();
     page.onRequest(request -> requests.add(request));
-    page.navigate(getServer().EMPTY_PAGE);
+    page.navigate(server.EMPTY_PAGE);
     assertEquals(1, requests.size());
     assertEquals(page.mainFrame(), requests.get(0).frame());
   }
 
   @Test
   void shouldWorkForSubframeNavigationRequest() {
-    page.navigate(getServer().EMPTY_PAGE);
+    page.navigate(server.EMPTY_PAGE);
     List<Request> requests = new ArrayList<>();
     page.onRequest(request -> requests.add(request));
-    attachFrame(page, "frame1", getServer().EMPTY_PAGE);
+    attachFrame(page, "frame1", server.EMPTY_PAGE);
     assertEquals(1, requests.size());
     assertEquals(page.frames().get(1), requests.get(0).frame());
   }
 
   @Test
   void shouldWorkForFetchRequests() {
-    page.navigate(getServer().EMPTY_PAGE);
+    page.navigate(server.EMPTY_PAGE);
     List<Request> requests = new ArrayList<>();
     page.onRequest(request -> requests.add(request));
     page.evaluate("() => fetch('/digits/1.png')");
@@ -64,36 +64,36 @@ public class TestNetworkRequest extends TestBase {
 
   @Test
   void shouldWorkForARedirect() {
-    getServer().setRedirect("/foo.html", "/empty.html");
+    server.setRedirect("/foo.html", "/empty.html");
     List<Request> requests = new ArrayList<>();
     page.onRequest(request -> requests.add(request));
-    page.navigate(getServer().PREFIX + "/foo.html");
+    page.navigate(server.PREFIX + "/foo.html");
 
     assertEquals(2, requests.size());
-    assertEquals(getServer().PREFIX + "/foo.html", requests.get(0).url());
-    assertEquals(getServer().PREFIX + "/empty.html", requests.get(1).url());
+    assertEquals(server.PREFIX + "/foo.html", requests.get(0).url());
+    assertEquals(server.PREFIX + "/empty.html", requests.get(1).url());
   }
 
   // https://github.com/microsoft/playwright/issues/3993
   @Test
   void shouldNotWorkForARedirectAndInterception() {
-    getServer().setRedirect("/foo.html", "/empty.html");
+    server.setRedirect("/foo.html", "/empty.html");
     List<Request> requests = new ArrayList<>();
     page.route("**", route -> {
       requests.add(route.request());
       route.resume();
     });
-    page.navigate(getServer().PREFIX + "/foo.html");
+    page.navigate(server.PREFIX + "/foo.html");
 
-    assertEquals(getServer().PREFIX + "/empty.html", page.url());
+    assertEquals(server.PREFIX + "/empty.html", page.url());
 
     assertEquals(1, requests.size());
-    assertEquals(getServer().PREFIX + "/foo.html", requests.get(0).url());
+    assertEquals(server.PREFIX + "/foo.html", requests.get(0).url());
   }
 
   @Test
   void shouldReturnHeaders() {
-    Response response = page.navigate(getServer().EMPTY_PAGE);
+    Response response = page.navigate(server.EMPTY_PAGE);
     if (isChromium())
       assertTrue(response.request().headers().get("user-agent").contains("Chrome"));
     else if (isFirefox())
@@ -105,14 +105,14 @@ public class TestNetworkRequest extends TestBase {
   @Test
   @DisabledIf(value="com.microsoft.playwright.TestBase#isWebKit", disabledReason="fail")
   void shouldGetTheSameHeadersAsTheServer() throws ExecutionException, InterruptedException {
-    Future<Server.Request> serverRequest = getServer().futureRequest("/empty.html");
-    getServer().setRoute("/empty.html", exchange -> {
+    Future<Server.Request> serverRequest = server.futureRequest("/empty.html");
+    server.setRoute("/empty.html", exchange -> {
       exchange.sendResponseHeaders(200, 0);
       try (OutputStreamWriter writer = new OutputStreamWriter(exchange.getResponseBody())) {
         writer.write("done");
       }
     });
-    Response response = page.navigate(getServer().PREFIX + "/empty.html");
+    Response response = page.navigate(server.PREFIX + "/empty.html");
     Map<String, String> expectedHeaders = serverRequest.get().headers.entrySet().stream().collect(
       Collectors.toMap(e -> e.getKey().toLowerCase(), e -> e.getValue().get(0)));
     assertEquals(expectedHeaders, response.request().headers());
@@ -121,9 +121,9 @@ public class TestNetworkRequest extends TestBase {
   @Test
   @DisabledIf(value="com.microsoft.playwright.TestBase#isWebKit", disabledReason="fail")
   void shouldGetTheSameHeadersAsTheServerCORP() throws ExecutionException, InterruptedException {
-    page.navigate(getServer().PREFIX + "/empty.html");
-    Future<Server.Request> serverRequest = getServer().futureRequest("/something");
-    getServer().setRoute("/something", exchange -> {
+    page.navigate(server.PREFIX + "/empty.html");
+    Future<Server.Request> serverRequest = server.futureRequest("/something");
+    server.setRoute("/something", exchange -> {
       exchange.getResponseHeaders().add("Access-Control-Allow-Origin", "*");
       exchange.sendResponseHeaders(200, 0);
       try (OutputStreamWriter writer = new OutputStreamWriter(exchange.getResponseBody())) {
@@ -131,10 +131,10 @@ public class TestNetworkRequest extends TestBase {
       }
     });
     Response response = page.waitForResponse("**", () -> {
-        Object text = page.evaluate("async url => {\n" +
+      Object text = page.evaluate("async url => {\n" +
           "  const data = await fetch(url);\n" +
           "  return data.text();\n" +
-          "}", getServer().CROSS_PROCESS_PREFIX + "/something");
+          "}", server.CROSS_PROCESS_PREFIX + "/something");
         assertEquals("done", text);
       });
     Map<String, String> expectedHeaders = serverRequest.get().headers.entrySet().stream().collect(
@@ -144,8 +144,8 @@ public class TestNetworkRequest extends TestBase {
 
   @Test
   void shouldReturnPostData() {
-    page.navigate(getServer().EMPTY_PAGE);
-    getServer().setRoute("/post", exchange -> {
+    page.navigate(server.EMPTY_PAGE);
+    server.setRoute("/post", exchange -> {
       exchange.sendResponseHeaders(200, 0);
       exchange.getResponseBody().close();
     });
@@ -158,8 +158,8 @@ public class TestNetworkRequest extends TestBase {
 
   @Test
   void shouldWorkWithBinaryPostData() {
-    page.navigate(getServer().EMPTY_PAGE);
-    getServer().setRoute("/post", exchange -> {
+    page.navigate(server.EMPTY_PAGE);
+    server.setRoute("/post", exchange -> {
       exchange.sendResponseHeaders(200, 0);
       exchange.getResponseBody().close();
     });
@@ -178,8 +178,8 @@ public class TestNetworkRequest extends TestBase {
 
   @Test
   void shouldWorkWithBinaryPostDataAndInterception() {
-    page.navigate(getServer().EMPTY_PAGE);
-    getServer().setRoute("/post", exchange -> {
+    page.navigate(server.EMPTY_PAGE);
+    server.setRoute("/post", exchange -> {
       exchange.sendResponseHeaders(200, 0);
       exchange.getResponseBody().close();
     });
@@ -199,7 +199,7 @@ public class TestNetworkRequest extends TestBase {
 
   @Test
   void shouldBeUndefinedWhenThereIsNoPostData() {
-    Response response = page.navigate(getServer().EMPTY_PAGE);
+    Response response = page.navigate(server.EMPTY_PAGE);
     assertNull(response.request().postData());
   }
 
@@ -214,7 +214,7 @@ public class TestNetworkRequest extends TestBase {
   @Test
   void shouldReturnEventSource() {
     // 1. Setup server-sent events on server that immediately sends a message to the client.
-    getServer().setRoute("/sse", exchange -> {
+    server.setRoute("/sse", exchange -> {
       exchange.getResponseHeaders().add("Content-Type", "text/event-stream");
       exchange.getResponseHeaders().add("Connection", "keep-alive");
       exchange.getResponseHeaders().add("Cache-Control", "no-cache");
@@ -224,7 +224,7 @@ public class TestNetworkRequest extends TestBase {
       }
     });
     // 2. Subscribe to page request events.
-    page.navigate(getServer().EMPTY_PAGE);
+    page.navigate(server.EMPTY_PAGE);
     List<Request> requests = new ArrayList<>();
     page.onRequest(request -> requests.add(request));
     // 3. Connect to EventSource in browser and return first message.
@@ -249,8 +249,8 @@ public class TestNetworkRequest extends TestBase {
       }
       requests.put(name, request);
     });
-    getServer().setRedirect("/rrredirect", "/frames/one-frame.html");
-    page.navigate(getServer().PREFIX + "/rrredirect");
+    server.setRedirect("/rrredirect", "/frames/one-frame.html");
+    page.navigate(server.PREFIX + "/rrredirect");
     assertTrue(requests.get("rrredirect").isNavigationRequest());
     assertTrue(requests.get("one-frame.html").isNavigationRequest());
     assertTrue(requests.get("frame.html").isNavigationRequest());
@@ -262,7 +262,7 @@ public class TestNetworkRequest extends TestBase {
   void shouldReturnNavigationBitWhenNavigatingToImage() {
     List<Request> requests = new ArrayList<>();
     page.onRequest(request -> requests.add(request));
-    page.navigate(getServer().PREFIX + "/pptr.png");
+    page.navigate(server.PREFIX + "/pptr.png");
     assertTrue(requests.get(0).isNavigationRequest());
   }
 }

--- a/playwright/src/test/java/com/microsoft/playwright/TestNetworkResponse.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestNetworkResponse.java
@@ -31,13 +31,13 @@ import static org.junit.jupiter.api.Assertions.*;
 public class TestNetworkResponse extends TestBase {
   @Test
   void shouldWork() {
-    getServer().setRoute("/empty.html", exchange -> {
+    server.setRoute("/empty.html", exchange -> {
       exchange.getResponseHeaders().add("foo", "bar");
       exchange.getResponseHeaders().add("BaZ", "bAz");
       exchange.sendResponseHeaders(200, 0);
       exchange.getResponseBody().close();
     });
-    Response response = page.navigate(getServer().EMPTY_PAGE);
+    Response response = page.navigate(server.EMPTY_PAGE);
     assertEquals("bar", response.headers().get("foo"));
     assertEquals("bAz", response.headers().get("baz"));
     assertNull(response.headers().get("BaZ"));
@@ -45,22 +45,22 @@ public class TestNetworkResponse extends TestBase {
 
   @Test
   void shouldReturnText() {
-    Response response = page.navigate(getServer().PREFIX + "/simple.json");
+    Response response = page.navigate(server.PREFIX + "/simple.json");
     assertEquals("{\"foo\": \"bar\"}\n", response.text());
   }
 
   @Test
   void shouldReturnUncompressedText() {
-    getServer().enableGzip("/simple.json");
-    Response response = page.navigate(getServer().PREFIX + "/simple.json");
+    server.enableGzip("/simple.json");
+    Response response = page.navigate(server.PREFIX + "/simple.json");
     assertEquals("gzip", response.headers().get("content-encoding"));
     assertEquals("{\"foo\": \"bar\"}\n", response.text());
   }
 
   @Test
   void shouldThrowWhenRequestingBodyOfRedirectedResponse() {
-    getServer().setRedirect("/foo.html", "/empty.html");
-    Response response = page.navigate(getServer().PREFIX + "/foo.html");
+    server.setRedirect("/foo.html", "/empty.html");
+    Response response = page.navigate(server.PREFIX + "/foo.html");
     Request redirectedFrom = response.request().redirectedFrom();
     assertNotNull(redirectedFrom);
     Response redirected = redirectedFrom.response();
@@ -75,10 +75,10 @@ public class TestNetworkResponse extends TestBase {
 
   @Test
   void shouldWaitUntilResponseCompletes() throws ExecutionException, InterruptedException {
-    page.navigate(getServer().EMPTY_PAGE);
+    page.navigate(server.EMPTY_PAGE);
     Semaphore responseWritten = new Semaphore(0);
     Semaphore responseRead = new Semaphore(0);
-    getServer().setRoute("/get", exchange -> {
+    server.setRoute("/get", exchange -> {
       // In Firefox, |fetch| will be hanging until it receives |Content-Type| header
       // from server.
       exchange.getResponseHeaders().add("Content-Type", "text/plain; charset=utf-8");
@@ -119,26 +119,26 @@ public class TestNetworkResponse extends TestBase {
   }
   @Test
   void shouldReturnBody() throws IOException {
-    Response response = page.navigate(getServer().PREFIX + "/pptr.png");
+    Response response = page.navigate(server.PREFIX + "/pptr.png");
     byte[] expected = Files.readAllBytes(Paths.get("src/test/resources/pptr.png"));
     assertTrue(Arrays.equals(expected, response.body()));
   }
 
   @Test
   void shouldReturnBodyWithCompression() throws IOException {
-    getServer().enableGzip("/pptr.png");
-    Response response = page.navigate(getServer().PREFIX + "/pptr.png");
+    server.enableGzip("/pptr.png");
+    Response response = page.navigate(server.PREFIX + "/pptr.png");
     byte[] expected = Files.readAllBytes(Paths.get("src/test/resources/pptr.png"));
     assertTrue(Arrays.equals(expected, response.body()));
   }
 
   @Test
   void shouldReturnStatusText() {
-    getServer().setRoute("/cool", exchange -> {
+    server.setRoute("/cool", exchange -> {
       exchange.sendResponseHeaders(200, 0);
       exchange.getResponseBody().close();
     });
-    Response response = page.navigate(getServer().PREFIX + "/cool");
+    Response response = page.navigate(server.PREFIX + "/cool");
     assertEquals("OK", response.statusText());
   }
 }

--- a/playwright/src/test/java/com/microsoft/playwright/TestPageBasic.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestPageBasic.java
@@ -54,7 +54,7 @@ public class TestPageBasic extends TestBase {
   @Test
   void shouldRunBeforeunloadIfAskedFor() {
     Page newPage = context.newPage();
-    newPage.navigate(getServer().PREFIX + "/beforeunload.html");
+    newPage.navigate(server.PREFIX + "/beforeunload.html");
     // We have to interact with a page so that "beforeunload" handlers
     // fire.
     newPage.click("body");
@@ -87,7 +87,7 @@ public class TestPageBasic extends TestBase {
   @Test
   void shouldNotRunBeforeunloadByDefault() {
     Page newPage = context.newPage();
-    newPage.navigate(getServer().PREFIX + "/beforeunload.html");
+    newPage.navigate(server.PREFIX + "/beforeunload.html");
     // We have to interact with a page so that "beforeunload" handlers
     // fire.
     newPage.click("body");
@@ -111,7 +111,7 @@ public class TestPageBasic extends TestBase {
     try {
       newPage.waitForResponse("**", () -> {
         try {
-          newPage.waitForRequest(getServer().EMPTY_PAGE, () -> newPage.close());
+          newPage.waitForRequest(server.EMPTY_PAGE, () -> newPage.close());
           fail("waitForRequest() should throw");
         } catch (PlaywrightException e) {
           assertTrue(e.getMessage().contains("Page closed"));
@@ -171,23 +171,23 @@ public class TestPageBasic extends TestBase {
   @Test
   void pageUrlShouldWork() {
     assertEquals("about:blank", page.url());
-    page.navigate(getServer().EMPTY_PAGE);
-    assertEquals(getServer().EMPTY_PAGE, page.url());
+    page.navigate(server.EMPTY_PAGE);
+    assertEquals(server.EMPTY_PAGE, page.url());
   }
 
   @Test
   void pageUrlShouldIncludeHashes() {
-    page.navigate(getServer().EMPTY_PAGE + "#hash");
-    assertEquals(getServer().EMPTY_PAGE + "#hash", page.url());
+    page.navigate(server.EMPTY_PAGE + "#hash");
+    assertEquals(server.EMPTY_PAGE + "#hash", page.url());
     page.evaluate("() => {\n" +
       "    window.location.hash = 'dynamic';\n" +
       "}");
-    assertEquals(getServer().EMPTY_PAGE + "#dynamic", page.url());
+    assertEquals(server.EMPTY_PAGE + "#dynamic", page.url());
   }
 
   @Test
   void pageTitleShouldReturnThePageTitle() {
-    page.navigate(getServer().PREFIX + "/title.html");
+    page.navigate(server.PREFIX + "/title.html");
     assertEquals("Woof-Woof", page.title());
   }
 
@@ -220,11 +220,11 @@ public class TestPageBasic extends TestBase {
 
   @Test
   void pageFrameShouldRespectUrl() {
-    page.setContent("<iframe src='" + getServer().EMPTY_PAGE + "'></iframe>");
+    page.setContent("<iframe src='" + server.EMPTY_PAGE + "'></iframe>");
     assertNull(page.frameByUrl(Pattern.compile("bogus")));
     Frame frame = page.frameByUrl(Pattern.compile(".*empty.*"));
     assertNotNull(frame);
-    assertEquals(getServer().EMPTY_PAGE, frame.url());
+    assertEquals(server.EMPTY_PAGE, frame.url());
   }
 
   @Test
@@ -257,7 +257,7 @@ public class TestPageBasic extends TestBase {
 
   @Test
   void pagePressShouldWork() {
-    page.navigate(getServer().PREFIX + "/input/textarea.html");
+    page.navigate(server.PREFIX + "/input/textarea.html");
     page.press("textarea", "a");
     assertEquals("a", page.evaluate("() => document.querySelector('textarea').value"));
   }
@@ -273,7 +273,7 @@ public class TestPageBasic extends TestBase {
 
   @Test
   void framePressShouldWork() {
-    page.setContent("<iframe name=inner src='" + getServer().PREFIX + "/input/textarea.html'></iframe>");
+    page.setContent("<iframe name=inner src='" + server.PREFIX + "/input/textarea.html'></iframe>");
     Frame frame = page.frame("inner");
     frame.press("textarea", "a");
     assertEquals("a", frame.evaluate("() => document.querySelector('textarea').value"));

--- a/playwright/src/test/java/com/microsoft/playwright/TestPageEmulateMedia.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestPageEmulateMedia.java
@@ -82,20 +82,18 @@ public class TestPageEmulateMedia extends TestBase {
   @Test
   void shouldWorkInPopup() {
     {
-      BrowserContext context = getBrowser().newContext(new Browser.NewContextOptions().setColorScheme(DARK));
+      BrowserContext context = browser.newContext(new Browser.NewContextOptions().setColorScheme(DARK));
       Page page = context.newPage();
-      page.navigate(getServer().EMPTY_PAGE);
-      Page popup = page.waitForPopup(() ->
-        page.evaluate("url => { window.open(url); }", getServer().EMPTY_PAGE));
+      page.navigate(server.EMPTY_PAGE);
+      Page popup = page.waitForPopup(() -> page.evaluate("url => { window.open(url); }", server.EMPTY_PAGE));
       assertEquals(false, popup.evaluate("() => matchMedia('(prefers-color-scheme: light)').matches"));
       assertEquals(true, popup.evaluate("() => matchMedia('(prefers-color-scheme: dark)').matches"));
       context.close();
     }
     {
-      Page page = getBrowser().newPage(new Browser.NewPageOptions().setColorScheme(LIGHT));
-      page.navigate(getServer().EMPTY_PAGE);
-      Page popup = page.waitForPopup(() ->
-        page.evaluate("url => { window.open(url); }", getServer().EMPTY_PAGE));
+      Page page = browser.newPage(new Browser.NewPageOptions().setColorScheme(LIGHT));
+      page.navigate(server.EMPTY_PAGE);
+      Page popup = page.waitForPopup(() -> page.evaluate("url => { window.open(url); }", server.EMPTY_PAGE));
       assertEquals(true, popup.evaluate("() => matchMedia('(prefers-color-scheme: light)').matches"));
       assertEquals(false, popup.evaluate("() => matchMedia('(prefers-color-scheme: dark)').matches"));
       page.close();
@@ -104,9 +102,9 @@ public class TestPageEmulateMedia extends TestBase {
 
   @Test
   void shouldWorkInCrossProcessIframe() {
-    Page page = getBrowser().newPage(new Browser.NewPageOptions().setColorScheme(DARK));
-    page.navigate(getServer().EMPTY_PAGE);
-    attachFrame(page, "frame1", getServer().CROSS_PROCESS_PREFIX + "/empty.html");
+    Page page = browser.newPage(new Browser.NewPageOptions().setColorScheme(DARK));
+    page.navigate(server.EMPTY_PAGE);
+    attachFrame(page, "frame1", server.CROSS_PROCESS_PREFIX + "/empty.html");
     Frame frame = page.frames().get(1);
     assertEquals(true, frame.evaluate("() => matchMedia('(prefers-color-scheme: dark)').matches"));
     page.close();

--- a/playwright/src/test/java/com/microsoft/playwright/TestPageEvaluate.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestPageEvaluate.java
@@ -123,7 +123,7 @@ public class TestPageEvaluate extends TestBase {
 
   @Test
   void shouldEvaluateInThePageContext() {
-    page.navigate(getServer().PREFIX + "/global-var.html");
+    page.navigate(server.PREFIX + "/global-var.html");
     assertEquals(123, page.evaluate("globalVar"));
   }
 
@@ -175,18 +175,18 @@ public class TestPageEvaluate extends TestBase {
     page.onFrameNavigated(frame -> {
       frameEvaluation[0] = frame.evaluate("() => 6 * 7");
     });
-    page.navigate(getServer().EMPTY_PAGE);
+    page.navigate(server.EMPTY_PAGE);
     assertEquals(42, frameEvaluation[0]);
   }
 
   @Test
   void shouldWorkRightAfterACrossOriginNavigation() {
-    page.navigate(getServer().EMPTY_PAGE);
+    page.navigate(server.EMPTY_PAGE);
     Object[] frameEvaluation = {null};
     page.onFrameNavigated(frame -> {
       frameEvaluation[0] = frame.evaluate("() => 6 * 7");
     });
-    page.navigate(getServer().CROSS_PROCESS_PREFIX + "/empty.html");
+    page.navigate(server.CROSS_PROCESS_PREFIX + "/empty.html");
     assertEquals(42, frameEvaluation[0]);
   }
 
@@ -447,7 +447,7 @@ public class TestPageEvaluate extends TestBase {
 
   @Test
   void shouldNotThrowAnErrorWhenEvaluationDoesANavigation() {
-    page.navigate(getServer().PREFIX + "/one-style.html");
+    page.navigate(server.PREFIX + "/one-style.html");
     Object result = page.evaluate("() => {\n" +
       "  window.location.href = '/empty.html';\n" +
       "  return [42];\n" +
@@ -511,7 +511,7 @@ public class TestPageEvaluate extends TestBase {
   @Test
   void shouldAwaitPromiseFromPopup() {
     // Something is wrong about the way Firefox waits for the chained promise
-    page.navigate(getServer().EMPTY_PAGE);
+    page.navigate(server.EMPTY_PAGE);
     Object result = page.evaluate("() => {\n" +
       "  const win = window.open('about:blank');\n" +
       "  return new win['Promise'](f => f(42));\n" +
@@ -521,8 +521,8 @@ public class TestPageEvaluate extends TestBase {
 
   @Test
   void shouldWorkWithNewFunctionAndCSP() {
-    getServer().setCSP("/empty.html", "script-src " + getServer().PREFIX);
-    page.navigate(getServer().PREFIX + "/empty.html");
+    server.setCSP("/empty.html", "script-src " + server.PREFIX);
+    page.navigate(server.PREFIX + "/empty.html");
     assertEquals(true, page.evaluate("() => new Function('return true')()"));
   }
 
@@ -567,8 +567,8 @@ public class TestPageEvaluate extends TestBase {
 
   @Test
   void shouldWorkWithCSP() {
-    getServer().setCSP("/empty.html", "script-src 'self'");
-    page.navigate(getServer().EMPTY_PAGE);
+    server.setCSP("/empty.html", "script-src 'self'");
+    page.navigate(server.EMPTY_PAGE);
     assertEquals(4, page.evaluate("() => 2 + 2"));
   }
 

--- a/playwright/src/test/java/com/microsoft/playwright/TestPageEventNetwork.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestPageEventNetwork.java
@@ -29,23 +29,23 @@ public class TestPageEventNetwork extends TestBase {
   void PageEventsRequest() {
     List<Request> requests = new ArrayList<>();
     page.onRequest(request -> requests.add(request));
-    page.navigate(getServer().EMPTY_PAGE);
+    page.navigate(server.EMPTY_PAGE);
     assertEquals(1, requests.size());
-    assertEquals(getServer().EMPTY_PAGE, requests.get(0).url());
+    assertEquals(server.EMPTY_PAGE, requests.get(0).url());
     assertEquals("document", requests.get(0).resourceType());
     assertEquals("GET", requests.get(0).method());
     assertNotNull(requests.get(0).response());
     assertEquals(page.mainFrame(), requests.get(0).frame());
-    assertEquals(getServer().EMPTY_PAGE, requests.get(0).frame().url());
+    assertEquals(server.EMPTY_PAGE, requests.get(0).frame().url());
   }
 
   @Test
   void PageEventsResponse() {
     List<Response> responses = new ArrayList<>();
     page.onResponse(response -> responses.add(response));
-    page.navigate(getServer().EMPTY_PAGE);
+    page.navigate(server.EMPTY_PAGE);
     assertEquals(1, responses.size());
-    assertEquals(getServer().EMPTY_PAGE, responses.get(0).url());
+    assertEquals(server.EMPTY_PAGE, responses.get(0).url());
     assertEquals(200, responses.get(0).status());
     assertTrue(responses.get(0).ok());
     assertNotNull(responses.get(0).request());
@@ -53,10 +53,10 @@ public class TestPageEventNetwork extends TestBase {
 
   @Test
   void PageEventsRequestFailed() {
-    getServer().setRoute("/one-style.css", exchange -> exchange.getResponseBody().close());
+    server.setRoute("/one-style.css", exchange -> exchange.getResponseBody().close());
     List<Request> failedRequests = new ArrayList<>();
     page.onRequestFailed(request -> failedRequests.add(request));
-    page.navigate(getServer().PREFIX + "/one-style.html");
+    page.navigate(server.PREFIX + "/one-style.html");
     assertEquals(1, failedRequests.size());
     assertTrue(failedRequests.get(0).url().contains("one-style.css"));
     assertNull(failedRequests.get(0).response());
@@ -80,15 +80,15 @@ public class TestPageEventNetwork extends TestBase {
   void PageEventsRequestFinished() {
     Request[] requestRef = {null};
     page.onRequestFinished(r -> requestRef[0] = r);
-    Response response = page.navigate(getServer().EMPTY_PAGE);
+    Response response = page.navigate(server.EMPTY_PAGE);
     assertNull(response.finished());
     assertNotNull(response);
     Request request = requestRef[0];
     assertEquals(response.request(), request);
-    assertEquals(getServer().EMPTY_PAGE, request.url());
+    assertEquals(server.EMPTY_PAGE, request.url());
     assertNotNull(request.response());
     assertEquals(page.mainFrame(), request.frame());
-    assertEquals(getServer().EMPTY_PAGE, request.frame().url());
+    assertEquals(server.EMPTY_PAGE, request.frame().url());
     assertNull(request.failure());
   }
 
@@ -98,7 +98,7 @@ public class TestPageEventNetwork extends TestBase {
     page.onRequest(request -> events.add("request"));
     page.onResponse(response -> events.add("response"));
     page.onRequestFinished(r -> events.add("requestfinished"));
-    Response response = page.navigate(getServer().EMPTY_PAGE);
+    Response response = page.navigate(server.EMPTY_PAGE);
     assertNull(response.finished());
     assertEquals(asList("request", "response", "requestfinished"), events);
   }
@@ -118,17 +118,17 @@ public class TestPageEventNetwork extends TestBase {
     page.onRequestFailed(request -> {
       events.add("FAIL " + request.url());
     });
-    getServer().setRedirect("/foo.html", "/empty.html");
-    String FOO_URL = getServer().PREFIX + "/foo.html";
+    server.setRedirect("/foo.html", "/empty.html");
+    String FOO_URL = server.PREFIX + "/foo.html";
     Response response = page.navigate(FOO_URL);
     response.finished();
     assertEquals(asList(
       "GET " + FOO_URL,
       "302 " + FOO_URL,
       "DONE " + FOO_URL,
-      "GET " + getServer().EMPTY_PAGE,
-      "200 " + getServer().EMPTY_PAGE,
-      "DONE " + getServer().EMPTY_PAGE), events);
+      "GET " + server.EMPTY_PAGE,
+      "200 " + server.EMPTY_PAGE,
+      "DONE " + server.EMPTY_PAGE), events);
     Request redirectedFrom = response.request().redirectedFrom();
     assertTrue(redirectedFrom.url().contains("/foo.html"));
     assertNull(redirectedFrom.redirectedFrom());

--- a/playwright/src/test/java/com/microsoft/playwright/TestPageExposeFunction.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestPageExposeFunction.java
@@ -30,7 +30,7 @@ public class TestPageExposeFunction extends TestBase {
 
   @Test
   void exposeBindingShouldWork() {
-    BrowserContext context = getBrowser().newContext();
+    BrowserContext context = browser.newContext();
     Page page = context.newPage();
     BindingCallback.Source[] bindingSource = { null };
     page.exposeBinding("add", (source, args) -> {
@@ -109,7 +109,7 @@ public class TestPageExposeFunction extends TestBase {
     Object result = page.evaluate("async function() {\n" +
       "  return await window['compute'](9, 4);\n" +
       "}");
-    page.navigate(getServer().EMPTY_PAGE);
+    page.navigate(server.EMPTY_PAGE);
     assertEquals(36, result);
   }
 
@@ -119,7 +119,7 @@ public class TestPageExposeFunction extends TestBase {
   @Test
   void shouldWorkOnFrames() {
     page.exposeFunction("compute", args -> (Integer) args[0] * (Integer) args[1]);
-    page.navigate(getServer().PREFIX + "/frames/nested-frames.html");
+    page.navigate(server.PREFIX + "/frames/nested-frames.html");
     Frame frame = page.frames().get(1);
     Object result = frame.evaluate("async function() {\n" +
       "  return window['compute'](3, 5);\n" +
@@ -129,7 +129,7 @@ public class TestPageExposeFunction extends TestBase {
 
   @Test
   void shouldWorkOnFramesBeforeNavigation() {
-    page.navigate(getServer().PREFIX + "/frames/nested-frames.html");
+    page.navigate(server.PREFIX + "/frames/nested-frames.html");
     page.exposeFunction("compute", args -> (Integer) args[0] * (Integer) args[1]);
 
     Frame frame = page.frames().get(1);
@@ -141,10 +141,10 @@ public class TestPageExposeFunction extends TestBase {
 
   @Test
   void shouldWorkAfterCrossOriginNavigation() {
-    page.navigate(getServer().EMPTY_PAGE);
+    page.navigate(server.EMPTY_PAGE);
     page.exposeFunction("compute", args -> (Integer) args[0] * (Integer) args[1]);
 
-    page.navigate(getServer().CROSS_PROCESS_PREFIX + "/empty.html");
+    page.navigate(server.CROSS_PROCESS_PREFIX + "/empty.html");
     Object result = page.evaluate("window['compute'](9, 4)");
     assertEquals(36, result);
   }
@@ -183,13 +183,13 @@ public class TestPageExposeFunction extends TestBase {
     page.exposeBinding("logme", (source, args) -> {
       return 17;
     }, new Page.ExposeBindingOptions().setHandle(true));
-    page.navigate(getServer().EMPTY_PAGE);
+    page.navigate(server.EMPTY_PAGE);
 
     page.waitForNavigation(new Page.WaitForNavigationOptions().setWaitUntil(LOAD), () -> {
       page.evaluate("async url => {\n" +
         "  window['logme']({ foo: 42 });\n" +
         "  window.location.href = url;\n" +
-        "}", getServer().PREFIX + "/one-style.html");
+        "}", server.PREFIX + "/one-style.html");
     });
   }
 

--- a/playwright/src/test/java/com/microsoft/playwright/TestPageFill.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestPageFill.java
@@ -26,21 +26,21 @@ public class TestPageFill extends TestBase {
 
   @Test
   void shouldFillTextarea() {
-    page.navigate(getServer().PREFIX + "/input/textarea.html");
+    page.navigate(server.PREFIX + "/input/textarea.html");
     page.fill("textarea", "some value");
     assertEquals("some value", page.evaluate("() => window['result']"));
   }
 
   @Test
   void shouldFillInput() {
-    page.navigate(getServer().PREFIX + "/input/textarea.html");
+    page.navigate(server.PREFIX + "/input/textarea.html");
     page.fill("input", "some value");
     assertEquals("some value", page.evaluate("() => window['result']"));
   }
 
   @Test
   void shouldThrowOnUnsupportedInputs() {
-    page.navigate(getServer().PREFIX + "/input/textarea.html");
+    page.navigate(server.PREFIX + "/input/textarea.html");
     for (String type : new String[]{"button", "checkbox", "file", "image", "radio", "range", "reset", "submit"}) {
       page.evalOnSelector("input", "(input, type) => input.setAttribute('type', type)", type);
       try {
@@ -54,7 +54,7 @@ public class TestPageFill extends TestBase {
 
   @Test
   void shouldFillDifferentInputTypes() {
-    page.navigate(getServer().PREFIX + "/input/textarea.html");
+    page.navigate(server.PREFIX + "/input/textarea.html");
     for (String type : new String[]{"password", "search", "tel", "text", "url"}) {
       page.evalOnSelector("input", "(input, type) => input.setAttribute('type', type)", type);
       page.fill("input", "text " + type);
@@ -122,14 +122,14 @@ public class TestPageFill extends TestBase {
 
   @Test
   void shouldFillContenteditable() {
-    page.navigate(getServer().PREFIX + "/input/textarea.html");
+    page.navigate(server.PREFIX + "/input/textarea.html");
     page.fill("div[contenteditable]", "some value");
     assertEquals(page.evalOnSelector("div[contenteditable]", "div => div.textContent"), "some value");
   }
 
   @Test
   void shouldFillElementsWithExistingValueAndSelection() {
-    page.navigate(getServer().PREFIX + "/input/textarea.html");
+    page.navigate(server.PREFIX + "/input/textarea.html");
 
     page.evalOnSelector("input", "input => input.value = 'value one'");
     page.fill("input", "another value");
@@ -156,7 +156,7 @@ public class TestPageFill extends TestBase {
 
   @Test
   void shouldThrowWhenElementIsNotAnInputTextareaOrContenteditable() {
-    page.navigate(getServer().PREFIX + "/input/textarea.html");
+    page.navigate(server.PREFIX + "/input/textarea.html");
     try {
       page.fill("body", "");
       fail("did not throw");
@@ -231,7 +231,7 @@ public class TestPageFill extends TestBase {
 
   @Test
   void shouldBeAbleToClear() {
-    page.navigate(getServer().PREFIX + "/input/textarea.html");
+    page.navigate(server.PREFIX + "/input/textarea.html");
     page.fill("input", "some value");
     assertEquals("some value", page.evaluate("() => window['result']"));
     page.fill("input", "");

--- a/playwright/src/test/java/com/microsoft/playwright/TestPageKeyboard.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestPageKeyboard.java
@@ -27,7 +27,7 @@ public class TestPageKeyboard extends TestBase {
 
   @Test
   void shouldMoveWithTheArrowKeys() {
-    page.navigate(getServer().PREFIX + "/input/textarea.html");
+    page.navigate(server.PREFIX + "/input/textarea.html");
     page.type("textarea", "Hello World!");
     assertEquals("Hello World!", page.evaluate("() => document.querySelector('textarea').value"));
     for (int i = 0; i < "World!".length(); i++) {
@@ -46,7 +46,7 @@ public class TestPageKeyboard extends TestBase {
 
   @Test
   void shouldSendACharacterWithElementHandlePress() {
-    page.navigate(getServer().PREFIX + "/input/textarea.html");
+    page.navigate(server.PREFIX + "/input/textarea.html");
     ElementHandle textarea = page.querySelector("textarea");
     textarea.press("a");
     assertEquals("a", page.evaluate("() => document.querySelector('textarea').value"));
@@ -57,7 +57,7 @@ public class TestPageKeyboard extends TestBase {
 
   @Test
   void shouldSendACharacterWithInsertText() {
-    page.navigate(getServer().PREFIX + "/input/textarea.html");
+    page.navigate(server.PREFIX + "/input/textarea.html");
     page.focus("textarea");
     page.keyboard().insertText("嗨");
     assertEquals("嗨", page.evaluate("() => document.querySelector('textarea').value"));
@@ -68,7 +68,7 @@ public class TestPageKeyboard extends TestBase {
 
   @Test
   void insertTextShouldOnlyEmitInputEvent() {
-    page.navigate(getServer().PREFIX + "/input/textarea.html");
+    page.navigate(server.PREFIX + "/input/textarea.html");
     page.focus("textarea");
     JSHandle events = page.evaluateHandle("() => {\n" +
       "  const events = [];\n" +
@@ -86,7 +86,7 @@ public class TestPageKeyboard extends TestBase {
   void shouldReportShiftKey() {
     // Do NOT test on MacOS Firefox
     Assumptions.assumeFalse( isFirefox() && isMac);
-    page.navigate(getServer().PREFIX + "/input/keyboard.html");
+    page.navigate(server.PREFIX + "/input/keyboard.html");
     Keyboard keyboard = page.keyboard();
     Map<String, Integer> codeForKey = new HashMap<>();
     codeForKey.put("Shift", 16);
@@ -110,7 +110,7 @@ public class TestPageKeyboard extends TestBase {
 
   @Test
   void shouldReportMultipleModifiers() {
-    page.navigate(getServer().PREFIX + "/input/keyboard.html");
+    page.navigate(server.PREFIX + "/input/keyboard.html");
     Keyboard keyboard = page.keyboard();
     keyboard.down("Control");
     assertEquals("Keydown: Control ControlLeft 17 [Control]", page.evaluate("getResult()"));
@@ -128,7 +128,7 @@ public class TestPageKeyboard extends TestBase {
 
   @Test
   void shouldSendProperCodesWhileTyping() {
-    page.navigate(getServer().PREFIX + "/input/keyboard.html");
+    page.navigate(server.PREFIX + "/input/keyboard.html");
     page.keyboard().type("!");
     assertEquals(String.join("\n",
       new String[] {"Keydown: ! Digit1 49 []",
@@ -145,7 +145,7 @@ public class TestPageKeyboard extends TestBase {
 
   @Test
   void shouldSendProperCodesWhileTypingWithShift() {
-    page.navigate(getServer().PREFIX + "/input/keyboard.html");
+    page.navigate(server.PREFIX + "/input/keyboard.html");
     Keyboard keyboard = page.keyboard();
     keyboard.down("Shift");
     page.keyboard().type("~");
@@ -160,7 +160,7 @@ public class TestPageKeyboard extends TestBase {
 
   @Test
   void shouldNotTypeCanceledEvents() {
-    page.navigate(getServer().PREFIX + "/input/textarea.html");
+    page.navigate(server.PREFIX + "/input/textarea.html");
     page.focus("textarea");
     page.evaluate("() => {\n" +
       "  window.addEventListener('keydown', event => {\n" +
@@ -178,7 +178,7 @@ public class TestPageKeyboard extends TestBase {
 
   @Test
   void shouldPressPlus() {
-    page.navigate(getServer().PREFIX + "/input/keyboard.html");
+    page.navigate(server.PREFIX + "/input/keyboard.html");
     page.keyboard().press("+");
     assertEquals(String.join("\n",
       new String[] {"Keydown: + Equal 187 []", // 192 is ` keyCode
@@ -189,7 +189,7 @@ public class TestPageKeyboard extends TestBase {
 
   @Test
   void shouldPressShiftPlus() {
-    page.navigate(getServer().PREFIX + "/input/keyboard.html");
+    page.navigate(server.PREFIX + "/input/keyboard.html");
     page.keyboard().press("Shift++");
     assertEquals(String.join("\n",
       new String[] {"Keydown: Shift ShiftLeft 16 [Shift]",
@@ -202,7 +202,7 @@ public class TestPageKeyboard extends TestBase {
 
   @Test
   void shouldSupportPlusSeparatedModifier(){
-    page.navigate(getServer().PREFIX + "/input/keyboard.html");
+    page.navigate(server.PREFIX + "/input/keyboard.html");
     page.keyboard().press("Shift+~");
     assertEquals(String.join("\n",
       new String[] {"Keydown: Shift ShiftLeft 16 [Shift]",
@@ -215,7 +215,7 @@ public class TestPageKeyboard extends TestBase {
 
   @Test
   void shouldSupportMultiplePlusSeparatedModifier() {
-    page.navigate(getServer().PREFIX + "/input/keyboard.html");
+    page.navigate(server.PREFIX + "/input/keyboard.html");
     page.keyboard().press("Control+Shift+~");
     assertEquals(String.join("\n",
       new String[] {"Keydown: Control ControlLeft 17 [Control]",
@@ -229,7 +229,7 @@ public class TestPageKeyboard extends TestBase {
 
   @Test
   void shouldShiftRawCodes() {
-    page.navigate(getServer().PREFIX + "/input/keyboard.html");
+    page.navigate(server.PREFIX + "/input/keyboard.html");
     page.keyboard().press("Shift+Digit3");
     assertEquals(String.join("\n",
       new String[] {"Keydown: Shift ShiftLeft 16 [Shift]",
@@ -242,7 +242,7 @@ public class TestPageKeyboard extends TestBase {
 
   @Test
   void shouldSpecifyRepeatProperty() {
-    page.navigate(getServer().PREFIX + "/input/textarea.html");
+    page.navigate(server.PREFIX + "/input/textarea.html");
     page.focus("textarea");
     JSHandle lastEvent = captureLastKeyDown();
     page.keyboard().down("a");
@@ -260,7 +260,7 @@ public class TestPageKeyboard extends TestBase {
 
   @Test
   void shouldTypeAllKindsOfCharacters() {
-    page.navigate(getServer().PREFIX + "/input/textarea.html");
+    page.navigate(server.PREFIX + "/input/textarea.html");
     page.focus("textarea");
     final String text = "This text goes onto two lines.\\nThis character is 嗨.";
     page.keyboard().type(text);
@@ -269,7 +269,7 @@ public class TestPageKeyboard extends TestBase {
 
   @Test
   void shouldSpecifyLocation() {
-    page.navigate(getServer().PREFIX + "/input/textarea.html");
+    page.navigate(server.PREFIX + "/input/textarea.html");
     JSHandle lastEvent = captureLastKeyDown();
     ElementHandle textarea = page.querySelector("textarea");
     textarea.press("Digit5");
@@ -317,15 +317,15 @@ public class TestPageKeyboard extends TestBase {
 
   @Test
   void shouldTypeEmoji() {
-    page.navigate(getServer().PREFIX + "/input/textarea.html");
+    page.navigate(server.PREFIX + "/input/textarea.html");
     page.type("textarea", "👹 Tokyo street Japan 🇯🇵");
     assertEquals("👹 Tokyo street Japan 🇯🇵", page.evalOnSelector("textarea", "textarea => textarea.value"));
   }
 
   @Test
   void shouldTypeEmojiIntoAnIframe() {
-    page.navigate(getServer().EMPTY_PAGE);
-    attachFrame(page, "emoji-test", getServer().PREFIX + "/input/textarea.html");
+    page.navigate(server.EMPTY_PAGE);
+    attachFrame(page, "emoji-test", server.PREFIX + "/input/textarea.html");
     Frame frame = page.frames().get(1);
     ElementHandle textarea = frame.querySelector("textarea");
     textarea.type("👹 Tokyo street Japan 🇯🇵");
@@ -334,7 +334,7 @@ public class TestPageKeyboard extends TestBase {
 
   @Test
   void shouldHandleSelectAll() {
-    page.navigate(getServer().PREFIX + "/input/textarea.html");
+    page.navigate(server.PREFIX + "/input/textarea.html");
     ElementHandle textarea = page.querySelector("textarea");
     textarea.type("some text");
     String modifier = isMac ? "Meta" : "Control";
@@ -347,7 +347,7 @@ public class TestPageKeyboard extends TestBase {
 
   @Test
   void shouldBeAbleToPreventSelectAll() {
-    page.navigate(getServer().PREFIX + "/input/textarea.html");
+    page.navigate(server.PREFIX + "/input/textarea.html");
     ElementHandle textarea = page.querySelector("textarea");
     textarea.type("some text");
     page.evalOnSelector("textarea", "textarea => {\n" +
@@ -370,7 +370,7 @@ public class TestPageKeyboard extends TestBase {
     Assumptions.assumeTrue(isMac);
     // @see https://github.com/microsoft/playwright/issues/5721
     Assumptions.assumeFalse(isFirefox());
-    page.navigate(getServer().PREFIX + "/input/textarea.html");
+    page.navigate(server.PREFIX + "/input/textarea.html");
     ElementHandle textarea = page.querySelector("textarea");
     textarea.type("some text");
     // select one word backwards
@@ -403,8 +403,8 @@ public class TestPageKeyboard extends TestBase {
 
   @Test
   void shouldWorkAfterACrossOriginNavigation() {
-    page.navigate(getServer().PREFIX + "/empty.html");
-    page.navigate(getServer().CROSS_PROCESS_PREFIX + "/empty.html");
+    page.navigate(server.PREFIX + "/empty.html");
+    page.navigate(server.CROSS_PROCESS_PREFIX + "/empty.html");
     JSHandle lastEvent = captureLastKeyDown();
     page.keyboard().press("a");
     assertEquals("a", lastEvent.evaluate("l => l.key"));
@@ -434,7 +434,7 @@ public class TestPageKeyboard extends TestBase {
 
   @Test
   void shouldScrollWithPageDown() {
-    page.navigate(getServer().PREFIX + "/input/scrollable.html");
+    page.navigate(server.PREFIX + "/input/scrollable.html");
     // A click is required for WebKit to send the event into the body.
     page.click("body");
     page.keyboard().press("PageDown");

--- a/playwright/src/test/java/com/microsoft/playwright/TestPageScreenshot.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestPageScreenshot.java
@@ -31,7 +31,7 @@ public class TestPageScreenshot extends TestBase {
   @Test
   void shouldWork() throws IOException {
     page.setViewportSize(500, 500);
-    page.navigate(getServer().PREFIX + "/grid.html");
+    page.navigate(server.PREFIX + "/grid.html");
     byte[] screenshot = page.screenshot();
     BufferedImage image = ImageIO.read(new ByteArrayInputStream(screenshot));
     assertEquals(500, image.getWidth());
@@ -42,7 +42,7 @@ public class TestPageScreenshot extends TestBase {
   @Test
   void shouldClipRect() throws IOException {
     page.setViewportSize(500, 500);
-    page.navigate(getServer().PREFIX + "/grid.html");
+    page.navigate(server.PREFIX + "/grid.html");
     byte[] screenshot = page.screenshot(new Page.ScreenshotOptions()
       .setClip(new Clip(50, 100, 150, 100)));
     BufferedImage image = ImageIO.read(new ByteArrayInputStream(screenshot));

--- a/playwright/src/test/java/com/microsoft/playwright/TestPageSelectOption.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestPageSelectOption.java
@@ -29,7 +29,7 @@ import static org.junit.jupiter.api.Assertions.*;
 public class TestPageSelectOption extends TestBase {
   @Test
   void shouldSelectSingleOption() {
-    page.navigate(getServer().PREFIX + "/input/select.html");
+    page.navigate(server.PREFIX + "/input/select.html");
     page.selectOption("select", "blue");
     assertEquals(asList("blue"), page.evaluate("() => window['result'].onInput"));
     assertEquals(asList("blue"), page.evaluate("() => window['result'].onChange"));
@@ -37,7 +37,7 @@ public class TestPageSelectOption extends TestBase {
 
   @Test
   void shouldSelectSingleOptionByValue() {
-    page.navigate(getServer().PREFIX + "/input/select.html");
+    page.navigate(server.PREFIX + "/input/select.html");
     page.selectOption("select", new SelectOption().setValue("blue"));
     assertEquals(asList("blue"), page.evaluate("() => window['result'].onInput"));
     assertEquals(asList("blue"), page.evaluate("() => window['result'].onChange"));
@@ -45,7 +45,7 @@ public class TestPageSelectOption extends TestBase {
 
   @Test
   void shouldSelectSingleOptionByLabel() {
-    page.navigate(getServer().PREFIX + "/input/select.html");
+    page.navigate(server.PREFIX + "/input/select.html");
     page.selectOption("select", new SelectOption().setLabel("Indigo"));
     assertEquals(asList("indigo"), page.evaluate("() => window['result'].onInput"));
     assertEquals(asList("indigo"), page.evaluate("() => window['result'].onChange"));
@@ -53,7 +53,7 @@ public class TestPageSelectOption extends TestBase {
 
   @Test
   void shouldSelectSingleOptionByHandle() {
-    page.navigate(getServer().PREFIX + "/input/select.html");
+    page.navigate(server.PREFIX + "/input/select.html");
     page.selectOption("select", page.querySelector("[id=whiteOption]"));
     assertEquals(asList("white"), page.evaluate("() => window['result'].onInput"));
     assertEquals(asList("white"), page.evaluate("() => window['result'].onChange"));
@@ -61,7 +61,7 @@ public class TestPageSelectOption extends TestBase {
 
   @Test
   void shouldSelectSingleOptionByIndex() {
-    page.navigate(getServer().PREFIX + "/input/select.html");
+    page.navigate(server.PREFIX + "/input/select.html");
     page.selectOption("select", new SelectOption().setIndex(2));
     assertEquals(asList("brown"), page.evaluate("() => window['result'].onInput"));
     assertEquals(asList("brown"), page.evaluate("() => window['result'].onChange"));
@@ -69,7 +69,7 @@ public class TestPageSelectOption extends TestBase {
 
   @Test
   void shouldSelectSingleOptionByMultipleAttributes() {
-    page.navigate(getServer().PREFIX + "/input/select.html");
+    page.navigate(server.PREFIX + "/input/select.html");
     page.selectOption("select", new SelectOption().setValue("green").setLabel("Green"));
     assertEquals(asList("green"), page.evaluate("() => window['result'].onInput"));
     assertEquals(asList("green"), page.evaluate("() => window['result'].onChange"));
@@ -77,7 +77,7 @@ public class TestPageSelectOption extends TestBase {
 
   @Test
   void shouldNotSelectSingleOptionWhenSomeAttributesDoNotMatch() {
-    page.navigate(getServer().PREFIX + "/input/select.html");
+    page.navigate(server.PREFIX + "/input/select.html");
     page.evalOnSelector("select", "s => s.value = undefined");
     try {
       page.selectOption("select", new SelectOption()
@@ -90,7 +90,7 @@ public class TestPageSelectOption extends TestBase {
 
   @Test
   void shouldSelectOnlyFirstOption() {
-    page.navigate(getServer().PREFIX + "/input/select.html");
+    page.navigate(server.PREFIX + "/input/select.html");
     page.selectOption("select", new String[]{"blue", "green", "red"});
     assertEquals(asList("blue"), page.evaluate("() => window['result'].onInput"));
     assertEquals(asList("blue"), page.evaluate("() => window['result'].onChange"));
@@ -98,7 +98,7 @@ public class TestPageSelectOption extends TestBase {
 
   @Test
   void shouldNotThrowWhenSelectCausesNavigation() {
-    page.navigate(getServer().PREFIX + "/input/select.html");
+    page.navigate(server.PREFIX + "/input/select.html");
     page.evalOnSelector("select", "select => select.addEventListener('input', () => window.location.href = '/empty.html')");
     page.waitForNavigation(() -> page.selectOption("select", "blue"));
     assertTrue(page.url().contains("empty.html"));
@@ -106,7 +106,7 @@ public class TestPageSelectOption extends TestBase {
 
   @Test
   void shouldSelectMultipleOptions() {
-    page.navigate(getServer().PREFIX + "/input/select.html");
+    page.navigate(server.PREFIX + "/input/select.html");
     page.evaluate("() => window['makeMultiple']()");
     page.selectOption("select", new String[]{"blue", "green", "red"});
     assertEquals(asList("blue", "green", "red"), page.evaluate("() => window['result'].onInput"));
@@ -115,7 +115,7 @@ public class TestPageSelectOption extends TestBase {
 
   @Test
   void shouldSelectMultipleOptionsWithAttributes() {
-    page.navigate(getServer().PREFIX + "/input/select.html");
+    page.navigate(server.PREFIX + "/input/select.html");
     page.evaluate("() => window['makeMultiple']()");
     page.selectOption("select", new SelectOption[] {
       new SelectOption().setValue("blue"),
@@ -128,7 +128,7 @@ public class TestPageSelectOption extends TestBase {
 
   @Test
   void shouldRespectEventBubbling() {
-    page.navigate(getServer().PREFIX + "/input/select.html");
+    page.navigate(server.PREFIX + "/input/select.html");
     page.selectOption("select", "blue");
     assertEquals(asList("blue"), page.evaluate("() => window['result'].onBubblingInput"));
     assertEquals(asList("blue"), page.evaluate("() => window['result'].onBubblingChange"));
@@ -136,7 +136,7 @@ public class TestPageSelectOption extends TestBase {
 
   @Test
   void shouldThrowWhenElementIsNotASelect() {
-    page.navigate(getServer().PREFIX + "/input/select.html");
+    page.navigate(server.PREFIX + "/input/select.html");
     try {
       page.selectOption("body", "");
       fail("did not throw");
@@ -147,14 +147,14 @@ public class TestPageSelectOption extends TestBase {
 
   @Test
   void shouldReturnOnNoMatchedValues() {
-    page.navigate(getServer().PREFIX + "/input/select.html");
+    page.navigate(server.PREFIX + "/input/select.html");
     List<String> result = page.selectOption("select", new String[]{});
     assertEquals(emptyList(), result);
   }
 
   @Test
   void shouldReturnAnArrayOfMatchedValues() {
-    page.navigate(getServer().PREFIX + "/input/select.html");
+    page.navigate(server.PREFIX + "/input/select.html");
     page.evaluate("() => window['makeMultiple']()");
     List<String> result = page.selectOption("select", new String[]{"blue", "black", "magenta"});
     Collections.sort(result);
@@ -165,21 +165,21 @@ public class TestPageSelectOption extends TestBase {
 
   @Test
   void shouldReturnAnArrayOfOneElementWhenMultipleIsNotSet() {
-    page.navigate(getServer().PREFIX + "/input/select.html");
+    page.navigate(server.PREFIX + "/input/select.html");
     List<String> result = page.selectOption("select", new String[]{"42", "blue", "black", "magenta"});
     assertEquals(1, result.size());
   }
 
   @Test
   void shouldReturnOnNoValues() {
-    page.navigate(getServer().PREFIX + "/input/select.html");
+    page.navigate(server.PREFIX + "/input/select.html");
     Object result = page.selectOption("select", new String[0]);
     assertEquals(emptyList(), result);
   }
 
 //  @Test
   void shouldNotAllowNullItems() {
-    page.navigate(getServer().PREFIX + "/input/select.html");
+    page.navigate(server.PREFIX + "/input/select.html");
     page.evaluate("() => window['makeMultiple']()");
     try {
       page.selectOption("select", new String[]{"blue", null, "black","magenta"});
@@ -191,7 +191,7 @@ public class TestPageSelectOption extends TestBase {
 
   @Test
   void shouldUnselectWithNull() {
-    page.navigate(getServer().PREFIX + "/input/select.html");
+    page.navigate(server.PREFIX + "/input/select.html");
     page.evaluate("() => window['makeMultiple']()");
     List<String> result = page.selectOption("select", new String[]{"blue", "black", "magenta"});
     Collections.sort(result);
@@ -208,7 +208,7 @@ public class TestPageSelectOption extends TestBase {
 
   @Test
   void shouldDeselectAllOptionsWhenPassedNoValuesForAMultipleSelect() {
-    page.navigate(getServer().PREFIX + "/input/select.html");
+    page.navigate(server.PREFIX + "/input/select.html");
     page.evaluate("() => window['makeMultiple']()");
     page.selectOption("select", new String[]{"blue", "black", "magenta"});
     page.selectOption("select", new String[0]);
@@ -217,7 +217,7 @@ public class TestPageSelectOption extends TestBase {
 
   @Test
   void shouldDeselectAllOptionsWhenPassedNoValuesForASelectWithoutMultiple() {
-    page.navigate(getServer().PREFIX + "/input/select.html");
+    page.navigate(server.PREFIX + "/input/select.html");
     page.selectOption("select", new String[]{"blue", "black", "magenta"});
     page.selectOption("select", new String[0]);
     assertEquals(true, page.evalOnSelector("select", "select => Array.from(select.options).every(option => !option.selected)"));
@@ -230,7 +230,7 @@ public class TestPageSelectOption extends TestBase {
   // @see https://github.com/GoogleChrome/puppeteer/issues/3327
   @Test
   void shouldWorkWhenReDefiningTopLevelEventClass() {
-    page.navigate(getServer().PREFIX + "/input/select.html");
+    page.navigate(server.PREFIX + "/input/select.html");
     page.evaluate("() => window.Event = null");
     page.selectOption("select", "blue");
     assertEquals(asList("blue"), page.evaluate("() => window['result'].onInput"));

--- a/playwright/src/test/java/com/microsoft/playwright/TestPageSetExtraHttpHeaders.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestPageSetExtraHttpHeaders.java
@@ -29,40 +29,40 @@ public class TestPageSetExtraHttpHeaders extends TestBase {
   @Test
   void shouldWork() throws ExecutionException, InterruptedException {
     page.setExtraHTTPHeaders(mapOf("foo", "bar"));
-    Future<Server.Request> request = getServer().futureRequest("/empty.html");
-    page.navigate(getServer().EMPTY_PAGE);
+    Future<Server.Request> request = server.futureRequest("/empty.html");
+    page.navigate(server.EMPTY_PAGE);
     assertEquals(asList("bar"), request.get().headers.get("foo"));
     assertNull(request.get().headers.get("baz"));
   }
 
   @Test
   void shouldWorkWithRedirects() throws ExecutionException, InterruptedException {
-    getServer().setRedirect("/foo.html", "/empty.html");
+    server.setRedirect("/foo.html", "/empty.html");
     page.setExtraHTTPHeaders(mapOf("foo", "bar"));
-    Future<Server.Request> request = getServer().futureRequest("/empty.html");
-    page.navigate(getServer().PREFIX + "/foo.html");
+    Future<Server.Request> request = server.futureRequest("/empty.html");
+    page.navigate(server.PREFIX + "/foo.html");
     assertEquals(asList("bar"), request.get().headers.get("foo"));
   }
 
   @Test
   void shouldWorkWithExtraHeadersFromBrowserContext() throws ExecutionException, InterruptedException {
-    BrowserContext context = getBrowser().newContext();
+    BrowserContext context = browser.newContext();
     context.setExtraHTTPHeaders(mapOf("foo", "bar"));
     Page page = context.newPage();
-    Future<Server.Request> request = getServer().futureRequest("/empty.html");
-    page.navigate(getServer().EMPTY_PAGE);
+    Future<Server.Request> request = server.futureRequest("/empty.html");
+    page.navigate(server.EMPTY_PAGE);
     context.close();
     assertEquals(asList("bar"), request.get().headers.get("foo"));
   }
 
   @Test
   void shouldOverrideExtraHeadersFromBrowserContext() throws ExecutionException, InterruptedException {
-    BrowserContext context = getBrowser().newContext(new Browser.NewContextOptions()
+    BrowserContext context = browser.newContext(new Browser.NewContextOptions()
       .setExtraHTTPHeaders(mapOf("fOo", "bAr", "baR", "foO")));
     Page page = context.newPage();
     page.setExtraHTTPHeaders(mapOf("Foo", "Bar"));
-    Future<Server.Request> request = getServer().futureRequest("/empty.html");
-    page.navigate(getServer().EMPTY_PAGE);
+    Future<Server.Request> request = server.futureRequest("/empty.html");
+    page.navigate(server.EMPTY_PAGE);
     context.close();
     assertEquals(asList("Bar"), request.get().headers.get("foo"));
     assertEquals(asList("foO"), request.get().headers.get("bar"));
@@ -71,7 +71,7 @@ public class TestPageSetExtraHttpHeaders extends TestBase {
   @Test
   void shouldThrowForNonStringHeaderValues() {
     try {
-      getBrowser().newContext(new Browser.NewContextOptions().setExtraHTTPHeaders(mapOf("foo", null)));
+      browser.newContext(new Browser.NewContextOptions().setExtraHTTPHeaders(mapOf("foo", null)));
       fail("did not throw");
     } catch (PlaywrightException e) {
       assertTrue(e.getMessage().contains("expected string, got undefined"));

--- a/playwright/src/test/java/com/microsoft/playwright/TestPageSetInputFiles.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestPageSetInputFiles.java
@@ -37,7 +37,7 @@ public class TestPageSetInputFiles extends TestBase {
 
   @Test
   void shouldUploadTheFile() {
-    page.navigate(getServer().PREFIX + "/input/fileupload.html");
+    page.navigate(server.PREFIX + "/input/fileupload.html");
     ElementHandle input = page.querySelector("input");
     input.setInputFiles(FILE_TO_UPLOAD);
     assertEquals("file-to-upload.txt", page.evaluate("e => e.files[0].name", input));
@@ -116,8 +116,8 @@ public class TestPageSetInputFiles extends TestBase {
 
   @Test
   void shouldWorkWithCSP() {
-    getServer().setCSP("/empty.html", "default-src 'none'");
-    page.navigate(getServer().EMPTY_PAGE);
+    server.setCSP("/empty.html", "default-src 'none'");
+    page.navigate(server.EMPTY_PAGE);
     page.setContent("<input type=file>");
     page.setInputFiles("input", FILE_TO_UPLOAD);
     assertEquals(1, page.evalOnSelector("input", "input => input.files.length"));

--- a/playwright/src/test/java/com/microsoft/playwright/TestPageWaitForNavigation.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestPageWaitForNavigation.java
@@ -31,9 +31,9 @@ public class TestPageWaitForNavigation extends TestBase {
 
   @Test
   void shouldWork() {
-    page.navigate(getServer().EMPTY_PAGE);
+    page.navigate(server.EMPTY_PAGE);
     Response response = page.waitForNavigation(() -> page.evaluate(
-      "url => window.location.href = url", getServer().PREFIX + "/grid.html"));
+      "url => window.location.href = url", server.PREFIX + "/grid.html"));
     assertTrue(response.ok());
     assertTrue(response.url().contains("grid.html"));
   }
@@ -43,7 +43,7 @@ public class TestPageWaitForNavigation extends TestBase {
     try {
       page.waitForNavigation(
         new Page.WaitForNavigationOptions().setUrl("**/frame.html").setTimeout(5000),
-        () -> page.navigate(getServer().EMPTY_PAGE));
+          () -> page.navigate(server.EMPTY_PAGE));
       fail("did not throw");
     } catch (TimeoutError e) {
       assertTrue(e.getMessage().contains("Timeout 5000ms exceeded"));
@@ -58,11 +58,11 @@ public class TestPageWaitForNavigation extends TestBase {
 
   @Test
   void shouldWorkWithClickingOnAnchorLinks() {
-    page.navigate(getServer().EMPTY_PAGE);
+    page.navigate(server.EMPTY_PAGE);
     page.setContent("<a href='#foobar'>foobar</a>");
     Response response = page.waitForNavigation(() -> page.click("a"));
     assertNull(response);
-    assertEquals(getServer().EMPTY_PAGE + "#foobar", page.url());
+    assertEquals(server.EMPTY_PAGE + "#foobar", page.url());
   }
 
   private boolean checkSSLErrorMessage(String exceptionMessage, List<String> possibleErrorMessages) {
@@ -71,45 +71,45 @@ public class TestPageWaitForNavigation extends TestBase {
 
   @Test
   void shouldWorkWithClickingOnLinksWhichDoNotCommitNavigation() throws InterruptedException {
-    page.navigate(getServer().EMPTY_PAGE);
-    page.setContent("<a href='" + getHttpsServer().EMPTY_PAGE + "'>foobar</a>");
+    page.navigate(server.EMPTY_PAGE);
+    page.setContent("<a href='" + httpsServer.EMPTY_PAGE + "'>foobar</a>");
     try {
       page.waitForNavigation(() -> page.click("a"));
       fail("did not throw");
     } catch (PlaywrightException e) {
       // TODO: figure out why it is inconsistent on Linux WebKit.
-      List<String> possibleErrorMessages = expectedSSLError(getBrowserType().name());
+      List<String> possibleErrorMessages = expectedSSLError(browserType.name());
       assertTrue(checkSSLErrorMessage(e.getMessage(), possibleErrorMessages), "Unexpected exception: '" + e.getMessage() + "' check message(s): " + String.join(",", possibleErrorMessages));
     }
   }
 
   @Test
   void shouldWorkWithHistoryPushState() {
-    page.navigate(getServer().EMPTY_PAGE);
+    page.navigate(server.EMPTY_PAGE);
     page.setContent("<a onclick='javascript:pushState()'>SPA</a>\n" +
       "<script>\n" +
       "  function pushState() { history.pushState({}, '', 'wow.html') }\n" +
       "</script>");
     Response response = page.waitForNavigation(() -> page.click("a"));
     assertNull(response);
-    assertEquals(getServer().PREFIX + "/wow.html", page.url());
+    assertEquals(server.PREFIX + "/wow.html", page.url());
   }
 
   @Test
   void shouldWorkWithHistoryReplaceState() {
-    page.navigate(getServer().EMPTY_PAGE);
+    page.navigate(server.EMPTY_PAGE);
     page.setContent(" <a onclick='javascript:replaceState()'>SPA</a>\n" +
       "<script>\n" +
       "  function replaceState() { history.replaceState({}, '', '/replaced.html') }\n" +
       "</script>");
     Response response = page.waitForNavigation(() -> page.click("a"));
     assertNull(response);
-    assertEquals(getServer().PREFIX + "/replaced.html", page.url());
+    assertEquals(server.PREFIX + "/replaced.html", page.url());
   }
 
   @Test
   void shouldWorkWithDOMHistoryBackHistoryForward() {
-    page.navigate(getServer().EMPTY_PAGE);
+    page.navigate(server.EMPTY_PAGE);
     page.setContent("<a id=back onclick='javascript:goBack()'>back</a>\n" +
       "<a id=forward onclick='javascript:goForward()'>forward</a>\n" +
       "<script>\n" +
@@ -118,21 +118,21 @@ public class TestPageWaitForNavigation extends TestBase {
       "  history.pushState({}, '', '/first.html');\n" +
       "  history.pushState({}, '', '/second.html');\n" +
       "</script>");
-    assertEquals(getServer().PREFIX + "/second.html", page.url());
+    assertEquals(server.PREFIX + "/second.html", page.url());
 
     Response backResponse = page.waitForNavigation(() -> page.click("a#back"));
     assertNull(backResponse);
-    assertEquals(getServer().PREFIX + "/first.html", page.url());
+    assertEquals(server.PREFIX + "/first.html", page.url());
 
     Response forwardResponse = page.waitForNavigation(() -> page.click("a#forward"));
     page.click("a#forward");
     assertNull(forwardResponse);
-    assertEquals(getServer().PREFIX + "/second.html", page.url());
+    assertEquals(server.PREFIX + "/second.html", page.url());
   }
 
   @Test
   void shouldWorkWhenSubframeIssuesWindowStop() {
-    getServer().setRoute("/frames/style.css", exchange -> {});
+    server.setRoute("/frames/style.css", exchange -> {});
     boolean[] frameWindowStopCalled = {false};
     page.onFrameAttached(frame -> {
       page.onFrameNavigated(frame1 -> {
@@ -142,25 +142,25 @@ public class TestPageWaitForNavigation extends TestBase {
         }
       });
     });
-    page.navigate(getServer().PREFIX + "/frames/one-frame.html");
+    page.navigate(server.PREFIX + "/frames/one-frame.html");
     assertTrue(frameWindowStopCalled[0]);
   }
 
   @Test
   void shouldWorkWithUrlMatch() {
-    page.navigate(getServer().EMPTY_PAGE);
+    page.navigate(server.EMPTY_PAGE);
 
     Response response1 = page.waitForNavigation(
       new Page.WaitForNavigationOptions().setUrl("**/one-style.html"),
-      () -> page.navigate(getServer().PREFIX + "/one-style.html"));
+        () -> page.navigate(server.PREFIX + "/one-style.html"));
     assertNotNull(response1);
-    assertEquals(getServer().PREFIX + "/one-style.html", response1.url());
+    assertEquals(server.PREFIX + "/one-style.html", response1.url());
 
     Response response2 = page.waitForNavigation(
       new Page.WaitForNavigationOptions().setUrl(Pattern.compile("frame.html$")),
-      () -> page.navigate(getServer().PREFIX + "/frame.html"));
+        () -> page.navigate(server.PREFIX + "/frame.html"));
     assertNotNull(response2);
-    assertEquals(getServer().PREFIX + "/frame.html", response2.url());
+    assertEquals(server.PREFIX + "/frame.html", response2.url());
 
     Response response3 = page.waitForNavigation(
       new Page.WaitForNavigationOptions().setUrl(url -> {
@@ -170,14 +170,14 @@ public class TestPageWaitForNavigation extends TestBase {
           throw new RuntimeException(e);
         }
       }),
-      () -> page.navigate(getServer().PREFIX + "/frame.html?foo=bar"));
+        () -> page.navigate(server.PREFIX + "/frame.html?foo=bar"));
     assertNotNull(response3);
-    assertEquals(getServer().PREFIX + "/frame.html?foo=bar", response3.url());
+    assertEquals(server.PREFIX + "/frame.html?foo=bar", response3.url());
   }
 
   @Test
   void shouldWorkWithUrlMatchForSameDocumentNavigations() {
-    page.navigate(getServer().EMPTY_PAGE);
+    page.navigate(server.EMPTY_PAGE);
     Response response = page.waitForNavigation(new Page.WaitForNavigationOptions().setUrl("**/third.html"), () -> {
       page.evaluate("() => {\n" +
         "  history.pushState({}, '', '/first.html');\n" +
@@ -194,8 +194,8 @@ public class TestPageWaitForNavigation extends TestBase {
 
   @Test
   void shouldWorkForCrossProcessNavigations() {
-    page.navigate(getServer().EMPTY_PAGE);
-    String url = getServer().CROSS_PROCESS_PREFIX + "/empty.html";
+    page.navigate(server.EMPTY_PAGE);
+    String url = server.CROSS_PROCESS_PREFIX + "/empty.html";
     Response response = page.waitForNavigation(
       new Page.WaitForNavigationOptions().setWaitUntil(WaitUntilState.DOMCONTENTLOADED),
       () -> page.navigate(url));
@@ -206,10 +206,9 @@ public class TestPageWaitForNavigation extends TestBase {
 
   @Test
   void shouldWorkOnFrame() {
-    page.navigate(getServer().PREFIX + "/frames/one-frame.html");
+    page.navigate(server.PREFIX + "/frames/one-frame.html");
     Frame frame = page.frames().get(1);
-    Response response = frame.waitForNavigation(() ->
-      frame.evaluate("url => window.location.href = url", getServer().PREFIX + "/grid.html"));
+    Response response = frame.waitForNavigation(() -> frame.evaluate("url => window.location.href = url", server.PREFIX + "/grid.html"));
     assertTrue(response.ok());
     assertTrue(response.url().contains("grid.html"));
     assertEquals(frame, response.frame());
@@ -218,9 +217,9 @@ public class TestPageWaitForNavigation extends TestBase {
 
   @Test
   void shouldFailWhenFrameDetaches() throws InterruptedException {
-    page.navigate(getServer().PREFIX + "/frames/one-frame.html");
+    page.navigate(server.PREFIX + "/frames/one-frame.html");
     Frame frame = page.frames().get(1);
-    getServer().setRoute("/empty.html", exchange -> {});
+    server.setRoute("/empty.html", exchange -> {});
     try {
       frame.waitForNavigation(() -> {
         page.evaluate("() => {\n" +
@@ -249,7 +248,7 @@ public class TestPageWaitForNavigation extends TestBase {
 
   @Test
   void shouldThrowOnInvalidUrlMatcherTypeInFrame() {
-    page.navigate(getServer().PREFIX + "/frames/one-frame.html");
+    page.navigate(server.PREFIX + "/frames/one-frame.html");
     Frame frame = page.frames().get(1);
     try {
       Frame.WaitForNavigationOptions options = new Frame.WaitForNavigationOptions();

--- a/playwright/src/test/java/com/microsoft/playwright/TestPageWaitForRequest.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestPageWaitForRequest.java
@@ -26,28 +26,28 @@ public class TestPageWaitForRequest extends TestBase {
 
   @Test
   void shouldWork() {
-    page.navigate(getServer().EMPTY_PAGE);
-    Request request = page.waitForRequest(getServer().PREFIX + "/digits/2.png", () -> {
+    page.navigate(server.EMPTY_PAGE);
+    Request request = page.waitForRequest(server.PREFIX + "/digits/2.png", () -> {
       page.evaluate("() => {\n" +
         "  fetch('/digits/1.png');\n" +
         "  fetch('/digits/2.png');\n" +
         "  fetch('/digits/3.png');\n" +
         "}");
     });
-    assertEquals(getServer().PREFIX + "/digits/2.png", request.url());
+    assertEquals(server.PREFIX + "/digits/2.png", request.url());
   }
 
   @Test
   void shouldWorkWithPredicate() {
-    page.navigate(getServer().EMPTY_PAGE);
-    Request request = page.waitForRequest(r -> r.url().equals(getServer().PREFIX + "/digits/2.png"), () -> {
+    page.navigate(server.EMPTY_PAGE);
+    Request request = page.waitForRequest(r -> r.url().equals(server.PREFIX + "/digits/2.png"), () -> {
       page.evaluate("() => {\n" +
         "  fetch('/digits/1.png');\n" +
         "  fetch('/digits/2.png');\n" +
         "  fetch('/digits/3.png');\n" +
         "}");
     });
-    assertEquals(getServer().PREFIX + "/digits/2.png", request.url());
+    assertEquals(server.PREFIX + "/digits/2.png", request.url());
   }
 
   @Test
@@ -73,9 +73,9 @@ public class TestPageWaitForRequest extends TestBase {
 
   @Test
   void shouldWorkWithNoTimeout() {
-    page.navigate(getServer().EMPTY_PAGE);
+    page.navigate(server.EMPTY_PAGE);
     Request request = page.waitForRequest(
-      getServer().PREFIX + "/digits/2.png",
+      server.PREFIX + "/digits/2.png",
       new Page.WaitForRequestOptions().setTimeout(0),() -> {
         page.evaluate("() => setTimeout(() => {\n" +
           "  fetch('/digits/1.png');\n" +
@@ -83,18 +83,18 @@ public class TestPageWaitForRequest extends TestBase {
           "  fetch('/digits/3.png');\n" +
           "}, 50)");
       });
-    assertEquals(getServer().PREFIX + "/digits/2.png", request.url());
+    assertEquals(server.PREFIX + "/digits/2.png", request.url());
   }
 
   @Test
   void shouldWorkWithUrlMatch() {
-    page.navigate(getServer().EMPTY_PAGE);
+    page.navigate(server.EMPTY_PAGE);
     Request request = page.waitForRequest(Pattern.compile(".*digits/\\d\\.png"), () -> {
       page.evaluate("() => {\n" +
         "  fetch('/digits/1.png');\n" +
         "}");
     });
-    assertEquals(getServer().PREFIX + "/digits/1.png", request.url());
+    assertEquals(server.PREFIX + "/digits/1.png", request.url());
   }
 
   void shouldWorkWithUrlMatchRegularExpressionFromADifferentContext() {

--- a/playwright/src/test/java/com/microsoft/playwright/TestPageWaitForResponse.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestPageWaitForResponse.java
@@ -23,41 +23,41 @@ import static org.junit.jupiter.api.Assertions.*;
 public class TestPageWaitForResponse extends TestBase {
   @Test
   void shouldWork() {
-    page.navigate(getServer().EMPTY_PAGE);
-    Response response = page.waitForResponse(getServer().PREFIX + "/digits/2.png", () -> {
+    page.navigate(server.EMPTY_PAGE);
+    Response response = page.waitForResponse(server.PREFIX + "/digits/2.png", () -> {
       page.evaluate("() => {\n" +
         "  fetch('/digits/1.png');\n" +
         "  fetch('/digits/2.png');\n" +
         "  fetch('/digits/3.png');\n" +
         "}");
     });
-    assertEquals(getServer().PREFIX + "/digits/2.png", response.url());
+    assertEquals(server.PREFIX + "/digits/2.png", response.url());
   }
 
   @Test
   void shouldRespectTimeout() {
-    page.navigate(getServer().EMPTY_PAGE);
-    Response response = page.waitForResponse(r -> r.url().equals(getServer().PREFIX + "/digits/2.png"), () -> {
+    page.navigate(server.EMPTY_PAGE);
+    Response response = page.waitForResponse(r -> r.url().equals(server.PREFIX + "/digits/2.png"), () -> {
       page.evaluate("() => {\n" +
         "  fetch('/digits/1.png');\n" +
         "  fetch('/digits/2.png');\n" +
         "  fetch('/digits/3.png');\n" +
         "}");
     });
-    assertEquals(getServer().PREFIX + "/digits/2.png", response.url());
+    assertEquals(server.PREFIX + "/digits/2.png", response.url());
   }
 
   @Test
   void shouldWorkWithPredicate() {
-    page.navigate(getServer().EMPTY_PAGE);
-    Response response = page.waitForResponse(r -> r.url().equals(getServer().PREFIX + "/digits/2.png"), () -> {
+    page.navigate(server.EMPTY_PAGE);
+    Response response = page.waitForResponse(r -> r.url().equals(server.PREFIX + "/digits/2.png"), () -> {
       page.evaluate("() => {\n" +
         "  fetch('/digits/1.png');\n" +
         "  fetch('/digits/2.png');\n" +
         "  fetch('/digits/3.png');\n" +
         "}");
     });
-    assertEquals(getServer().PREFIX + "/digits/2.png", response.url());
+    assertEquals(server.PREFIX + "/digits/2.png", response.url());
   }
 
   @Test
@@ -73,9 +73,9 @@ public class TestPageWaitForResponse extends TestBase {
 
   @Test
   void shouldWorkWithNoTimeout() {
-    page.navigate(getServer().EMPTY_PAGE);
+    page.navigate(server.EMPTY_PAGE);
     Response response = page.waitForResponse(
-      getServer().PREFIX + "/digits/2.png",
+      server.PREFIX + "/digits/2.png",
       new Page.WaitForResponseOptions().setTimeout(0),
       () -> {
         page.evaluate("() => setTimeout(() => {\n" +
@@ -85,6 +85,6 @@ public class TestPageWaitForResponse extends TestBase {
           "}, 50)");
 
       });
-    assertEquals(getServer().PREFIX + "/digits/2.png", response.url());
+    assertEquals(server.PREFIX + "/digits/2.png", response.url());
   }
 }

--- a/playwright/src/test/java/com/microsoft/playwright/TestPageWaitForUrl.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestPageWaitForUrl.java
@@ -24,14 +24,14 @@ import static org.junit.jupiter.api.Assertions.*;
 public class TestPageWaitForUrl extends TestBase {
   @Test
   void shouldWork() {
-    page.navigate(getServer().EMPTY_PAGE);
-    page.evaluate("url => window.location.href = url", getServer().PREFIX + "/grid.html");
+    page.navigate(server.EMPTY_PAGE);
+    page.evaluate("url => window.location.href = url", server.PREFIX + "/grid.html");
     page.waitForURL("**/grid.html");
   }
 
   @Test
   void shouldRespectTimeout() {
-    page.navigate(getServer().EMPTY_PAGE);
+    page.navigate(server.EMPTY_PAGE);
     try {
       page.waitForURL("**/frame.html", new Page.WaitForURLOptions().setTimeout(2500));
       fail("did not throw");
@@ -42,14 +42,14 @@ public class TestPageWaitForUrl extends TestBase {
 
   @Test
   void shouldWorkWithBothDomcontentloadedAndLoad() {
-    page.navigate(getServer().PREFIX + "/one-style.html");
+    page.navigate(server.PREFIX + "/one-style.html");
     page.waitForURL("**/one-style.html", new Page.WaitForURLOptions().setWaitUntil(WaitUntilState.DOMCONTENTLOADED));
     page.waitForURL("**/one-style.html", new Page.WaitForURLOptions().setWaitUntil(WaitUntilState.LOAD));
   }
 
   @Test
   void shouldWorkWithClickingOnAnchorLinks() {
-    page.navigate(getServer().EMPTY_PAGE);
+    page.navigate(server.EMPTY_PAGE);
     page.setContent("<a href='#foobar'>foobar</a>");
     page.click("a");
     page.waitForURL("**/*#foobar");
@@ -57,31 +57,31 @@ public class TestPageWaitForUrl extends TestBase {
 
   @Test
   void shouldWorkWithHistoryPushState() {
-    page.navigate(getServer().EMPTY_PAGE);
+    page.navigate(server.EMPTY_PAGE);
     page.setContent("<a onclick='javascript:pushState()'>SPA</a>\n" +
       "<script>\n" +
       "  function pushState() { history.pushState({}, '', 'wow.html') }\n" +
       "</script>");
     page.click("a");
     page.waitForURL("**/wow.html");
-    assertEquals(getServer().PREFIX + "/wow.html", page.url());
+    assertEquals(server.PREFIX + "/wow.html", page.url());
   }
 
   @Test
   void shouldWorkWithHistoryReplaceState() {
-    page.navigate(getServer().EMPTY_PAGE);
+    page.navigate(server.EMPTY_PAGE);
     page.setContent(" <a onclick='javascript:replaceState()'>SPA</a>\n" +
       "<script>\n" +
       "  function replaceState() { history.replaceState({}, '', '/replaced.html') }\n" +
       "</script>");
     page.click("a");
     page.waitForURL("**/replaced.html");
-    assertEquals(getServer().PREFIX + "/replaced.html", page.url());
+    assertEquals(server.PREFIX + "/replaced.html", page.url());
   }
 
   @Test
   void shouldWorkWithDOMHistoryBackHistoryForward() {
-    page.navigate(getServer().EMPTY_PAGE);
+    page.navigate(server.EMPTY_PAGE);
     page.setContent("<a id=back onclick='javascript:goBack()'>back</a>\n" +
       "<a id=forward onclick='javascript:goForward()'>forward</a>\n" +
       "<script>\n" +
@@ -90,22 +90,22 @@ public class TestPageWaitForUrl extends TestBase {
       "  history.pushState({}, '', '/first.html');\n" +
       "  history.pushState({}, '', '/second.html');\n" +
       "</script>");
-    assertEquals(getServer().PREFIX + "/second.html", page.url());
+    assertEquals(server.PREFIX + "/second.html", page.url());
 
     page.click("a#back");
     page.waitForURL("**/first.html");
-    assertEquals(getServer().PREFIX + "/first.html", page.url());
+    assertEquals(server.PREFIX + "/first.html", page.url());
 
     page.click("a#forward");
     page.waitForURL("**/second.html");
-    assertEquals(getServer().PREFIX + "/second.html", page.url());
+    assertEquals(server.PREFIX + "/second.html", page.url());
   }
 
   @Test
   void shouldWorkOnFrame() {
-    page.navigate(getServer().PREFIX + "/frames/one-frame.html");
+    page.navigate(server.PREFIX + "/frames/one-frame.html");
     Frame frame = page.frames().get(1);
-    frame.evaluate("url => window.location.href = url", getServer().PREFIX + "/grid.html");
+    frame.evaluate("url => window.location.href = url", server.PREFIX + "/grid.html");
     frame.waitForURL("**/grid.html");
   }
 }

--- a/playwright/src/test/java/com/microsoft/playwright/TestPopup.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestPopup.java
@@ -32,11 +32,11 @@ public class TestPopup extends TestBase {
 
   @Test
   void shouldInheritUserAgentFromBrowserContext() throws ExecutionException, InterruptedException {
-    BrowserContext context = getBrowser().newContext(new Browser.NewContextOptions().setUserAgent("hey"));
+    BrowserContext context = browser.newContext(new Browser.NewContextOptions().setUserAgent("hey"));
     Page page = context.newPage();
-    page.navigate(getServer().EMPTY_PAGE);
+    page.navigate(server.EMPTY_PAGE);
     page.setContent("<a target=_blank rel=noopener href='/popup/popup.html'>link</a>");
-    Future<Server.Request> requestPromise = getServer().futureRequest("/popup/popup.html");
+    Future<Server.Request> requestPromise = server.futureRequest("/popup/popup.html");
     Page popup = context.waitForPage(() -> page.click("a"));
     popup.waitForLoadState(DOMCONTENTLOADED);
     String userAgent = (String) popup.evaluate("() => window['initialUserAgent']");
@@ -48,9 +48,9 @@ public class TestPopup extends TestBase {
 
   @Test
   void shouldRespectRoutesFromBrowserContext() {
-    BrowserContext context = getBrowser().newContext();
+    BrowserContext context = browser.newContext();
     Page page = context.newPage();
-    page.navigate(getServer().EMPTY_PAGE);
+    page.navigate(server.EMPTY_PAGE);
     page.setContent("<a target=_blank rel=noopener href='empty.html'>link</a>");
     boolean[] intercepted = {false};
     context.route("**/empty.html", route -> {
@@ -66,12 +66,12 @@ public class TestPopup extends TestBase {
   @Test
   void shouldInheritExtraHeadersFromBrowserContext() throws ExecutionException, InterruptedException {
     @SuppressWarnings("unchecked")
-    BrowserContext context = getBrowser().newContext(new Browser.NewContextOptions()
+    BrowserContext context = browser.newContext(new Browser.NewContextOptions()
       .setExtraHTTPHeaders(mapOf("foo", "bar")));
     Page page = context.newPage();
-    page.navigate(getServer().EMPTY_PAGE);
-    Future<Server.Request> requestPromise = getServer().futureRequest("/dummy.html");
-    page.evaluate("url => window['_popup'] = window.open(url)", getServer().PREFIX + "/dummy.html");
+    page.navigate(server.EMPTY_PAGE);
+    Future<Server.Request> requestPromise = server.futureRequest("/dummy.html");
+    page.evaluate("url => window['_popup'] = window.open(url)", server.PREFIX + "/dummy.html");
     Server.Request request = requestPromise.get();
     context.close();
     assertEquals(Arrays.asList("bar"), request.headers.get("foo"));
@@ -79,27 +79,27 @@ public class TestPopup extends TestBase {
 
   @Test
   void shouldInheritOfflineFromBrowserContext() {
-    BrowserContext context = getBrowser().newContext();
+    BrowserContext context = browser.newContext();
     Page page = context.newPage();
-    page.navigate(getServer().EMPTY_PAGE);
+    page.navigate(server.EMPTY_PAGE);
     context.setOffline(true);
     boolean online = (boolean) page.evaluate("url => {\n" +
       "  const win = window.open(url);\n" +
       "  return win.navigator.onLine;\n" +
-      "}", getServer().PREFIX + "/dummy.html");
+      "}", server.PREFIX + "/dummy.html");
     context.close();
     assertFalse(online);
   }
 
   @Test
   void shouldInheritHttpCredentialsFromBrowserContext() {
-    getServer().setAuth("/title.html", "user", "pass");
-    BrowserContext context = getBrowser().newContext(new Browser.NewContextOptions()
+    server.setAuth("/title.html", "user", "pass");
+    BrowserContext context = browser.newContext(new Browser.NewContextOptions()
       .setHttpCredentials("user", "pass"));
     Page page = context.newPage();
-    page.navigate(getServer().EMPTY_PAGE);
+    page.navigate(server.EMPTY_PAGE);
     Page popup = page.waitForPopup(() -> page.evaluate(
-      "url => window['_popup'] = window.open(url)", getServer().PREFIX + "/title.html"));
+      "url => window['_popup'] = window.open(url)", server.PREFIX + "/title.html"));
     popup.waitForLoadState(DOMCONTENTLOADED);
     assertEquals("Woof-Woof", popup.title());
     context.close();
@@ -107,11 +107,11 @@ public class TestPopup extends TestBase {
 
   @Test
   void shouldInheritTouchSupportFromBrowserContext() {
-    BrowserContext context = getBrowser().newContext(new Browser.NewContextOptions()
+    BrowserContext context = browser.newContext(new Browser.NewContextOptions()
       .setViewportSize(400, 500)
       .setHasTouch(true));
     Page page = context.newPage();
-    page.navigate(getServer().EMPTY_PAGE);
+    page.navigate(server.EMPTY_PAGE);
     Object hasTouch = page.evaluate("() => {\n" +
       "  const win = window.open('');\n" +
       "  return 'ontouchstart' in win;\n" +
@@ -122,10 +122,10 @@ public class TestPopup extends TestBase {
 
   @Test
   void shouldInheritViewportSizeFromBrowserContext() {
-    BrowserContext context = getBrowser().newContext(new Browser.NewContextOptions()
+    BrowserContext context = browser.newContext(new Browser.NewContextOptions()
       .setViewportSize(400, 500));
     Page page = context.newPage();
-    page.navigate(getServer().EMPTY_PAGE);
+    page.navigate(server.EMPTY_PAGE);
     Object size = page.evaluate("() => {\n" +
       "  const win = window.open('about:blank');\n" +
       "  return { width: win.innerWidth, height: win.innerHeight };\n" +
@@ -136,10 +136,10 @@ public class TestPopup extends TestBase {
 
   @Test
   void shouldUseViewportSizeFromWindowFeatures() {
-    BrowserContext context = getBrowser().newContext(new Browser.NewContextOptions()
+    BrowserContext context = browser.newContext(new Browser.NewContextOptions()
       .setViewportSize(700, 700));
     Page page = context.newPage();
-    page.navigate(getServer().EMPTY_PAGE);
+    page.navigate(server.EMPTY_PAGE);
     Object[] size = {null};
     Page popup = page.waitForPopup(() -> {
       size[0] = page.evaluate("() => {\n" +
@@ -157,16 +157,16 @@ public class TestPopup extends TestBase {
 
   @Test
   void shouldRespectRoutesFromBrowserContextWithWindowOpen() {
-    BrowserContext context = getBrowser().newContext();
+    BrowserContext context = browser.newContext();
     Page page = context.newPage();
-    page.navigate(getServer().EMPTY_PAGE);
+    page.navigate(server.EMPTY_PAGE);
     boolean[] intercepted = {false};
     context.route("**/empty.html", route -> {
       route.resume();
       intercepted[0] = true;
     });
     page.waitForPopup(() -> {
-      page.evaluate("url => window['__popup'] = window.open(url)", getServer().EMPTY_PAGE);
+      page.evaluate("url => window['__popup'] = window.open(url)", server.EMPTY_PAGE);
     });
     assertTrue(intercepted[0]);
     context.close();
@@ -174,10 +174,10 @@ public class TestPopup extends TestBase {
 
   @Test
   void BrowserContextAddInitScriptShouldApplyToAnInProcessPopup() {
-    BrowserContext context = getBrowser().newContext();
+    BrowserContext context = browser.newContext();
     context.addInitScript("window['injected'] = 123");
     Page page = context.newPage();
-    page.navigate(getServer().EMPTY_PAGE);
+    page.navigate(server.EMPTY_PAGE);
     Object injected = page.evaluate("() => {\n" +
       "  const win = window.open('about:blank');\n" +
       "  return win['injected'];\n" +
@@ -188,12 +188,12 @@ public class TestPopup extends TestBase {
 
   @Test
   void BrowserContextAddInitScriptShouldApplyToACrossProcessPopup() {
-    BrowserContext context = getBrowser().newContext();
+    BrowserContext context = browser.newContext();
     context.addInitScript("(() => window['injected'] = 123)()");
     Page page = context.newPage();
-    page.navigate(getServer().EMPTY_PAGE);
+    page.navigate(server.EMPTY_PAGE);
     Page popup = page.waitForPopup(() -> {
-      page.evaluate("url => window.open(url)", getServer().CROSS_PROCESS_PREFIX + "/title.html");
+      page.evaluate("url => window.open(url)", server.CROSS_PROCESS_PREFIX + "/title.html");
     });
     assertEquals(123, popup.evaluate("injected"));
 
@@ -205,7 +205,7 @@ public class TestPopup extends TestBase {
 
   @Test
   void shouldExposeFunctionFromBrowserContext() {
-    BrowserContext context = getBrowser().newContext();
+    BrowserContext context = browser.newContext();
     List<String> messages = new ArrayList<>();
     context.exposeFunction("add", args -> {
       messages.add("binding");
@@ -213,7 +213,7 @@ public class TestPopup extends TestBase {
     });
     Page page = context.newPage();
 //    context.on("page", () => messages.push('page'));
-    page.navigate(getServer().EMPTY_PAGE);
+    page.navigate(server.EMPTY_PAGE);
     Object added = page.evaluate("async () => {\n" +
       "  const win = window.open('about:blank');\n" +
       "  return win['add'](9, 4);\n" +

--- a/playwright/src/test/java/com/microsoft/playwright/TestQuerySelector.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestQuerySelector.java
@@ -113,7 +113,7 @@ public class TestQuerySelector extends TestBase {
 
   @Test
   void shouldReturnEmptyArrayIfNothingIsFound() {
-    page.navigate(getServer().EMPTY_PAGE);
+    page.navigate(server.EMPTY_PAGE);
     List<ElementHandle> elements = page.querySelectorAll("div");
     assertEquals(0, elements.size());
   }

--- a/playwright/src/test/java/com/microsoft/playwright/TestRequestContinue.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestRequestContinue.java
@@ -32,7 +32,7 @@ public class TestRequestContinue extends TestBase {
   @Test
   void shouldWork() {
     page.route("**/*", route -> route.resume());
-    page.navigate(getServer().EMPTY_PAGE);
+    page.navigate(server.EMPTY_PAGE);
   }
 
   @Test
@@ -42,18 +42,18 @@ public class TestRequestContinue extends TestBase {
       headers.put("FOO", "bar");
       route.resume(new Route.ResumeOptions().setHeaders(headers));
     });
-    page.navigate(getServer().EMPTY_PAGE);
-    Future<Server.Request> request = getServer().futureRequest("/sleep.zzz");
+    page.navigate(server.EMPTY_PAGE);
+    Future<Server.Request> request = server.futureRequest("/sleep.zzz");
     page.evaluate("() => fetch('/sleep.zzz')");
     assertEquals(Arrays.asList("bar"), request.get().headers.get("foo"));
   }
 
   @Test
   void shouldAmendMethod() throws ExecutionException, InterruptedException {
-    Future<Server.Request> sRequest = getServer().futureRequest("/sleep.zzz");
-    page.navigate(getServer().EMPTY_PAGE);
+    Future<Server.Request> sRequest = server.futureRequest("/sleep.zzz");
+    page.navigate(server.EMPTY_PAGE);
     page.route("**/*", route -> route.resume(new Route.ResumeOptions().setMethod("POST")));
-    Future<Server.Request> request = getServer().futureRequest("/sleep.zzz");
+    Future<Server.Request> request = server.futureRequest("/sleep.zzz");
     page.evaluate("() => fetch('/sleep.zzz')");
     assertEquals("POST", request.get().method);
     assertEquals("POST", sRequest.get().method);
@@ -61,12 +61,12 @@ public class TestRequestContinue extends TestBase {
 
   @Test
   void shouldOverrideRequestUrl() throws ExecutionException, InterruptedException {
-    Future<Server.Request> serverRequest = getServer().futureRequest("/global-var.html");
+    Future<Server.Request> serverRequest = server.futureRequest("/global-var.html");
     page.route("**/foo", route -> {
-      route.resume(new Route.ResumeOptions().setUrl(getServer().PREFIX + "/global-var.html"));
+      route.resume(new Route.ResumeOptions().setUrl(server.PREFIX + "/global-var.html"));
     });
-    Response response = page.navigate(getServer().PREFIX + "/foo");
-    assertEquals(getServer().PREFIX + "/foo", response.url());
+    Response response = page.navigate(server.PREFIX + "/foo");
+    assertEquals(server.PREFIX + "/foo", response.url());
     assertEquals(123, page.evaluate("window['globalVar']"));
     assertEquals("GET", serverRequest.get().method);
   }
@@ -82,47 +82,47 @@ public class TestRequestContinue extends TestBase {
         route.resume();
       }
     });
-    page.navigate(getServer().EMPTY_PAGE);
+    page.navigate(server.EMPTY_PAGE);
     assertNotNull(error[0]);
     assertTrue(error[0].getMessage().contains("New URL must have same protocol as overridden URL"), error[0].getMessage());
   }
 
   @Test
   void shouldOverrideMethodAlongWithUrl() throws ExecutionException, InterruptedException {
-    Future<Server.Request> serverRequest = getServer().futureRequest("/empty.html");
+    Future<Server.Request> serverRequest = server.futureRequest("/empty.html");
     page.route("**/foo", route -> {
-      route.resume(new Route.ResumeOptions().setUrl(getServer().EMPTY_PAGE).setMethod("POST"));
+      route.resume(new Route.ResumeOptions().setUrl(server.EMPTY_PAGE).setMethod("POST"));
     });
-    page.navigate(getServer().PREFIX + "/foo");
+    page.navigate(server.PREFIX + "/foo");
     assertEquals("POST", serverRequest.get().method);
   }
 
   @Test
   void shouldAmendMethodOnMainRequest() throws ExecutionException, InterruptedException {
-    Future<Server.Request> request = getServer().futureRequest("/empty.html");
+    Future<Server.Request> request = server.futureRequest("/empty.html");
     page.route("**/*", route -> route.resume(new Route.ResumeOptions().setMethod("POST")));
-    page.navigate(getServer().EMPTY_PAGE);
+    page.navigate(server.EMPTY_PAGE);
     assertEquals("POST", request.get().method);
   }
 
   @Test
   void shouldAmendPostData() throws ExecutionException, InterruptedException {
-    page.navigate(getServer().EMPTY_PAGE);
+    page.navigate(server.EMPTY_PAGE);
     page.route("**/*", route -> {
       route.resume(new Route.ResumeOptions().setPostData("doggo"));
     });
-    Future<Server.Request> serverRequest = getServer().futureRequest("/sleep.zzz");
+    Future<Server.Request> serverRequest = server.futureRequest("/sleep.zzz");
     page.evaluate("() => fetch('/sleep.zzz', { method: 'POST', body: 'birdy' })");
     assertEquals("doggo", new String(serverRequest.get().postBody, UTF_8));
   }
 
   @Test
   void shouldAmendUtf8PostData() throws ExecutionException, InterruptedException {
-    page.navigate(getServer().EMPTY_PAGE);
+    page.navigate(server.EMPTY_PAGE);
     page.route("**/*", route -> {
       route.resume(new Route.ResumeOptions().setPostData("пушкин"));
     });
-    Future<Server.Request> serverRequest = getServer().futureRequest("/sleep.zzz");
+    Future<Server.Request> serverRequest = server.futureRequest("/sleep.zzz");
     page.evaluate("() => fetch('/sleep.zzz', { method: 'POST', body: 'birdy' })");
     assertEquals("POST", serverRequest.get().method);
     assertEquals("пушкин", new String(serverRequest.get().postBody, UTF_8));
@@ -130,11 +130,11 @@ public class TestRequestContinue extends TestBase {
 
   @Test
   void shouldAmendLongerPostData() throws ExecutionException, InterruptedException {
-    page.navigate(getServer().EMPTY_PAGE);
+    page.navigate(server.EMPTY_PAGE);
     page.route("**/*", route -> {
       route.resume(new Route.ResumeOptions().setPostData("doggo-is-longer-than-birdy"));
     });
-    Future<Server.Request> serverRequest = getServer().futureRequest("/sleep.zzz");
+    Future<Server.Request> serverRequest = server.futureRequest("/sleep.zzz");
     page.evaluate("() => fetch('/sleep.zzz', { method: 'POST', body: 'birdy' })");
     assertEquals("POST", serverRequest.get().method);
     assertEquals("doggo-is-longer-than-birdy", new String(serverRequest.get().postBody, UTF_8));
@@ -142,7 +142,7 @@ public class TestRequestContinue extends TestBase {
 
   @Test
   void shouldAmendBinaryPostData() throws ExecutionException, InterruptedException {
-    page.navigate(getServer().EMPTY_PAGE);
+    page.navigate(server.EMPTY_PAGE);
     byte[] arr = new byte[256];
     for (int i = 0; i < arr.length; i++) {
       arr[i] = (byte) i;
@@ -150,7 +150,7 @@ public class TestRequestContinue extends TestBase {
     page.route("**/*", route -> {
       route.resume(new Route.ResumeOptions().setPostData(arr));
     });
-    Future<Server.Request> serverRequest = getServer().futureRequest("/sleep.zzz");
+    Future<Server.Request> serverRequest = server.futureRequest("/sleep.zzz");
     page.evaluate("() => fetch('/sleep.zzz', { method: 'POST', body: 'birdy' })");
     assertEquals("POST", serverRequest.get().method);
     byte[] buffer = serverRequest.get().postBody;

--- a/playwright/src/test/java/com/microsoft/playwright/TestRequestFulfill.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestRequestFulfill.java
@@ -36,7 +36,7 @@ public class TestRequestFulfill extends TestBase {
         .setHeaders(mapOf("foo", "bar"))
         .setBody("Yo, page!"));
     });
-    Response response = page.navigate(getServer().EMPTY_PAGE);
+    Response response = page.navigate(server.EMPTY_PAGE);
     assertEquals(201, response.status());
     assertEquals("bar", response.headers().get("foo"));
     assertEquals("Yo, page!", page.evaluate("() => document.body.textContent"));
@@ -49,7 +49,7 @@ public class TestRequestFulfill extends TestBase {
         .setStatus(422)
         .setBody("Yo, page!"));
     });
-    Response response = page.navigate(getServer().EMPTY_PAGE);
+    Response response = page.navigate(server.EMPTY_PAGE);
     assertEquals(422, response.status());
     assertEquals("Unprocessable Entity", response.statusText());
     assertEquals("Yo, page!", page.evaluate("document.body.textContent"));
@@ -79,7 +79,7 @@ public class TestRequestFulfill extends TestBase {
       "  img.src = PREFIX + '/does-not-exist.png';\n" +
       "  document.body.appendChild(img);\n" +
       "  return new Promise(fulfill => img.onload = fulfill);\n" +
-      "}", getServer().PREFIX);
+      "}", server.PREFIX);
     ElementHandle img = page.querySelector("img");
 //    expect(img.screenshot()).toMatchSnapshot("mock-binary-response.png");
   }
@@ -98,7 +98,7 @@ public class TestRequestFulfill extends TestBase {
       "  img.src = PREFIX + '/does-not-exist.svg';\n" +
       "  document.body.appendChild(img);\n" +
       "  return new Promise((f, r) => { img.onload = f; img.onerror = r; });\n" +
-      "}", getServer().PREFIX);
+      "}", server.PREFIX);
     ElementHandle img = page.querySelector("img");
 //    expect(img.screenshot()).toMatchSnapshot("mock-svg.png");
   }

--- a/playwright/src/test/java/com/microsoft/playwright/TestScreencast.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestScreencast.java
@@ -27,7 +27,7 @@ import static org.junit.jupiter.api.Assertions.*;
 public class TestScreencast extends TestBase {
   @Test
   void shouldExposeVideoPath(@TempDir Path videosDir) {
-    BrowserContext context = getBrowser().newContext(new Browser.NewContextOptions()
+    BrowserContext context = browser.newContext(new Browser.NewContextOptions()
       .setRecordVideoDir(videosDir).setRecordVideoSize(320, 240)
       .setViewportSize(320, 240));
     Page page = context.newPage();
@@ -40,7 +40,7 @@ public class TestScreencast extends TestBase {
 
   @Test
   void shouldSaveAsVideo(@TempDir Path videosDir) {
-    BrowserContext context = getBrowser().newContext(
+    BrowserContext context = browser.newContext(
       new Browser.NewContextOptions()
         .setRecordVideoDir(videosDir)
         .setRecordVideoSize(320, 240)
@@ -57,7 +57,7 @@ public class TestScreencast extends TestBase {
 
   @Test
   void saveAsShouldThrowWhenNoVideoFrames(@TempDir Path videosDir) {
-    BrowserContext context = getBrowser().newContext(
+    BrowserContext context = browser.newContext(
       new Browser.NewContextOptions()
         .setRecordVideoDir(videosDir)
         .setRecordVideoSize(320, 240)
@@ -87,7 +87,7 @@ public class TestScreencast extends TestBase {
 
   @Test
   void shouldDeleteVideo(@TempDir Path videosDir) {
-    BrowserContext context = getBrowser().newContext(
+    BrowserContext context = browser.newContext(
       new Browser.NewContextOptions()
         .setRecordVideoDir(videosDir)
         .setRecordVideoSize(320, 240)

--- a/playwright/src/test/java/com/microsoft/playwright/TestSelectorsCss.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestSelectorsCss.java
@@ -72,7 +72,7 @@ public class TestSelectorsCss extends TestBase {
 
   @Test
   void shouldWorkForOpenShadowRoots() {
-    page.navigate(getServer().PREFIX + "/deep-shadow.html");
+    page.navigate(server.PREFIX + "/deep-shadow.html");
     assertEquals("Hello from root1", page.evalOnSelector("css=span", "e => e.textContent"));
     assertEquals("Hello from root3 #2", page.evalOnSelector("css=[attr=\"value\\ space\"]", "e => e.textContent"));
     assertEquals("Hello from root3 #2", page.evalOnSelector("css=[attr='value\\ \\space']", "e => e.textContent"));
@@ -121,7 +121,7 @@ public class TestSelectorsCss extends TestBase {
 
   @Test
   void shouldWorkWithCommaSeparatedList() {
-    page.navigate(getServer().PREFIX + "/deep-shadow.html");
+    page.navigate(server.PREFIX + "/deep-shadow.html");
     assertEquals(5, page.evalOnSelectorAll("css=span,section #root1", "els => els.length"));
     assertEquals(5, page.evalOnSelectorAll("css=section #root1, div span", "els => els.length"));
     assertEquals("root1", page.evalOnSelector("css=doesnotexist , section #root1", "e => e.id"));
@@ -260,7 +260,7 @@ public class TestSelectorsCss extends TestBase {
 
   @Test
   void shouldWorkWithColonNthChild(){
-    page.navigate(getServer().PREFIX + "/deep-shadow.html");
+    page.navigate(server.PREFIX + "/deep-shadow.html");
     assertEquals(3, page.evalOnSelectorAll("css=span:nth-child(odd)", "els => els.length"));
     assertEquals(1, page.evalOnSelectorAll("css=span:nth-child(even)", "els => els.length"));
     assertEquals(4, page.evalOnSelectorAll("css=span:nth-child(n+1)", "els => els.length"));
@@ -275,7 +275,7 @@ public class TestSelectorsCss extends TestBase {
 
   @Test
   void shouldWorkWithColonNot() {
-    page.navigate(getServer().PREFIX + "/deep-shadow.html");
+    page.navigate(server.PREFIX + "/deep-shadow.html");
     assertEquals(2, page.evalOnSelectorAll("css=div:not(#root1)", "els => els.length"));
     assertEquals(4, page.evalOnSelectorAll("css=body :not(span)", "els => els.length"));
     assertEquals(0, page.evalOnSelectorAll("css=div > :not(span):not(div)", "els => els.length"));
@@ -328,7 +328,7 @@ public class TestSelectorsCss extends TestBase {
 
   @Test
   void shouldWorkWithSpacesInColonNthChildAndColonNot() {
-    page.navigate(getServer().PREFIX + "/deep-shadow.html");
+    page.navigate(server.PREFIX + "/deep-shadow.html");
     assertEquals(1, page.evalOnSelectorAll("css=span:nth-child(23n +2)", "els => els.length"));
     assertEquals(1, page.evalOnSelectorAll("css=span:nth-child(23n+ 2)", "els => els.length"));
     assertEquals(1, page.evalOnSelectorAll("css=span:nth-child( 23n + 2 )", "els => els.length"));
@@ -343,7 +343,7 @@ public class TestSelectorsCss extends TestBase {
 
   @Test
   void shouldWorkWithColonIs() {
-    page.navigate(getServer().PREFIX + "/deep-shadow.html");
+    page.navigate(server.PREFIX + "/deep-shadow.html");
     assertEquals(1, page.evalOnSelectorAll("css=div:is(#root1)", "els => els.length"));
     assertEquals(1, page.evalOnSelectorAll("css=div:is(#root1, #target)", "els => els.length"));
     assertEquals(0, page.evalOnSelectorAll("css=div:is(span, #target)", "els => els.length"));
@@ -358,7 +358,7 @@ public class TestSelectorsCss extends TestBase {
 
   @Test
   void shouldWorkWithColonHas() {
-    page.navigate(getServer().PREFIX + "/deep-shadow.html");
+    page.navigate(server.PREFIX + "/deep-shadow.html");
     assertEquals(2, page.evalOnSelectorAll("css=div:has(#target)", "els => els.length"));
     assertEquals(3, page.evalOnSelectorAll("css=div:has([data-testid=foo])", "els => els.length"));
     assertEquals(2, page.evalOnSelectorAll("css=div:has([attr*=value])", "els => els.length"));
@@ -366,7 +366,7 @@ public class TestSelectorsCss extends TestBase {
 
   @Test
   void shouldWorkWithColonScope() {
-    page.navigate(getServer().PREFIX + "/deep-shadow.html");
+    page.navigate(server.PREFIX + "/deep-shadow.html");
     // 'is' does not change the scope, so it remains 'html'.
     assertEquals(0, page.evalOnSelectorAll("css=div:is(:scope#root1)", "els => els.length"));
     assertEquals(1, page.evalOnSelectorAll("css=div:is(:scope #root1)", "els => els.length"));

--- a/playwright/src/test/java/com/microsoft/playwright/TestSelectorsRegister.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestSelectorsRegister.java
@@ -37,11 +37,11 @@ public class TestSelectorsRegister extends TestBase {
       "  }\n" +
       "}";
     // Register one engine before creating context.
-    getPlaywright().selectors().register("tag", selectorScript);
+    playwright.selectors().register("tag", selectorScript);
 
-    BrowserContext context = getBrowser().newContext();
+    BrowserContext context = browser.newContext();
     // Register another engine after creating context.
-    getPlaywright().selectors().register("tag2", selectorScript);
+    playwright.selectors().register("tag2", selectorScript);
 
     Page page = context.newPage();
     page.setContent("<div><span></span></div><div></div>");
@@ -65,7 +65,7 @@ public class TestSelectorsRegister extends TestBase {
 
   @Test
   void shouldWorkWithPath() {
-    getPlaywright().selectors().register("foo", Paths.get("src/test/resources/sectionselectorengine.js"));
+    playwright.selectors().register("foo", Paths.get("src/test/resources/sectionselectorengine.js"));
     page.setContent("<section></section>");
     assertEquals("SECTION", page.evalOnSelector("foo=whatever", "e => e.nodeName"));
   }
@@ -81,8 +81,8 @@ public class TestSelectorsRegister extends TestBase {
       "    return window['__answer'] ? [window['__answer'], document.body, document.documentElement] : [];\n" +
       "  }\n" +
       "}";
-    getPlaywright().selectors().register("main", createDummySelector);
-    getPlaywright().selectors().register("isolated", createDummySelector, new Selectors.RegisterOptions().setContentScript(true));
+    playwright.selectors().register("main", createDummySelector);
+    playwright.selectors().register("isolated", createDummySelector, new Selectors.RegisterOptions().setContentScript(true));
     page.setContent("<div><span><section></section></span></div>");
     page.evaluate("() => window['__answer'] = document.querySelector('span')");
     // Works in main if asked.
@@ -123,22 +123,22 @@ public class TestSelectorsRegister extends TestBase {
       "  }\n" +
       "}";
     try {
-      getPlaywright().selectors().register("$", createDummySelector);
+      playwright.selectors().register("$", createDummySelector);
       fail("did not throw");
     } catch (PlaywrightException e) {
       assertTrue(e.getMessage().contains("Selector engine name may only contain [a-zA-Z0-9_] characters"));
     }
     // Selector names are case-sensitive.
-    getPlaywright().selectors().register("dummy", createDummySelector);
-    getPlaywright().selectors().register("duMMy", createDummySelector);
+    playwright.selectors().register("dummy", createDummySelector);
+    playwright.selectors().register("duMMy", createDummySelector);
     try {
-      getPlaywright().selectors().register("dummy", createDummySelector);
+      playwright.selectors().register("dummy", createDummySelector);
       fail("did not throw");
     } catch (PlaywrightException e) {
       assertTrue(e.getMessage().contains("\"dummy\" selector engine has been already registered"));
     }
     try {
-      getPlaywright().selectors().register("css", createDummySelector);
+      playwright.selectors().register("css", createDummySelector);
       fail("did not throw");
     } catch (PlaywrightException e) {
       assertTrue(e.getMessage().contains("\"css\" is a predefined selector engine"));

--- a/playwright/src/test/java/com/microsoft/playwright/TestTap.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestTap.java
@@ -33,7 +33,7 @@ public class TestTap extends TestBase {
 
   @Override
   BrowserContext createContext() {
-    return getBrowser().newContext(new Browser.NewContextOptions().setHasTouch(true));
+    return browser.newContext(new Browser.NewContextOptions().setHasTouch(true));
   }
 
   private JSHandle trackEvents(ElementHandle target) {
@@ -97,11 +97,11 @@ public class TestTap extends TestBase {
 
   @Test
   void shouldWaitForANavigationCausedByATap() throws InterruptedException {
-    page.navigate(getServer().EMPTY_PAGE);
+    page.navigate(server.EMPTY_PAGE);
     page.setContent("<a href='/intercept-this.html'>link</a>;");
     Semaphore responseWritten = new Semaphore(0);
     List<String> events = Collections.synchronizedList(new ArrayList<>());
-    getServer().setRoute("/intercept-this.html", exchange -> {
+    server.setRoute("/intercept-this.html", exchange -> {
       // make sure the tap doesnt resolve too early
       try {
         Thread.sleep(100);

--- a/playwright/src/test/java/com/microsoft/playwright/TestTracing.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestTracing.java
@@ -27,8 +27,16 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestTracing extends TestBase {
 
+  @Override
   @BeforeAll
-  static void launchBrowser(@TempDir Path tempDir) {
+  void launchBrowser() {
+    // The method is replaced by the method below (with temp dir as extra parameter,
+    // we cannot declare temp dir field as it would be initialized too late).
+  }
+
+  @BeforeAll
+  void launchBrowser(@TempDir Path tempDir) {
+    System.out.println("new launchBrowser(");
     BrowserType.LaunchOptions options = createLaunchOptions();
     options.setTraceDir(tempDir.resolve("trace-dir"));
     launchBrowser(options);
@@ -38,7 +46,7 @@ public class TestTracing extends TestBase {
   void shouldCollectTrace1(@TempDir Path tempDir) {
     context.tracing().start(new Tracing.StartOptions().setName("test")
       .setScreenshots(true).setSnapshots(true));
-    page.navigate(getServer().EMPTY_PAGE);
+    page.navigate(server.EMPTY_PAGE);
     page.setContent("<button>Click</button>");
     page.click("'Click'");
     page.close();
@@ -53,7 +61,7 @@ public class TestTracing extends TestBase {
   void shouldCollectTwoTraces(@TempDir Path tempDir) {
     context.tracing().start(new Tracing.StartOptions().setName("test1")
       .setScreenshots(true).setSnapshots(true));
-    page.navigate(getServer().EMPTY_PAGE);
+    page.navigate(server.EMPTY_PAGE);
     page.setContent("<button>Click</button>");
     page.click("'Click'");
     context.tracing().stop();

--- a/playwright/src/test/java/com/microsoft/playwright/TestWaitForFunction.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestWaitForFunction.java
@@ -136,8 +136,8 @@ public class TestWaitForFunction extends TestBase {
 
   @Test
   void shouldWorkWithStrictCSPPolicy() {
-    getServer().setCSP("/empty.html", "script-src " + getServer().PREFIX);
-    page.navigate(getServer().EMPTY_PAGE);
+    server.setCSP("/empty.html", "script-src " + server.PREFIX);
+    page.navigate(server.EMPTY_PAGE);
 
     page.evaluate("() => window['__FOO'] = 'hit'");
     page.waitForFunction("() => window['__FOO'] === 'hit'");
@@ -206,9 +206,9 @@ public class TestWaitForFunction extends TestBase {
 
   @Test
   void shouldSurviveCrossProcessNavigation() {
-    page.navigate(getServer().EMPTY_PAGE);
+    page.navigate(server.EMPTY_PAGE);
     page.reload();
-    page.navigate(getServer().CROSS_PROCESS_PREFIX + "/grid.html");
+    page.navigate(server.CROSS_PROCESS_PREFIX + "/grid.html");
     page.evaluate("() => window['__FOO'] = 1");
     JSHandle result = page.waitForFunction("window.__FOO === 1");
     assertNotNull(result);
@@ -216,8 +216,8 @@ public class TestWaitForFunction extends TestBase {
 
   @Test
   void shouldSurviveNavigations() {
-    page.navigate(getServer().EMPTY_PAGE);
-    page.navigate(getServer().PREFIX + "/consolelog.html");
+    page.navigate(server.EMPTY_PAGE);
+    page.navigate(server.PREFIX + "/consolelog.html");
     page.evaluate("() => window['__done'] = true");
     page.waitForFunction("() => window['__done']");
   }
@@ -236,7 +236,7 @@ public class TestWaitForFunction extends TestBase {
 
     @Test
     void shouldNotBeCalledAfterFinishingSuccessfully() {
-      page.navigate(getServer().EMPTY_PAGE);
+      page.navigate(server.EMPTY_PAGE);
       List<String> messages = new ArrayList<>();
       page.onConsoleMessage(msg -> {
         if (msg.text().startsWith("waitForFunction")) {
@@ -262,7 +262,7 @@ public class TestWaitForFunction extends TestBase {
 
   @Test
   void shouldNotBeCalledAfterFinishingUnsuccessfully() {
-    page.navigate(getServer().EMPTY_PAGE);
+    page.navigate(server.EMPTY_PAGE);
     List<String> messages = new ArrayList<>();
     page.onConsoleMessage(msg -> {
       if (msg.text().startsWith("waitForFunction")) {

--- a/playwright/src/test/java/com/microsoft/playwright/TestWebSocket.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestWebSocket.java
@@ -150,7 +150,7 @@ public class TestWebSocket extends TestBase {
     });
     page.evaluate("port => {\n" +
       "  new WebSocket('ws://localhost:' + port + '/bogus-ws');\n" +
-      "}", getServer().PORT);
+      "}", server.PORT);
     waitForCondition(socketError);
     if (isFirefox()) {
       assertEquals("CLOSE_ABNORMAL", error[0]);

--- a/playwright/src/test/java/com/microsoft/playwright/TestWorkers.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestWorkers.java
@@ -30,11 +30,10 @@ public class TestWorkers extends TestBase {
 
   @Test
   void pageWorkers() {
-    Worker worker = page.waitForWorker(() ->
-      page.navigate(getServer().PREFIX + "/worker/worker.html"));
+    Worker worker = page.waitForWorker(() -> page.navigate(server.PREFIX + "/worker/worker.html"));
     assertTrue(worker.url().contains("worker.js"));
     assertEquals("worker function result", worker.evaluate("() => self['workerFunction']()"));
-    page.navigate(getServer().EMPTY_PAGE);
+    page.navigate(server.EMPTY_PAGE);
     assertEquals(0, page.workers().size());
   }
 
@@ -101,24 +100,24 @@ public class TestWorkers extends TestBase {
   @Test
   @DisabledIf(value="com.microsoft.playwright.TestBase#isFirefox", disabledReason="flaky upstream")
   void shouldClearUponNavigation() {
-    page.navigate(getServer().EMPTY_PAGE);
+    page.navigate(server.EMPTY_PAGE);
     Worker worker = page.waitForWorker(() -> page.evaluate(
       "() => new Worker(URL.createObjectURL(new Blob(['console.log(1)'], {type: 'application/javascript'})))"));
     assertEquals(1, page.workers().size());
-    Worker destroyed = worker.waitForClose(() -> page.navigate(getServer().PREFIX + "/one-style.html"));
+    Worker destroyed = worker.waitForClose(() -> page.navigate(server.PREFIX + "/one-style.html"));
     assertEquals(worker, destroyed);
     assertEquals(0, page.workers().size());
   }
 
   @Test
   void shouldClearUponCrossProcessNavigation() {
-    page.navigate(getServer().EMPTY_PAGE);
+    page.navigate(server.EMPTY_PAGE);
     Worker worker = page.waitForWorker(() -> page.evaluate(
       "() => new Worker(URL.createObjectURL(new Blob(['console.log(1)'], {type: 'application/javascript'})))"));
     assertEquals(1, page.workers().size());
     boolean[] destroyed = {false};
     worker.onClose(worker1 -> destroyed[0] = true);
-    page.navigate(getServer().CROSS_PROCESS_PREFIX + "/empty.html");
+    page.navigate(server.CROSS_PROCESS_PREFIX + "/empty.html");
     assertTrue(destroyed[0]);
     assertEquals(0, page.workers().size());
   }
@@ -126,13 +125,13 @@ public class TestWorkers extends TestBase {
   @Test
   @EnabledIf(value="com.microsoft.playwright.TestBase#isWebKit", disabledReason="fixme")
   void shouldAttributeNetworkActivityForWorkerInsideIframeToTheIframe() {
-    page.navigate(getServer().PREFIX + "/empty.html");
+    page.navigate(server.PREFIX + "/empty.html");
     Frame[] frame = {null};
     Worker worker = page.waitForWorker(() -> {
-      frame[0] = attachFrame(page, "frame1", getServer().PREFIX + "/worker/worker.html");
+      frame[0] = attachFrame(page, "frame1", server.PREFIX + "/worker/worker.html");
     });
     assertNotNull(frame[0]);
-    String url = getServer().PREFIX + "/one-style.css";
+    String url = server.PREFIX + "/one-style.css";
     Request request = page.waitForRequest(url, () -> {
       worker.evaluate("url => fetch(url).then(response => response.text()).then(console.log)", url);
     });
@@ -142,8 +141,8 @@ public class TestWorkers extends TestBase {
 
   @Test
   void shouldReportNetworkActivity() {
-    Worker worker = page.waitForWorker(() -> page.navigate(getServer().PREFIX + "/worker/worker.html"));
-    String url = getServer().PREFIX + "/one-style.css";
+    Worker worker = page.waitForWorker(() -> page.navigate(server.PREFIX + "/worker/worker.html"));
+    String url = server.PREFIX + "/one-style.css";
     Request[] request = {null};
     Response response = page.waitForResponse(url, () -> {
       request[0] = page.waitForRequest(url, () -> {
@@ -158,8 +157,8 @@ public class TestWorkers extends TestBase {
   @Test
   void shouldReportNetworkActivityOnWorkerCreation() {
     // Chromium needs waitForDebugger enabled for this one.
-    page.navigate(getServer().EMPTY_PAGE);
-    String url = getServer().PREFIX + "/one-style.css";
+    page.navigate(server.EMPTY_PAGE);
+    String url = server.PREFIX + "/one-style.css";
     Request[] request = {null};
     Response response = page.waitForResponse(url, () -> {
       request[0] = page.waitForRequest(url, () -> {
@@ -175,9 +174,9 @@ public class TestWorkers extends TestBase {
 
   @Test
   void shouldFormatNumberUsingContextLocale() {
-    BrowserContext context = getBrowser().newContext(new Browser.NewContextOptions().setLocale("ru-RU"));
+    BrowserContext context = browser.newContext(new Browser.NewContextOptions().setLocale("ru-RU"));
     Page page = context.newPage();
-    page.navigate(getServer().EMPTY_PAGE);
+    page.navigate(server.EMPTY_PAGE);
     Worker worker = page.waitForWorker(() -> page.evaluate(
       "() => new Worker(URL.createObjectURL(new Blob(['console.log(1)'], {type: 'application/javascript'})))"));
     assertEquals("10\u00A0000,2", worker.evaluate("() => (10000.20).toLocaleString()"));


### PR DESCRIPTION
Use [`@TestInstance`](https://junit.org/junit5/docs/current/api/org.junit.jupiter.api/org/junit/jupiter/api/TestInstance.html) annotation on the test classes to ensure one instance of a class is created for all its test methods. This way we safely get rid of static ThreadLocal fields by making them instance fields.