### PR TITLE
test: close file reader when done

### DIFF
--- a/playwright/src/test/java/com/microsoft/playwright/TestChromiumTracing.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestChromiumTracing.java
@@ -35,91 +35,92 @@ import static org.junit.jupiter.api.Assertions.*;
 public class TestChromiumTracing extends TestBase {
   @Test
   void shouldOutputATrace(@TempDir Path tempDir) {
-    Page page = browser.newPage();
-    Path outputTraceFile = tempDir.resolve("trace.json");
-    browser.startTracing(page, new Browser.StartTracingOptions()
-      .setScreenshots(true).setPath(outputTraceFile));
-    page.navigate(server.PREFIX + "/grid.html");
-    browser.stopTracing();
-    assertTrue(Files.exists(outputTraceFile));
-    page.close();
+    try (Page page = browser.newPage()) {
+      Path outputTraceFile = tempDir.resolve("trace.json");
+      browser.startTracing(page, new Browser.StartTracingOptions()
+        .setScreenshots(true).setPath(outputTraceFile));
+      page.navigate(server.PREFIX + "/grid.html");
+      browser.stopTracing();
+      assertTrue(Files.exists(outputTraceFile));
+    }
   }
 
   @Test
   void shouldCreateDirectoriesAsNeeded(@TempDir Path tempDir) {
-    Page page = browser.newPage();
-    Path filePath = tempDir.resolve("these/are/directories/trace.json");
-    browser.startTracing(page, new Browser.StartTracingOptions()
-      .setScreenshots(true).setPath(filePath));
-    page.navigate(server.PREFIX + "/grid.html");
-    browser.stopTracing();
-    assertTrue(Files.exists(filePath));
-    page.close();
+    try (Page page = browser.newPage()) {
+      Path filePath = tempDir.resolve("these/are/directories/trace.json");
+      browser.startTracing(page, new Browser.StartTracingOptions()
+        .setScreenshots(true).setPath(filePath));
+      page.navigate(server.PREFIX + "/grid.html");
+      browser.stopTracing();
+      assertTrue(Files.exists(filePath));
+    }
   }
 
   @Test
   void shouldRunWithCustomCategoriesIfProvided(@TempDir Path tempDir) throws IOException {
-    Page page = browser.newPage();
-    Path outputTraceFile = tempDir.resolve("trace.json");
-    browser.startTracing(page, new Browser.StartTracingOptions()
-      .setPath(outputTraceFile)
-      .setCategories(asList("disabled-by-default-v8.cpu_profiler.hires")));
-    browser.stopTracing();
-    byte[] data = Files.readAllBytes(outputTraceFile);
-    JsonObject traceJson = new Gson().fromJson(new FileReader(outputTraceFile.toFile()), JsonObject.class);
-    assertTrue(traceJson.getAsJsonObject("metadata").get("trace-config")
-      .getAsString().contains("disabled-by-default-v8.cpu_profiler.hires"));
-    page.close();
+    try (Page page = browser.newPage()) {
+      Path outputTraceFile = tempDir.resolve("trace.json");
+      browser.startTracing(page, new Browser.StartTracingOptions()
+        .setPath(outputTraceFile)
+        .setCategories(asList("disabled-by-default-v8.cpu_profiler.hires")));
+      browser.stopTracing();
+      try (FileReader fileReader = new FileReader(outputTraceFile.toFile())) {
+        JsonObject traceJson = new Gson().fromJson(fileReader, JsonObject.class);
+        assertTrue(traceJson.getAsJsonObject("metadata").get("trace-config")
+          .getAsString().contains("disabled-by-default-v8.cpu_profiler.hires"));
+      }
+    }
   }
 
   @Test
   void shouldThrowIfTracingOnTwoPages(@TempDir Path tempDir) {
-    Page page = browser.newPage();
-    Path outputTraceFile = tempDir.resolve("trace.json");
-    browser.startTracing(page, new Browser.StartTracingOptions()
+    try (Page page = browser.newPage()) {
+      Path outputTraceFile = tempDir.resolve("trace.json");
+      browser.startTracing(page, new Browser.StartTracingOptions()
         .setPath(outputTraceFile));
-    Page newPage = browser.newPage();
-    try {
-      browser.startTracing(newPage, new Browser.StartTracingOptions()
-        .setPath(outputTraceFile));
-      fail("did not throw");
-    } catch (PlaywrightException e) {
+      Page newPage = browser.newPage();
+      try {
+        browser.startTracing(newPage, new Browser.StartTracingOptions()
+          .setPath(outputTraceFile));
+        fail("did not throw");
+      } catch (PlaywrightException e) {
+      }
+      newPage.close();
+      browser.stopTracing();
     }
-    newPage.close();
-    browser.stopTracing();
-    page.close();
   }
 
   @Test
   void shouldReturnABuffer(@TempDir Path tempDir) throws IOException {
-    Page page = browser.newPage();
-    Path outputTraceFile = tempDir.resolve("trace.json");
-    browser.startTracing(page, new Browser.StartTracingOptions()
-      .setScreenshots(true).setPath(outputTraceFile));
-    page.navigate(server.PREFIX + "/grid.html");
-    byte[] trace = browser.stopTracing();
-    byte[] buf = Files.readAllBytes(outputTraceFile);
-    assertArrayEquals(buf, trace);
-    page.close();
+    try (Page page = browser.newPage()) {
+      Path outputTraceFile = tempDir.resolve("trace.json");
+      browser.startTracing(page, new Browser.StartTracingOptions()
+        .setScreenshots(true).setPath(outputTraceFile));
+      page.navigate(server.PREFIX + "/grid.html");
+      byte[] trace = browser.stopTracing();
+      byte[] buf = Files.readAllBytes(outputTraceFile);
+      assertArrayEquals(buf, trace);
+    }
   }
 
   @Test
   void shouldWorkWithoutOptions() {
-    Page page = browser.newPage();
-    browser.startTracing(page);
-    page.navigate(server.PREFIX + "/grid.html");
-    byte[] trace = browser.stopTracing();
-    assertNotNull(trace);
-    page.close();
+    try (Page page = browser.newPage()) {
+      browser.startTracing(page);
+      page.navigate(server.PREFIX + "/grid.html");
+      byte[] trace = browser.stopTracing();
+      assertNotNull(trace);
+    }
   }
 
   @Test
   void shouldSupportABufferWithoutAPath() {
-    Page page = browser.newPage();
-    browser.startTracing(page, new Browser.StartTracingOptions().setScreenshots(true));
-    page.navigate(server.PREFIX + "/grid.html");
-    byte[] trace = browser.stopTracing();
-    assertTrue(new String(trace, StandardCharsets.UTF_8).contains("screenshot"));
-    page.close();
+    try (Page page = browser.newPage()) {
+      browser.startTracing(page, new Browser.StartTracingOptions().setScreenshots(true));
+      page.navigate(server.PREFIX + "/grid.html");
+      byte[] trace = browser.stopTracing();
+      assertTrue(new String(trace, StandardCharsets.UTF_8).contains("screenshot"));
+    }
   }
 }


### PR DESCRIPTION
Should fix the following error:
```
Error:  Tests run: 2, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 16.072 s <<< FAILURE! - in com.microsoft.playwright.TestChromiumTracing
Error:  com.microsoft.playwright.TestChromiumTracing.shouldRunWithCustomCategoriesIfProvided(Path)  Time elapsed: 3.322 s  <<< ERROR!
java.io.IOException: Failed to delete temp directory C:\Users\RUNNER~1\AppData\Local\Temp\junit5012661792671279287. The following paths could not be deleted (see suppressed exceptions for details): , trace.json
```