### PR TITLE
test: disable test that flakes in Chromium

### DIFF
--- a/playwright/src/test/java/com/microsoft/playwright/TestNetworkRequest.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestNetworkRequest.java
@@ -28,8 +28,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.stream.Collectors;
 
-import static com.microsoft.playwright.Utils.attachFrame;
-import static com.microsoft.playwright.Utils.mapOf;
+import static com.microsoft.playwright.Utils.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class TestNetworkRequest extends TestBase {
@@ -102,8 +101,13 @@ public class TestNetworkRequest extends TestBase {
       assertTrue(response.request().headers().get("user-agent").contains("WebKit"));
   }
 
+
+  static boolean isWebKitWindowsOrChromium() {
+    return (isWebKit() && getOS() == Utils.OS.WINDOWS) || isChromium();
+  }
+
   @Test
-  @DisabledIf(value="com.microsoft.playwright.TestBase#isChromium", disabledReason="Flaky, see https://github.com/microsoft/playwright/issues/6690")
+  @DisabledIf(value="isWebKitWindowsOrChromium", disabledReason="Flaky, see https://github.com/microsoft/playwright/issues/6690")
   void shouldGetTheSameHeadersAsTheServer() throws ExecutionException, InterruptedException {
     Future<Server.Request> serverRequest = server.futureRequest("/empty.html");
     server.setRoute("/empty.html", exchange -> {

--- a/playwright/src/test/java/com/microsoft/playwright/TestNetworkRequest.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestNetworkRequest.java
@@ -103,7 +103,7 @@ public class TestNetworkRequest extends TestBase {
   }
 
   @Test
-  @DisabledIf(value="com.microsoft.playwright.TestBase#isWebKit", disabledReason="fail")
+  @DisabledIf(value="com.microsoft.playwright.TestBase#isChromium", disabledReason="Flaky, see https://github.com/microsoft/playwright/issues/6690")
   void shouldGetTheSameHeadersAsTheServer() throws ExecutionException, InterruptedException {
     Future<Server.Request> serverRequest = server.futureRequest("/empty.html");
     server.setRoute("/empty.html", exchange -> {


### PR DESCRIPTION
```
Error:  Failures: 
Error:    TestNetworkRequest.shouldGetTheSameHeadersAsTheServer:118 expected: <{sec-fetch-mode=navigate, sec-fetch-site=none, upgrade-insecure-requests=1, host=localhost:9102, connection=keep-alive, sec-fetch-user=?1, accept-encoding=gzip, deflate, br, user-agent=Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/92.0.4500.0 Safari/537.36, sec-fetch-dest=document, accept=text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9}> but was: <{upgrade-insecure-requests=1, user-agent=Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/92.0.4500.0 Safari/537.36}>
```

https://github.com/microsoft/playwright/issues/6690