### PR TITLE
feat: provide jbang-catalog to run playwright cli

### DIFF
--- a/jbang-catalog.json
+++ b/jbang-catalog.json
@@ -1,0 +1,10 @@
+{
+  "catalogs": {},
+  "aliases": {
+    "playwright": {
+      "script-ref": "scripts/playwright.java",
+      "description": "Playwright lets you automate Chromium, Firefox and Webkit with a single API. \nWith this cli you can install, trace, generate pdf and screenshots and more.\nExample on how to record and run a script:\n```\n  jbang playwright@microsoft/playwright-java codegen -o Example.java`\n  jbang --deps com.microsoft.playwright:playwright:RELEASE Example.java\n```"
+    }
+  },
+  "templates": {}
+}

--- a/scripts/playwright.java
+++ b/scripts/playwright.java
@@ -1,0 +1,17 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//DEPS com.microsoft.playwright:playwright:RELEASE
+//DESCRIPTION Playwright lets you automate Chromium, Firefox and Webkit with a single API. 
+//DESCRIPTION With this cli you can install, trace, generate pdf and screenshots and more.
+//DESCRIPTION
+//DESCRIPTION Example on how to record and run a script:
+//DESCRIPTION ```
+//DESCRIPTION   jbang playwright@microsoft/playwright-java codegen -o Example.java`
+//DESCRIPTION   jbang --deps com.microsoft.playwright:playwright:RELEASE Example.java
+//DESCRIPTION ```
+
+public class playwright {
+
+    public static void main(String... args) throws Exception {
+        com.microsoft.playwright.CLI.main(args);
+    }
+}


### PR DESCRIPTION
current docs explains how when you have a maven project you can run the cli.

with this PR you can just use jbang.

if you don't have jbang installed already see jbang.dev/downloads or just run this first:

```
curl -Ls https://sh.jbang.dev | bash -s - app setup
```

then you can do:
```
jbang playwright@microsoft/playwright-java codegen -o Example.java
```

for now you can try it with the following which runs it from my branch:
```
jbang playwright@maxandersen/playwright-java/jbang codegen -o Example.java
```

I also opened https://github.com/microsoft/playwright/pull/7696 which adds small header to generated java code 
that enables you to run the generated scripts directly. if that happens you can just do `jbang Example.java` 

Thank you