### PR TITLE
fix: support 0 size read from stream

### DIFF
--- a/playwright/src/main/java/com/microsoft/playwright/impl/Stream.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/Stream.java
@@ -45,6 +45,9 @@ public class Stream extends ChannelOwner {
 
     @Override
     public int read(byte[] b, int off, int len) {
+      if (len == 0) {
+        return 0;
+      }
       JsonObject params = new JsonObject();
       params.addProperty("size", len);
       JsonObject json = sendMessage("read", params).getAsJsonObject();

--- a/playwright/src/test/java/com/microsoft/playwright/TestDownload.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestDownload.java
@@ -368,6 +368,19 @@ public class TestDownload extends TestBase {
   }
 
   @Test
+  void streamShouldSupportZeroSizeRead() throws IOException {
+    Page page = browser.newPage(new Browser.NewPageOptions().setAcceptDownloads(true));
+    page.setContent("<a href='" + server.PREFIX + "/download'>download</a>");
+    Download download = page.waitForDownload(() -> page.click("a"));
+
+    InputStream stream = download.createReadStream();
+    byte[] b = new byte[1];
+    int read = stream.read(b, 0, 0);
+    assertEquals(0, read);
+    page.close();
+  }
+
+  @Test
   void shouldDeleteDownloadsOnContextDestruction() {
     Page page = browser.newPage(new Browser.NewPageOptions().setAcceptDownloads(true));
     page.setContent("<a href='" + server.PREFIX + "/download'>download</a>");


### PR DESCRIPTION
Otherwise java.io.InputStream.readAllBytes may throw as described in the bug (it first calls read with size=8192 and then with size=0 which we treated as read all remaining data).

Fixes #538