### PR TITLE
docs: update maven version number for README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ To run Playwright simply add following dependency to your Maven project:
 <dependency>
   <groupId>com.microsoft.playwright</groupId>
   <artifactId>playwright</artifactId>
-  <version>1.12.0</version>
+  <version>1.14.1</version>
 </dependency>
 ```
 


### PR DESCRIPTION
Hi, I found that there has been a latest package (version 1.14.1) in the maven central repository, but it's still the old version number in the `README.md`, I think it should be updated, am I right ? 