### PR TITLE
fix(docker): add test-jar to the project dependencies

### DIFF
--- a/tools/test-local-installation/create_project_and_run_tests.sh
+++ b/tools/test-local-installation/create_project_and_run_tests.sh
@@ -10,6 +10,7 @@ cd "$(dirname $0)"
 PROJECT_DIR=$(mktemp -d)
 echo "Creating project in $PROJECT_DIR"
 cp -R . $PROJECT_DIR
+cp -R ../../assertions/src/test/ $PROJECT_DIR/src/
 cp -R ../../driver-bundle/src/test/ $PROJECT_DIR/src/
 cp -R ../../playwright/src/test/ $PROJECT_DIR/src/
 cd $PROJECT_DIR

--- a/tools/test-local-installation/pom.xml
+++ b/tools/test-local-installation/pom.xml
@@ -21,6 +21,18 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>com.microsoft.playwright</groupId>
+      <artifactId>playwright</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.microsoft.playwright</groupId>
+      <artifactId>assertions</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
       <version>${gson.version}</version>


### PR DESCRIPTION
Docker tests have been busted since https://github.com/microsoft/playwright-java/pull/657 because `test-local-installation` project didn't add playwright test jar to its dependencies and http server could not serve any assets. This patch also adds assertions tests to the list of tests that we'll run in Docker.