### PR TITLE
fix(route): do not wait for driver ack

### DIFF
--- a/playwright/src/main/java/com/microsoft/playwright/impl/RouteImpl.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/RouteImpl.java
@@ -38,7 +38,7 @@ public class RouteImpl extends ChannelOwner implements Route {
     withLogging("Route.abort", () -> {
       JsonObject params = new JsonObject();
       params.addProperty("errorCode", errorCode);
-      sendMessage("abort", params);
+      sendMessageAsync("abort", params);
     });
   }
 
@@ -73,7 +73,7 @@ public class RouteImpl extends ChannelOwner implements Route {
       String base64 = Base64.getEncoder().encodeToString(bytes);
       params.addProperty("postData", base64);
     }
-    sendMessage("continue", params);
+    sendMessageAsync("continue", params);
   }
 
   @Override
@@ -128,7 +128,7 @@ public class RouteImpl extends ChannelOwner implements Route {
     params.add("headers", Serialization.toProtocol(headers));
     params.addProperty("isBase64", isBase64);
     params.addProperty("body", body);
-    sendMessage("fulfill", params);
+    sendMessageAsync("fulfill", params);
   }
 
   @Override

--- a/playwright/src/test/java/com/microsoft/playwright/TestRequestContinue.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestRequestContinue.java
@@ -16,6 +16,7 @@
 
 package com.microsoft.playwright;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
@@ -72,6 +73,7 @@ public class TestRequestContinue extends TestBase {
   }
 
   @Test
+  @Disabled("resume() method is now asynchronous")
   void shouldNotAllowChangingProtocolWhenOverridingUrl() {
     PlaywrightException[] error = {null};
     page.route("**/*", route -> {


### PR DESCRIPTION
When there are many pages sending lots of requests it route handler may end up being called recursively and even cause stack overflow like in the linked issue. At the same time there is no good reason to block on `Route.continue/abort/fulfill` calls waiting for an ack from the driver. The network interception error (if any) should be surfaced on the Page object anyway.

#678