### PR TITLE
fix(tests): do not use redirectTestOutputToFile

### DIFF
--- a/driver-bundle/pom.xml
+++ b/driver-bundle/pom.xml
@@ -32,9 +32,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <redirectTestOutputToFile>true</redirectTestOutputToFile>
-        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -144,7 +144,6 @@
               </configurationParameters>
             </properties>
             <failIfNoTests>false</failIfNoTests>
-            <redirectTestOutputToFile>true</redirectTestOutputToFile>
           </configuration>
         </plugin>
         <plugin>

--- a/tools/test-local-installation/pom.xml
+++ b/tools/test-local-installation/pom.xml
@@ -64,9 +64,6 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>3.0.0-M5</version>
-        <configuration>
-          <redirectTestOutputToFile>true</redirectTestOutputToFile>
-        </configuration>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
Looks like this option causes some of the tests (TestBrowserContextRoute and TestPageRoute) to hang. It was first noticed in Docker after https://github.com/microsoft/playwright-java/pull/657 but the tests also fail intermittently on Chromium Linux bot:

![image](https://user-images.githubusercontent.com/9798949/139723494-270b4c33-a990-47f2-9e04-c610620193cb.png)
