### PR TITLE
devops: clean old build before updating readme

### DIFF
--- a/scripts/update_readme.sh
+++ b/scripts/update_readme.sh
@@ -7,6 +7,9 @@ trap "cd $(pwd -P)" EXIT
 
 cd "$(dirname $0)/.."
 
+# Remove artifacts from previous driver (for local builds).
+mvn clean
+
 # Built from source and do local install.
 mvn install --no-transfer-progress -D skipTests
 


### PR DESCRIPTION
Otherwise previous driver may be used which would result in incorrect browser versions.