### PR TITLE
chore: convert using reflection instead of Gson

### DIFF
--- a/assertions/src/main/java/com/microsoft/playwright/impl/LocatorAssertionsImpl.java
+++ b/assertions/src/main/java/com/microsoft/playwright/impl/LocatorAssertionsImpl.java
@@ -24,7 +24,7 @@ import java.util.List;
 import java.util.regex.Pattern;
 
 import static com.microsoft.playwright.impl.Serialization.serializeArgument;
-import static com.microsoft.playwright.impl.Utils.convertViaJson;
+import static com.microsoft.playwright.impl.Utils.convertType;
 
 public class LocatorAssertionsImpl extends AssertionsBase implements LocatorAssertions {
   public LocatorAssertionsImpl(Locator locator) {
@@ -41,7 +41,7 @@ public class LocatorAssertionsImpl extends AssertionsBase implements LocatorAsse
     expected.string = text;
     expected.matchSubstring = true;
     expected.normalizeWhiteSpace = true;
-    expectImpl("to.have.text", expected, text, "Locator expected to contain text", convertViaJson(options, FrameExpectOptions.class));
+    expectImpl("to.have.text", expected, text, "Locator expected to contain text", convertType(options, FrameExpectOptions.class));
   }
 
   @Override
@@ -49,7 +49,7 @@ public class LocatorAssertionsImpl extends AssertionsBase implements LocatorAsse
     ExpectedTextValue expected = expectedRegex(pattern);
     expected.matchSubstring = true;
     expected.normalizeWhiteSpace = true;
-    expectImpl("to.have.text", expected, pattern, "Locator expected to contain regex", convertViaJson(options, FrameExpectOptions.class));
+    expectImpl("to.have.text", expected, pattern, "Locator expected to contain regex", convertType(options, FrameExpectOptions.class));
   }
 
   @Override
@@ -62,7 +62,7 @@ public class LocatorAssertionsImpl extends AssertionsBase implements LocatorAsse
       expected.normalizeWhiteSpace = true;
       list.add(expected);
     }
-    expectImpl("to.contain.text.array", list, strings, "Locator expected to contain text", convertViaJson(options, FrameExpectOptions.class));
+    expectImpl("to.contain.text.array", list, strings, "Locator expected to contain text", convertType(options, FrameExpectOptions.class));
   }
 
   @Override
@@ -74,7 +74,7 @@ public class LocatorAssertionsImpl extends AssertionsBase implements LocatorAsse
       expected.normalizeWhiteSpace = true;
       list.add(expected);
     }
-    expectImpl("to.contain.text.array", list, patterns, "Locator expected to contain text", convertViaJson(options, FrameExpectOptions.class));
+    expectImpl("to.contain.text.array", list, patterns, "Locator expected to contain text", convertType(options, FrameExpectOptions.class));
   }
 
   @Override
@@ -94,7 +94,7 @@ public class LocatorAssertionsImpl extends AssertionsBase implements LocatorAsse
     if (options == null) {
       options = new HasAttributeOptions();
     }
-    FrameExpectOptions commonOptions = convertViaJson(options, FrameExpectOptions.class);
+    FrameExpectOptions commonOptions = convertType(options, FrameExpectOptions.class);
     commonOptions.expressionArg = name;
     String message = "Locator expected to have attribute '" + name + "'";
     if (expectedValue instanceof Pattern) {
@@ -107,13 +107,13 @@ public class LocatorAssertionsImpl extends AssertionsBase implements LocatorAsse
   public void hasClass(String text, HasClassOptions options) {
     ExpectedTextValue expected = new ExpectedTextValue();
     expected.string = text;
-    expectImpl("to.have.class", expected, text, "Locator expected to have class", convertViaJson(options, FrameExpectOptions.class));
+    expectImpl("to.have.class", expected, text, "Locator expected to have class", convertType(options, FrameExpectOptions.class));
   }
 
   @Override
   public void hasClass(Pattern pattern, HasClassOptions options) {
     ExpectedTextValue expected = expectedRegex(pattern);
-    expectImpl("to.have.class", expected, pattern, "Locator expected to have class matching regex", convertViaJson(options, FrameExpectOptions.class));
+    expectImpl("to.have.class", expected, pattern, "Locator expected to have class matching regex", convertType(options, FrameExpectOptions.class));
   }
 
   @Override
@@ -124,7 +124,7 @@ public class LocatorAssertionsImpl extends AssertionsBase implements LocatorAsse
       expected.string = text;
       list.add(expected);
     }
-    expectImpl("to.have.class.array", list, strings, "Locator expected to have class", convertViaJson(options, FrameExpectOptions.class));
+    expectImpl("to.have.class.array", list, strings, "Locator expected to have class", convertType(options, FrameExpectOptions.class));
   }
 
   @Override
@@ -134,7 +134,7 @@ public class LocatorAssertionsImpl extends AssertionsBase implements LocatorAsse
       ExpectedTextValue expected = expectedRegex(pattern);
       list.add(expected);
     }
-    expectImpl("to.have.class.array", list, patterns, "Locator expected to have class matching regex", convertViaJson(options, FrameExpectOptions.class));
+    expectImpl("to.have.class.array", list, patterns, "Locator expected to have class matching regex", convertType(options, FrameExpectOptions.class));
   }
 
   @Override
@@ -142,7 +142,7 @@ public class LocatorAssertionsImpl extends AssertionsBase implements LocatorAsse
     if (options == null) {
       options = new HasCountOptions();
     }
-    FrameExpectOptions commonOptions = convertViaJson(options, FrameExpectOptions.class);
+    FrameExpectOptions commonOptions = convertType(options, FrameExpectOptions.class);
     commonOptions.expectedNumber = count;
     List<ExpectedTextValue> expectedText = null;
     expectImpl("to.have.count", expectedText, count, "Locator expected to have count", commonOptions);
@@ -165,7 +165,7 @@ public class LocatorAssertionsImpl extends AssertionsBase implements LocatorAsse
     if (options == null) {
       options = new HasCSSOptions();
     }
-    FrameExpectOptions commonOptions = convertViaJson(options, FrameExpectOptions.class);
+    FrameExpectOptions commonOptions = convertType(options, FrameExpectOptions.class);
     commonOptions.expressionArg = name;
     String message = "Locator expected to have CSS property '" + name + "'";
     if (expectedValue instanceof Pattern) {
@@ -178,7 +178,7 @@ public class LocatorAssertionsImpl extends AssertionsBase implements LocatorAsse
   public void hasId(String id, HasIdOptions options) {
     ExpectedTextValue expected = new ExpectedTextValue();
     expected.string = id;
-    expectImpl("to.have.id", expected, id, "Locator expected to have ID", convertViaJson(options, FrameExpectOptions.class));
+    expectImpl("to.have.id", expected, id, "Locator expected to have ID", convertType(options, FrameExpectOptions.class));
   }
 
   @Override
@@ -186,7 +186,7 @@ public class LocatorAssertionsImpl extends AssertionsBase implements LocatorAsse
     if (options == null) {
       options = new HasJSPropertyOptions();
     }
-    FrameExpectOptions commonOptions = convertViaJson(options, FrameExpectOptions.class);
+    FrameExpectOptions commonOptions = convertType(options, FrameExpectOptions.class);
     commonOptions.expressionArg = name;
     commonOptions.expectedValue = serializeArgument(value);
     List<ExpectedTextValue> list = null;
@@ -199,7 +199,7 @@ public class LocatorAssertionsImpl extends AssertionsBase implements LocatorAsse
     expected.string = text;
     expected.matchSubstring = false;
     expected.normalizeWhiteSpace = true;
-    expectImpl("to.have.text", expected, text, "Locator expected to have text", convertViaJson(options, FrameExpectOptions.class));
+    expectImpl("to.have.text", expected, text, "Locator expected to have text", convertType(options, FrameExpectOptions.class));
   }
 
   @Override
@@ -208,7 +208,7 @@ public class LocatorAssertionsImpl extends AssertionsBase implements LocatorAsse
     // Just match substring, same as containsText.
     expected.matchSubstring = true;
     expected.normalizeWhiteSpace = true;
-    expectImpl("to.have.text", expected, pattern, "Locator expected to have text matching regex", convertViaJson(options, FrameExpectOptions.class));
+    expectImpl("to.have.text", expected, pattern, "Locator expected to have text matching regex", convertType(options, FrameExpectOptions.class));
   }
 
   @Override
@@ -221,7 +221,7 @@ public class LocatorAssertionsImpl extends AssertionsBase implements LocatorAsse
       expected.normalizeWhiteSpace = true;
       list.add(expected);
     }
-    expectImpl("to.have.text.array", list, strings, "Locator expected to have text", convertViaJson(options, FrameExpectOptions.class));
+    expectImpl("to.have.text.array", list, strings, "Locator expected to have text", convertType(options, FrameExpectOptions.class));
   }
 
   @Override
@@ -233,60 +233,60 @@ public class LocatorAssertionsImpl extends AssertionsBase implements LocatorAsse
       expected.normalizeWhiteSpace = true;
       list.add(expected);
     }
-    expectImpl("to.have.text.array", list, patterns, "Locator expected to have text matching regex", convertViaJson(options, FrameExpectOptions.class));
+    expectImpl("to.have.text.array", list, patterns, "Locator expected to have text matching regex", convertType(options, FrameExpectOptions.class));
   }
 
   @Override
   public void hasValue(String value, HasValueOptions options) {
     ExpectedTextValue expected = new ExpectedTextValue();
     expected.string = value;
-    expectImpl("to.have.value", expected, value, "Locator expected to have value", convertViaJson(options, FrameExpectOptions.class));
+    expectImpl("to.have.value", expected, value, "Locator expected to have value", convertType(options, FrameExpectOptions.class));
   }
 
   @Override
   public void hasValue(Pattern pattern, HasValueOptions options) {
     ExpectedTextValue expected = expectedRegex(pattern);
-    expectImpl("to.have.value", expected, pattern, "Locator expected to have value matching regex", convertViaJson(options, FrameExpectOptions.class));
+    expectImpl("to.have.value", expected, pattern, "Locator expected to have value matching regex", convertType(options, FrameExpectOptions.class));
   }
 
   @Override
   public void isChecked(IsCheckedOptions options) {
-    expectTrue("to.be.checked", "Locator expected to be checked", convertViaJson(options, FrameExpectOptions.class));
+    expectTrue("to.be.checked", "Locator expected to be checked", convertType(options, FrameExpectOptions.class));
   }
 
   @Override
   public void isDisabled(IsDisabledOptions options) {
-    expectTrue("to.be.disabled", "Locator expected to be disabled", convertViaJson(options, FrameExpectOptions.class));
+    expectTrue("to.be.disabled", "Locator expected to be disabled", convertType(options, FrameExpectOptions.class));
   }
 
   @Override
   public void isEditable(IsEditableOptions options) {
-    expectTrue("to.be.editable", "Locator expected to be editable", convertViaJson(options, FrameExpectOptions.class));
+    expectTrue("to.be.editable", "Locator expected to be editable", convertType(options, FrameExpectOptions.class));
   }
 
   @Override
   public void isEmpty(IsEmptyOptions options) {
-    expectTrue("to.be.empty", "Locator expected to be empty", convertViaJson(options, FrameExpectOptions.class));
+    expectTrue("to.be.empty", "Locator expected to be empty", convertType(options, FrameExpectOptions.class));
   }
 
   @Override
   public void isEnabled(IsEnabledOptions options) {
-    expectTrue("to.be.enabled", "Locator expected to be enabled", convertViaJson(options, FrameExpectOptions.class));
+    expectTrue("to.be.enabled", "Locator expected to be enabled", convertType(options, FrameExpectOptions.class));
   }
 
   @Override
   public void isFocused(IsFocusedOptions options) {
-    expectTrue("to.be.focused", "Locator expected to be focused", convertViaJson(options, FrameExpectOptions.class));
+    expectTrue("to.be.focused", "Locator expected to be focused", convertType(options, FrameExpectOptions.class));
   }
 
   @Override
   public void isHidden(IsHiddenOptions options) {
-    expectTrue("to.be.hidden", "Locator expected to be hidden", convertViaJson(options, FrameExpectOptions.class));
+    expectTrue("to.be.hidden", "Locator expected to be hidden", convertType(options, FrameExpectOptions.class));
   }
 
   @Override
   public void isVisible(IsVisibleOptions options) {
-    expectTrue("to.be.visible", "Locator expected to be visible", convertViaJson(options, FrameExpectOptions.class));
+    expectTrue("to.be.visible", "Locator expected to be visible", convertType(options, FrameExpectOptions.class));
   }
 
   private void expectTrue(String expression, String message, FrameExpectOptions options) {

--- a/assertions/src/main/java/com/microsoft/playwright/impl/PageAssertionsImpl.java
+++ b/assertions/src/main/java/com/microsoft/playwright/impl/PageAssertionsImpl.java
@@ -22,7 +22,7 @@ import com.microsoft.playwright.assertions.PageAssertions;
 import java.util.regex.Pattern;
 
 import static com.microsoft.playwright.impl.UrlMatcher.resolveUrl;
-import static com.microsoft.playwright.impl.Utils.convertViaJson;
+import static com.microsoft.playwright.impl.Utils.convertType;
 
 public class PageAssertionsImpl extends AssertionsBase implements PageAssertions {
   private final PageImpl actualPage;
@@ -40,13 +40,13 @@ public class PageAssertionsImpl extends AssertionsBase implements PageAssertions
   public void hasTitle(String title, HasTitleOptions options) {
     ExpectedTextValue expected = new ExpectedTextValue();
     expected.string = title;
-    expectImpl("to.have.title", expected, title, "Page title expected to be", convertViaJson(options, FrameExpectOptions.class));
+    expectImpl("to.have.title", expected, title, "Page title expected to be", convertType(options, FrameExpectOptions.class));
   }
 
   @Override
   public void hasTitle(Pattern pattern, HasTitleOptions options) {
     ExpectedTextValue expected = expectedRegex(pattern);
-    expectImpl("to.have.title", expected, pattern, "Page title expected to match regex", convertViaJson(options, FrameExpectOptions.class));
+    expectImpl("to.have.title", expected, pattern, "Page title expected to match regex", convertType(options, FrameExpectOptions.class));
   }
 
   @Override
@@ -56,13 +56,13 @@ public class PageAssertionsImpl extends AssertionsBase implements PageAssertions
       url = resolveUrl(actualPage.context().baseUrl, url);
     }
     expected.string = url;
-    expectImpl("to.have.url", expected, url, "Page URL expected to be", convertViaJson(options, FrameExpectOptions.class));
+    expectImpl("to.have.url", expected, url, "Page URL expected to be", convertType(options, FrameExpectOptions.class));
   }
 
   @Override
   public void hasURL(Pattern pattern, HasURLOptions options) {
     ExpectedTextValue expected = expectedRegex(pattern);
-    expectImpl("to.have.url", expected, pattern, "Page URL expected to match regex", convertViaJson(options, FrameExpectOptions.class));
+    expectImpl("to.have.url", expected, pattern, "Page URL expected to match regex", convertType(options, FrameExpectOptions.class));
   }
 
   @Override

--- a/playwright/src/main/java/com/microsoft/playwright/impl/APIRequestContextImpl.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/APIRequestContextImpl.java
@@ -17,7 +17,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 import static com.microsoft.playwright.impl.Serialization.*;
-import static com.microsoft.playwright.impl.Utils.convertViaReflection;
+import static com.microsoft.playwright.impl.Utils.convertType;
 import static com.microsoft.playwright.impl.Utils.toFilePayload;
 
 class APIRequestContextImpl extends ChannelOwner implements APIRequestContext {
@@ -198,7 +198,7 @@ class APIRequestContextImpl extends ChannelOwner implements APIRequestContext {
   }
 
   private static <T> FetchOptions toFetchOptions(T options) {
-    FetchOptions fetchOptions = convertViaReflection(options, FetchOptions.class);
+    FetchOptions fetchOptions = convertType(options, FetchOptions.class);
     if (fetchOptions == null) {
       fetchOptions = new FetchOptions();
     }

--- a/playwright/src/main/java/com/microsoft/playwright/impl/BrowserImpl.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/BrowserImpl.java
@@ -31,7 +31,7 @@ import java.util.*;
 import java.util.function.Consumer;
 
 import static com.microsoft.playwright.impl.Serialization.gson;
-import static com.microsoft.playwright.impl.Utils.convertViaJson;
+import static com.microsoft.playwright.impl.Utils.convertType;
 import static com.microsoft.playwright.impl.Utils.isSafeCloseError;
 
 class BrowserImpl extends ChannelOwner implements Browser {
@@ -209,7 +209,7 @@ class BrowserImpl extends ChannelOwner implements Browser {
   }
 
   private Page newPageImpl(NewPageOptions options) {
-    BrowserContextImpl context = newContext(convertViaJson(options, NewContextOptions.class));
+    BrowserContextImpl context = newContext(convertType(options, NewContextOptions.class));
     PageImpl page = context.newPage();
     page.ownedContext = context;
     context.ownerPage = page;

--- a/playwright/src/main/java/com/microsoft/playwright/impl/ElementHandleImpl.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/ElementHandleImpl.java
@@ -20,7 +20,6 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.microsoft.playwright.ElementHandle;
-import com.microsoft.playwright.FileChooser;
 import com.microsoft.playwright.Frame;
 import com.microsoft.playwright.options.BoundingBox;
 import com.microsoft.playwright.options.ElementState;
@@ -34,7 +33,7 @@ import java.util.Base64;
 import java.util.List;
 
 import static com.microsoft.playwright.impl.Serialization.*;
-import static com.microsoft.playwright.impl.Utils.convertViaJson;
+import static com.microsoft.playwright.impl.Utils.convertType;
 import static com.microsoft.playwright.options.ScreenshotType.JPEG;
 import static com.microsoft.playwright.options.ScreenshotType.PNG;
 
@@ -435,9 +434,9 @@ public class ElementHandleImpl extends JSHandleImpl implements ElementHandle {
   @Override
   public void setChecked(boolean checked, SetCheckedOptions options) {
     if (checked) {
-      check(convertViaJson(options, CheckOptions.class));
+      check(convertType(options, CheckOptions.class));
     } else {
-      uncheck(convertViaJson(options, UncheckOptions.class));
+      uncheck(convertType(options, UncheckOptions.class));
     }
   }
 

--- a/playwright/src/main/java/com/microsoft/playwright/impl/FileChooserImpl.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/FileChooserImpl.java
@@ -23,7 +23,7 @@ import com.microsoft.playwright.options.FilePayload;
 
 import java.nio.file.Path;
 
-import static com.microsoft.playwright.impl.Utils.convertViaJson;
+import static com.microsoft.playwright.impl.Utils.convertType;
 
 class FileChooserImpl implements FileChooser {
   private final PageImpl page;
@@ -69,6 +69,6 @@ class FileChooserImpl implements FileChooser {
   @Override
   public void setFiles(FilePayload[] files, SetFilesOptions options) {
     page.withLogging("FileChooser.setInputFiles",
-      () -> element.setInputFilesImpl(files, convertViaJson(options, ElementHandle.SetInputFilesOptions.class)));
+        () -> element.setInputFilesImpl(files, convertType(options, ElementHandle.SetInputFilesOptions.class)));
   }
 }

--- a/playwright/src/main/java/com/microsoft/playwright/impl/FrameImpl.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/FrameImpl.java
@@ -31,9 +31,9 @@ import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
+import static com.microsoft.playwright.impl.Utils.convertType;
 import static com.microsoft.playwright.options.WaitUntilState.*;
 import static com.microsoft.playwright.impl.Serialization.*;
-import static com.microsoft.playwright.impl.Utils.convertViaJson;
 
 public class FrameImpl extends ChannelOwner implements Frame {
   private String name;
@@ -656,9 +656,9 @@ public class FrameImpl extends ChannelOwner implements Frame {
 
   void setCheckedImpl(String selector, boolean checked, SetCheckedOptions options) {
     if (checked) {
-      checkImpl(selector, convertViaJson(options, CheckOptions.class));
+      checkImpl(selector, convertType(options, CheckOptions.class));
     } else {
-      uncheckImpl(selector, convertViaJson(options, UncheckOptions.class));
+      uncheckImpl(selector, convertType(options, UncheckOptions.class));
     }
   }
 
@@ -807,7 +807,7 @@ public class FrameImpl extends ChannelOwner implements Frame {
   }
 
   void waitForLoadStateImpl(LoadState state, WaitForLoadStateOptions options) {
-    waitForLoadStateImpl(convertViaJson(state, WaitUntilState.class), options);
+    waitForLoadStateImpl(convertType(state, WaitUntilState.class), options);
   }
 
   private void waitForLoadStateImpl(WaitUntilState state, WaitForLoadStateOptions options) {
@@ -1011,10 +1011,10 @@ public class FrameImpl extends ChannelOwner implements Frame {
       options = new WaitForURLOptions();
     }
     if (matcher.test(url())) {
-      waitForLoadStateImpl(options.waitUntil, convertViaJson(options, WaitForLoadStateOptions.class));
+      waitForLoadStateImpl(options.waitUntil, convertType(options, WaitForLoadStateOptions.class));
       return;
     }
-    waitForNavigationImpl(() -> {}, convertViaJson(options, WaitForNavigationOptions.class), matcher);
+    waitForNavigationImpl(() -> {}, convertType(options, WaitForNavigationOptions.class), matcher);
   }
 
   protected void handleEvent(String event, JsonObject params) {

--- a/playwright/src/main/java/com/microsoft/playwright/impl/LocatorImpl.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/LocatorImpl.java
@@ -13,8 +13,7 @@ import java.util.List;
 import java.util.function.BiFunction;
 
 import static com.microsoft.playwright.impl.Serialization.gson;
-import static com.microsoft.playwright.impl.Serialization.serializeArgument;
-import static com.microsoft.playwright.impl.Utils.convertViaJson;
+import static com.microsoft.playwright.impl.Utils.convertType;
 
 class LocatorImpl implements Locator {
   private final FrameImpl frame;
@@ -26,7 +25,7 @@ class LocatorImpl implements Locator {
   }
 
   private <R, O> R withElement(BiFunction<ElementHandle, O, R> callback, O options) {
-    ElementHandleOptions handleOptions = convertViaJson(options, ElementHandleOptions.class);
+    ElementHandleOptions handleOptions = convertType(options, ElementHandleOptions.class);
     // TODO: support deadline based timeout
 //    Double timeout = null;
 //    if (handleOptions != null) {
@@ -64,7 +63,7 @@ class LocatorImpl implements Locator {
     if (options == null) {
       options = new CheckOptions();
     }
-    frame.check(selector, convertViaJson(options, Frame.CheckOptions.class).setStrict(true));
+    frame.check(selector, convertType(options, Frame.CheckOptions.class).setStrict(true));
   }
 
   @Override
@@ -72,7 +71,7 @@ class LocatorImpl implements Locator {
     if (options == null) {
       options = new ClickOptions();
     }
-    frame.click(selector, convertViaJson(options, Frame.ClickOptions.class).setStrict(true));
+    frame.click(selector, convertType(options, Frame.ClickOptions.class).setStrict(true));
   }
 
   @Override
@@ -85,7 +84,7 @@ class LocatorImpl implements Locator {
     if (options == null) {
       options = new DblclickOptions();
     }
-    frame.dblclick(selector, convertViaJson(options, Frame.DblclickOptions.class).setStrict(true));
+    frame.dblclick(selector, convertType(options, Frame.DblclickOptions.class).setStrict(true));
   }
 
   @Override
@@ -93,7 +92,7 @@ class LocatorImpl implements Locator {
     if (options == null) {
       options = new DispatchEventOptions();
     }
-    frame.dispatchEvent(selector, type, eventInit, convertViaJson(options, Frame.DispatchEventOptions.class).setStrict(true));
+    frame.dispatchEvent(selector, type, eventInit, convertType(options, Frame.DispatchEventOptions.class).setStrict(true));
   }
 
   @Override
@@ -101,7 +100,7 @@ class LocatorImpl implements Locator {
     if (options == null) {
       options = new ElementHandleOptions();
     }
-    Frame.WaitForSelectorOptions frameOptions = convertViaJson(options, Frame.WaitForSelectorOptions.class);
+    Frame.WaitForSelectorOptions frameOptions = convertType(options, Frame.WaitForSelectorOptions.class);
     frameOptions.setStrict(true);
     frameOptions.setState(WaitForSelectorState.ATTACHED);
     return frame.waitForSelector(selector, frameOptions);
@@ -132,7 +131,7 @@ class LocatorImpl implements Locator {
     if (options == null) {
       options = new FillOptions();
     }
-    frame.fill(selector, value, convertViaJson(options, Frame.FillOptions.class).setStrict(true));
+    frame.fill(selector, value, convertType(options, Frame.FillOptions.class).setStrict(true));
   }
 
   @Override
@@ -145,7 +144,7 @@ class LocatorImpl implements Locator {
     if (options == null) {
       options = new FocusOptions();
     }
-    frame.focus(selector, convertViaJson(options, Frame.FocusOptions.class).setStrict(true));
+    frame.focus(selector, convertType(options, Frame.FocusOptions.class).setStrict(true));
   }
 
   @Override
@@ -158,7 +157,7 @@ class LocatorImpl implements Locator {
     if (options == null) {
       options = new GetAttributeOptions();
     }
-    return frame.getAttribute(selector, name, convertViaJson(options, Frame.GetAttributeOptions.class).setStrict(true));
+    return frame.getAttribute(selector, name, convertType(options, Frame.GetAttributeOptions.class).setStrict(true));
   }
 
   @Override
@@ -166,7 +165,7 @@ class LocatorImpl implements Locator {
     if (options == null) {
       options = new HoverOptions();
     }
-    frame.hover(selector, convertViaJson(options, Frame.HoverOptions.class).setStrict(true));
+    frame.hover(selector, convertType(options, Frame.HoverOptions.class).setStrict(true));
   }
 
   @Override
@@ -174,7 +173,7 @@ class LocatorImpl implements Locator {
     if (options == null) {
       options = new InnerHTMLOptions();
     }
-    return frame.innerHTML(selector, convertViaJson(options, Frame.InnerHTMLOptions.class).setStrict(true));
+    return frame.innerHTML(selector, convertType(options, Frame.InnerHTMLOptions.class).setStrict(true));
   }
 
   @Override
@@ -182,7 +181,7 @@ class LocatorImpl implements Locator {
     if (options == null) {
       options = new InnerTextOptions();
     }
-    return frame.innerText(selector, convertViaJson(options, Frame.InnerTextOptions.class).setStrict(true));
+    return frame.innerText(selector, convertType(options, Frame.InnerTextOptions.class).setStrict(true));
   }
 
   @Override
@@ -190,7 +189,7 @@ class LocatorImpl implements Locator {
     if (options == null) {
       options = new InputValueOptions();
     }
-    return frame.inputValue(selector, convertViaJson(options, Frame.InputValueOptions.class).setStrict(true));
+    return frame.inputValue(selector, convertType(options, Frame.InputValueOptions.class).setStrict(true));
   }
 
   @Override
@@ -198,7 +197,7 @@ class LocatorImpl implements Locator {
     if (options == null) {
       options = new IsCheckedOptions();
     }
-    return frame.isChecked(selector, convertViaJson(options, Frame.IsCheckedOptions.class).setStrict(true));
+    return frame.isChecked(selector, convertType(options, Frame.IsCheckedOptions.class).setStrict(true));
   }
 
   @Override
@@ -206,7 +205,7 @@ class LocatorImpl implements Locator {
     if (options == null) {
       options = new IsDisabledOptions();
     }
-    return frame.isDisabled(selector, convertViaJson(options, Frame.IsDisabledOptions.class).setStrict(true));
+    return frame.isDisabled(selector, convertType(options, Frame.IsDisabledOptions.class).setStrict(true));
   }
 
   @Override
@@ -214,7 +213,7 @@ class LocatorImpl implements Locator {
     if (options == null) {
       options = new IsEditableOptions();
     }
-    return frame.isEditable(selector, convertViaJson(options, Frame.IsEditableOptions.class).setStrict(true));
+    return frame.isEditable(selector, convertType(options, Frame.IsEditableOptions.class).setStrict(true));
   }
 
   @Override
@@ -222,7 +221,7 @@ class LocatorImpl implements Locator {
     if (options == null) {
       options = new IsEnabledOptions();
     }
-    return frame.isEnabled(selector, convertViaJson(options, Frame.IsEnabledOptions.class).setStrict(true));
+    return frame.isEnabled(selector, convertType(options, Frame.IsEnabledOptions.class).setStrict(true));
   }
 
   @Override
@@ -230,7 +229,7 @@ class LocatorImpl implements Locator {
     if (options == null) {
       options = new IsHiddenOptions();
     }
-    return frame.isHidden(selector, convertViaJson(options, Frame.IsHiddenOptions.class).setStrict(true));
+    return frame.isHidden(selector, convertType(options, Frame.IsHiddenOptions.class).setStrict(true));
   }
 
   @Override
@@ -238,7 +237,7 @@ class LocatorImpl implements Locator {
     if (options == null) {
       options = new IsVisibleOptions();
     }
-    return frame.isVisible(selector, convertViaJson(options, Frame.IsVisibleOptions.class).setStrict(true));
+    return frame.isVisible(selector, convertType(options, Frame.IsVisibleOptions.class).setStrict(true));
   }
 
   @Override
@@ -261,12 +260,12 @@ class LocatorImpl implements Locator {
     if (options == null) {
       options = new PressOptions();
     }
-    frame.press(selector, key, convertViaJson(options, Frame.PressOptions.class).setStrict(true));
+    frame.press(selector, key, convertType(options, Frame.PressOptions.class).setStrict(true));
   }
 
   @Override
   public byte[] screenshot(ScreenshotOptions options) {
-    return withElement((h, o) -> h.screenshot(o), convertViaJson(options, ElementHandle.ScreenshotOptions.class));
+    return withElement((h, o) -> h.screenshot(o), convertType(options, ElementHandle.ScreenshotOptions.class));
   }
 
   @Override
@@ -274,7 +273,7 @@ class LocatorImpl implements Locator {
     withElement((h, o) -> {
       h.scrollIntoViewIfNeeded(o);
       return null;
-    }, convertViaJson(options, ElementHandle.ScrollIntoViewIfNeededOptions.class));
+    }, convertType(options, ElementHandle.ScrollIntoViewIfNeededOptions.class));
   }
 
   @Override
@@ -282,7 +281,7 @@ class LocatorImpl implements Locator {
     if (options == null) {
       options = new SelectOptionOptions();
     }
-    return frame.selectOption(selector, values, convertViaJson(options, Frame.SelectOptionOptions.class).setStrict(true));
+    return frame.selectOption(selector, values, convertType(options, Frame.SelectOptionOptions.class).setStrict(true));
   }
 
   @Override
@@ -290,7 +289,7 @@ class LocatorImpl implements Locator {
     if (options == null) {
       options = new SelectOptionOptions();
     }
-    return frame.selectOption(selector, values, convertViaJson(options, Frame.SelectOptionOptions.class).setStrict(true));
+    return frame.selectOption(selector, values, convertType(options, Frame.SelectOptionOptions.class).setStrict(true));
   }
 
   @Override
@@ -298,7 +297,7 @@ class LocatorImpl implements Locator {
     if (options == null) {
       options = new SelectOptionOptions();
     }
-    return frame.selectOption(selector, values, convertViaJson(options, Frame.SelectOptionOptions.class).setStrict(true));
+    return frame.selectOption(selector, values, convertType(options, Frame.SelectOptionOptions.class).setStrict(true));
   }
 
   @Override
@@ -306,7 +305,7 @@ class LocatorImpl implements Locator {
     if (options == null) {
       options = new SelectOptionOptions();
     }
-    return frame.selectOption(selector, values, convertViaJson(options, Frame.SelectOptionOptions.class).setStrict(true));
+    return frame.selectOption(selector, values, convertType(options, Frame.SelectOptionOptions.class).setStrict(true));
   }
 
   @Override
@@ -314,7 +313,7 @@ class LocatorImpl implements Locator {
     if (options == null) {
       options = new SelectOptionOptions();
     }
-    return frame.selectOption(selector, values, convertViaJson(options, Frame.SelectOptionOptions.class).setStrict(true));
+    return frame.selectOption(selector, values, convertType(options, Frame.SelectOptionOptions.class).setStrict(true));
   }
 
   @Override
@@ -322,7 +321,7 @@ class LocatorImpl implements Locator {
     if (options == null) {
       options = new SelectOptionOptions();
     }
-    return frame.selectOption(selector, values, convertViaJson(options, Frame.SelectOptionOptions.class).setStrict(true));
+    return frame.selectOption(selector, values, convertType(options, Frame.SelectOptionOptions.class).setStrict(true));
   }
 
   @Override
@@ -330,7 +329,7 @@ class LocatorImpl implements Locator {
     withElement((h, o) -> {
       h.selectText(o);
       return null;
-    }, convertViaJson(options, ElementHandle.SelectTextOptions.class));
+    }, convertType(options, ElementHandle.SelectTextOptions.class));
   }
 
   @Override
@@ -338,7 +337,7 @@ class LocatorImpl implements Locator {
     if (options == null) {
       options = new SetCheckedOptions();
     }
-    frame.setChecked(selector, checked, convertViaJson(options, Frame.SetCheckedOptions.class).setStrict(true));
+    frame.setChecked(selector, checked, convertType(options, Frame.SetCheckedOptions.class).setStrict(true));
   }
 
   @Override
@@ -346,7 +345,7 @@ class LocatorImpl implements Locator {
     if (options == null) {
       options = new SetInputFilesOptions();
     }
-    frame.setInputFiles(selector, files, convertViaJson(options, Frame.SetInputFilesOptions.class).setStrict(true));
+    frame.setInputFiles(selector, files, convertType(options, Frame.SetInputFilesOptions.class).setStrict(true));
   }
 
   @Override
@@ -354,7 +353,7 @@ class LocatorImpl implements Locator {
     if (options == null) {
       options = new SetInputFilesOptions();
     }
-    frame.setInputFiles(selector, files, convertViaJson(options, Frame.SetInputFilesOptions.class).setStrict(true));
+    frame.setInputFiles(selector, files, convertType(options, Frame.SetInputFilesOptions.class).setStrict(true));
   }
 
   @Override
@@ -362,7 +361,7 @@ class LocatorImpl implements Locator {
     if (options == null) {
       options = new SetInputFilesOptions();
     }
-    frame.setInputFiles(selector, files, convertViaJson(options, Frame.SetInputFilesOptions.class).setStrict(true));
+    frame.setInputFiles(selector, files, convertType(options, Frame.SetInputFilesOptions.class).setStrict(true));
   }
 
   @Override
@@ -370,7 +369,7 @@ class LocatorImpl implements Locator {
     if (options == null) {
       options = new SetInputFilesOptions();
     }
-    frame.setInputFiles(selector, files, convertViaJson(options, Frame.SetInputFilesOptions.class).setStrict(true));
+    frame.setInputFiles(selector, files, convertType(options, Frame.SetInputFilesOptions.class).setStrict(true));
   }
 
   @Override
@@ -378,7 +377,7 @@ class LocatorImpl implements Locator {
     if (options == null) {
       options = new TapOptions();
     }
-    frame.tap(selector, convertViaJson(options, Frame.TapOptions.class).setStrict(true));
+    frame.tap(selector, convertType(options, Frame.TapOptions.class).setStrict(true));
   }
 
   @Override
@@ -386,7 +385,7 @@ class LocatorImpl implements Locator {
     if (options == null) {
       options = new TextContentOptions();
     }
-    return frame.textContent(selector, convertViaJson(options, Frame.TextContentOptions.class).setStrict(true));
+    return frame.textContent(selector, convertType(options, Frame.TextContentOptions.class).setStrict(true));
   }
 
   @Override
@@ -394,7 +393,7 @@ class LocatorImpl implements Locator {
     if (options == null) {
       options = new TypeOptions();
     }
-    frame.type(selector, text, convertViaJson(options, Frame.TypeOptions.class).setStrict(true));
+    frame.type(selector, text, convertType(options, Frame.TypeOptions.class).setStrict(true));
   }
 
   @Override
@@ -402,7 +401,7 @@ class LocatorImpl implements Locator {
     if (options == null) {
       options = new UncheckOptions();
     }
-    frame.uncheck(selector, convertViaJson(options, Frame.UncheckOptions.class).setStrict(true));
+    frame.uncheck(selector, convertType(options, Frame.UncheckOptions.class).setStrict(true));
   }
 
   @Override
@@ -414,7 +413,7 @@ class LocatorImpl implements Locator {
   }
 
   private void waitForImpl(WaitForOptions options) {
-    frame.withLogging("Locator.waitFor", () -> frame.waitForSelectorImpl(selector, convertViaJson(options, Frame.WaitForSelectorOptions.class).setStrict(true), true));
+    frame.withLogging("Locator.waitFor", () -> frame.waitForSelectorImpl(selector, convertType(options, Frame.WaitForSelectorOptions.class).setStrict(true), true));
   }
 
   @Override

--- a/playwright/src/main/java/com/microsoft/playwright/impl/MouseImpl.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/MouseImpl.java
@@ -20,7 +20,7 @@ import com.google.gson.JsonObject;
 import com.microsoft.playwright.Mouse;
 
 import static com.microsoft.playwright.impl.Serialization.gson;
-import static com.microsoft.playwright.impl.Utils.convertViaJson;
+import static com.microsoft.playwright.impl.Utils.convertType;
 
 class MouseImpl implements Mouse {
   private final ChannelOwner page;
@@ -54,7 +54,7 @@ class MouseImpl implements Mouse {
     if (options == null) {
       clickOptions = new ClickOptions();
     } else {
-      clickOptions = convertViaJson(options, ClickOptions.class);
+      clickOptions = convertType(options, ClickOptions.class);
     }
     clickOptions.clickCount = 2;
     click(x, y, clickOptions);

--- a/playwright/src/main/java/com/microsoft/playwright/impl/PageImpl.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/PageImpl.java
@@ -28,10 +28,10 @@ import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
+import static com.microsoft.playwright.impl.Utils.convertType;
 import static com.microsoft.playwright.options.ScreenshotType.JPEG;
 import static com.microsoft.playwright.options.ScreenshotType.PNG;
 import static com.microsoft.playwright.impl.Serialization.gson;
-import static com.microsoft.playwright.impl.Utils.convertViaJson;
 import static com.microsoft.playwright.impl.Utils.isSafeCloseError;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.nio.file.Files.readAllBytes;
@@ -558,7 +558,7 @@ public class PageImpl extends ChannelOwner implements Page {
   @Override
   public ElementHandle querySelector(String selector, QuerySelectorOptions options) {
     return withLogging("Page.querySelector", () -> mainFrame.querySelectorImpl(
-      selector, convertViaJson(options, Frame.QuerySelectorOptions.class)));
+      selector, convertType(options, Frame.QuerySelectorOptions.class)));
   }
 
   @Override
@@ -569,7 +569,7 @@ public class PageImpl extends ChannelOwner implements Page {
   @Override
   public Object evalOnSelector(String selector, String pageFunction, Object arg, EvalOnSelectorOptions options) {
     return withLogging("Page.evalOnSelector", () -> mainFrame.evalOnSelectorImpl(
-      selector, pageFunction, arg, convertViaJson(options, Frame.EvalOnSelectorOptions.class)));
+      selector, pageFunction, arg, convertType(options, Frame.EvalOnSelectorOptions.class)));
   }
 
   @Override
@@ -603,13 +603,13 @@ public class PageImpl extends ChannelOwner implements Page {
   @Override
   public ElementHandle addScriptTag(AddScriptTagOptions options) {
     return withLogging("Page.addScriptTag",
-      () -> mainFrame.addScriptTagImpl(convertViaJson(options, Frame.AddScriptTagOptions.class)));
+      () -> mainFrame.addScriptTagImpl(convertType(options, Frame.AddScriptTagOptions.class)));
   }
 
   @Override
   public ElementHandle addStyleTag(AddStyleTagOptions options) {
     return withLogging("Page.addStyleTag",
-      () -> mainFrame.addStyleTagImpl(convertViaJson(options, Frame.AddStyleTagOptions.class)));
+      () -> mainFrame.addStyleTagImpl(convertType(options, Frame.AddStyleTagOptions.class)));
   }
 
   @Override
@@ -620,13 +620,13 @@ public class PageImpl extends ChannelOwner implements Page {
   @Override
   public void check(String selector, CheckOptions options) {
     withLogging("Page.check",
-      () -> mainFrame.checkImpl(selector, convertViaJson(options, Frame.CheckOptions.class)));
+      () -> mainFrame.checkImpl(selector, convertType(options, Frame.CheckOptions.class)));
   }
 
   @Override
   public void click(String selector, ClickOptions options) {
     withLogging("Page.click",
-      () -> mainFrame.clickImpl(selector, convertViaJson(options, Frame.ClickOptions.class)));
+      () -> mainFrame.clickImpl(selector, convertType(options, Frame.ClickOptions.class)));
   }
 
   @Override
@@ -642,13 +642,13 @@ public class PageImpl extends ChannelOwner implements Page {
   @Override
   public void dblclick(String selector, DblclickOptions options) {
     withLogging("Page.dblclick",
-      () -> mainFrame.dblclickImpl(selector, convertViaJson(options, Frame.DblclickOptions.class)));
+      () -> mainFrame.dblclickImpl(selector, convertType(options, Frame.DblclickOptions.class)));
   }
 
   @Override
   public void dispatchEvent(String selector, String type, Object eventInit, DispatchEventOptions options) {
     withLogging("Page.dispatchEvent",
-      () -> mainFrame.dispatchEventImpl(selector, type, eventInit, convertViaJson(options, Frame.DispatchEventOptions.class)));
+      () -> mainFrame.dispatchEventImpl(selector, type, eventInit, convertType(options, Frame.DispatchEventOptions.class)));
   }
 
   @Override
@@ -705,13 +705,13 @@ public class PageImpl extends ChannelOwner implements Page {
   @Override
   public void fill(String selector, String value, FillOptions options) {
     withLogging("Page.fill",
-      () -> mainFrame.fillImpl(selector, value, convertViaJson(options, Frame.FillOptions.class)));
+      () -> mainFrame.fillImpl(selector, value, convertType(options, Frame.FillOptions.class)));
   }
 
   @Override
   public void focus(String selector, FocusOptions options) {
     withLogging("Page.focus",
-      () -> mainFrame.focusImpl(selector, convertViaJson(options, Frame.FocusOptions.class)));
+      () -> mainFrame.focusImpl(selector, convertType(options, Frame.FocusOptions.class)));
   }
 
   @Override
@@ -761,7 +761,7 @@ public class PageImpl extends ChannelOwner implements Page {
   @Override
   public String getAttribute(String selector, String name, GetAttributeOptions options) {
     return withLogging("Page.getAttribute",
-      () -> mainFrame.getAttributeImpl(selector, name, convertViaJson(options, Frame.GetAttributeOptions.class)));
+      () -> mainFrame.getAttributeImpl(selector, name, convertType(options, Frame.GetAttributeOptions.class)));
   }
 
   @Override
@@ -800,44 +800,41 @@ public class PageImpl extends ChannelOwner implements Page {
 
   @Override
   public ResponseImpl navigate(String url, NavigateOptions options) {
-    return withLogging("Page.navigate", () ->
-      mainFrame.navigateImpl(url, convertViaJson(options, Frame.NavigateOptions.class)));
+    return withLogging("Page.navigate", () -> mainFrame.navigateImpl(url, convertType(options, Frame.NavigateOptions.class)));
   }
 
   @Override
   public void hover(String selector, HoverOptions options) {
-    withLogging("Page.hover", () ->
-      mainFrame.hoverImpl(selector, convertViaJson(options, Frame.HoverOptions.class)));
+    withLogging("Page.hover", () -> mainFrame.hoverImpl(selector, convertType(options, Frame.HoverOptions.class)));
   }
 
   @Override
   public void dragAndDrop(String source, String target, DragAndDropOptions options) {
-    withLogging("Page.dragAndDrop", () ->
-      mainFrame.dragAndDropImpl(source, target, convertViaJson(options, Frame.DragAndDropOptions.class)));
+    withLogging("Page.dragAndDrop", () -> mainFrame.dragAndDropImpl(source, target, convertType(options, Frame.DragAndDropOptions.class)));
   }
 
   @Override
   public String innerHTML(String selector, InnerHTMLOptions options) {
     return withLogging("Page.innerHTML",
-      () -> mainFrame.innerHTMLImpl(selector, convertViaJson(options, Frame.InnerHTMLOptions.class)));
+      () -> mainFrame.innerHTMLImpl(selector, convertType(options, Frame.InnerHTMLOptions.class)));
   }
 
   @Override
   public String innerText(String selector, InnerTextOptions options) {
     return withLogging("Page.innerText",
-      () -> mainFrame.innerTextImpl(selector, convertViaJson(options, Frame.InnerTextOptions.class)));
+      () -> mainFrame.innerTextImpl(selector, convertType(options, Frame.InnerTextOptions.class)));
   }
 
   @Override
   public String inputValue(String selector, InputValueOptions options) {
     return withLogging("Page.inputValue",
-      () -> mainFrame.inputValueImpl(selector, convertViaJson(options, Frame.InputValueOptions.class)));
+      () -> mainFrame.inputValueImpl(selector, convertType(options, Frame.InputValueOptions.class)));
   }
 
   @Override
   public boolean isChecked(String selector, IsCheckedOptions options) {
     return withLogging("Page.isChecked",
-      () -> mainFrame.isCheckedImpl(selector, convertViaJson(options, Frame.IsCheckedOptions.class)));
+      () -> mainFrame.isCheckedImpl(selector, convertType(options, Frame.IsCheckedOptions.class)));
   }
 
   @Override
@@ -848,31 +845,31 @@ public class PageImpl extends ChannelOwner implements Page {
   @Override
   public boolean isDisabled(String selector, IsDisabledOptions options) {
     return withLogging("Page.isDisabled",
-      () -> mainFrame.isDisabledImpl(selector, convertViaJson(options, Frame.IsDisabledOptions.class)));
+      () -> mainFrame.isDisabledImpl(selector, convertType(options, Frame.IsDisabledOptions.class)));
   }
 
   @Override
   public boolean isEditable(String selector, IsEditableOptions options) {
     return withLogging("Page.isEditable",
-      () -> mainFrame.isEditableImpl(selector, convertViaJson(options, Frame.IsEditableOptions.class)));
+      () -> mainFrame.isEditableImpl(selector, convertType(options, Frame.IsEditableOptions.class)));
   }
 
   @Override
   public boolean isEnabled(String selector, IsEnabledOptions options) {
     return withLogging("Page.isEnabled",
-      () -> mainFrame.isEnabledImpl(selector, convertViaJson(options, Frame.IsEnabledOptions.class)));
+      () -> mainFrame.isEnabledImpl(selector, convertType(options, Frame.IsEnabledOptions.class)));
   }
 
   @Override
   public boolean isHidden(String selector, IsHiddenOptions options) {
     return withLogging("Page.isHidden",
-      () -> mainFrame.isHiddenImpl(selector, convertViaJson(options, Frame.IsHiddenOptions.class)));
+      () -> mainFrame.isHiddenImpl(selector, convertType(options, Frame.IsHiddenOptions.class)));
   }
 
   @Override
   public boolean isVisible(String selector, IsVisibleOptions options) {
     return withLogging("Page.isVisible",
-      () -> mainFrame.isVisibleImpl(selector, convertViaJson(options, Frame.IsVisibleOptions.class)));
+      () -> mainFrame.isVisibleImpl(selector, convertType(options, Frame.IsVisibleOptions.class)));
   }
 
   @Override
@@ -935,7 +932,7 @@ public class PageImpl extends ChannelOwner implements Page {
   @Override
   public void press(String selector, String key, PressOptions options) {
     withLogging("Page.press",
-      () -> mainFrame.pressImpl(selector, key, convertViaJson(options, Frame.PressOptions.class)));
+      () -> mainFrame.pressImpl(selector, key, convertType(options, Frame.PressOptions.class)));
   }
 
   @Override
@@ -1051,25 +1048,25 @@ public class PageImpl extends ChannelOwner implements Page {
   @Override
   public List<String> selectOption(String selector, SelectOption[] values, SelectOptionOptions options) {
     return withLogging("Page.selectOption",
-      () -> mainFrame.selectOptionImpl(selector, values, convertViaJson(options, Frame.SelectOptionOptions.class)));
+      () -> mainFrame.selectOptionImpl(selector, values, convertType(options, Frame.SelectOptionOptions.class)));
   }
 
   @Override
   public List<String> selectOption(String selector, ElementHandle[] values, SelectOptionOptions options) {
     return withLogging("Page.selectOption",
-      () -> mainFrame.selectOptionImpl(selector, values, convertViaJson(options, Frame.SelectOptionOptions.class)));
+      () -> mainFrame.selectOptionImpl(selector, values, convertType(options, Frame.SelectOptionOptions.class)));
   }
 
   @Override
   public void setChecked(String selector, boolean checked, SetCheckedOptions options) {
     withLogging("Page.setChecked",
-      () -> mainFrame.setCheckedImpl(selector, checked, convertViaJson(options, Frame.SetCheckedOptions.class)));
+      () -> mainFrame.setCheckedImpl(selector, checked, convertType(options, Frame.SetCheckedOptions.class)));
   }
 
   @Override
   public void setContent(String html, SetContentOptions options) {
     withLogging("Page.setContent",
-      () -> mainFrame.setContentImpl(html, convertViaJson(options, Frame.SetContentOptions.class)));
+      () -> mainFrame.setContentImpl(html, convertType(options, Frame.SetContentOptions.class)));
   }
 
   @Override
@@ -1116,7 +1113,7 @@ public class PageImpl extends ChannelOwner implements Page {
   @Override
   public void setInputFiles(String selector, Path[] files, SetInputFilesOptions options) {
     withLogging("Page.setInputFiles",
-      () -> mainFrame.setInputFilesImpl(selector, files, convertViaJson(options, Frame.SetInputFilesOptions.class)));
+      () -> mainFrame.setInputFilesImpl(selector, files, convertType(options, Frame.SetInputFilesOptions.class)));
   }
 
   @Override
@@ -1127,7 +1124,7 @@ public class PageImpl extends ChannelOwner implements Page {
   @Override
   public void setInputFiles(String selector, FilePayload[] files, SetInputFilesOptions options) {
     withLogging("Page.setInputFiles",
-      () -> mainFrame.setInputFilesImpl(selector, files, convertViaJson(options, Frame.SetInputFilesOptions.class)));
+      () -> mainFrame.setInputFilesImpl(selector, files, convertType(options, Frame.SetInputFilesOptions.class)));
   }
 
   @Override
@@ -1143,13 +1140,13 @@ public class PageImpl extends ChannelOwner implements Page {
   @Override
   public void tap(String selector, TapOptions options) {
     withLogging("Page.tap",
-      () -> mainFrame.tapImpl(selector, convertViaJson(options, Frame.TapOptions.class)));
+      () -> mainFrame.tapImpl(selector, convertType(options, Frame.TapOptions.class)));
   }
 
   @Override
   public String textContent(String selector, TextContentOptions options) {
     return withLogging("Page.textContent",
-      () -> mainFrame.textContentImpl(selector, convertViaJson(options, Frame.TextContentOptions.class)));
+      () -> mainFrame.textContentImpl(selector, convertType(options, Frame.TextContentOptions.class)));
   }
 
   @Override
@@ -1165,13 +1162,13 @@ public class PageImpl extends ChannelOwner implements Page {
   @Override
   public void type(String selector, String text, TypeOptions options) {
     withLogging("Page.type",
-      () -> mainFrame.typeImpl(selector, text, convertViaJson(options, Frame.TypeOptions.class)));
+      () -> mainFrame.typeImpl(selector, text, convertType(options, Frame.TypeOptions.class)));
   }
 
   @Override
   public void uncheck(String selector, UncheckOptions options) {
     withLogging("Page.uncheck",
-      () -> mainFrame.uncheckImpl(selector, convertViaJson(options, Frame.UncheckOptions.class)));
+      () -> mainFrame.uncheckImpl(selector, convertType(options, Frame.UncheckOptions.class)));
   }
 
   @Override
@@ -1244,13 +1241,13 @@ public class PageImpl extends ChannelOwner implements Page {
   @Override
   public JSHandle waitForFunction(String pageFunction, Object arg, WaitForFunctionOptions options) {
     return withLogging("Page.waitForFunction",
-      () -> mainFrame.waitForFunctionImpl(pageFunction, arg, convertViaJson(options, Frame.WaitForFunctionOptions.class)));
+      () -> mainFrame.waitForFunctionImpl(pageFunction, arg, convertType(options, Frame.WaitForFunctionOptions.class)));
   }
 
   @Override
   public void waitForLoadState(LoadState state, WaitForLoadStateOptions options) {
     withWaitLogging("Page.waitForLoadState", () -> {
-      mainFrame.waitForLoadStateImpl(state, convertViaJson(options, Frame.WaitForLoadStateOptions.class));
+      mainFrame.waitForLoadStateImpl(state, convertType(options, Frame.WaitForLoadStateOptions.class));
       return null;
     });
   }
@@ -1384,7 +1381,7 @@ public class PageImpl extends ChannelOwner implements Page {
   @Override
   public ElementHandle waitForSelector(String selector, WaitForSelectorOptions options) {
     return withLogging("Page.waitForSelector",
-      () -> mainFrame.waitForSelectorImpl(selector, convertViaJson(options, Frame.WaitForSelectorOptions.class)));
+      () -> mainFrame.waitForSelectorImpl(selector, convertType(options, Frame.WaitForSelectorOptions.class)));
   }
 
   @Override
@@ -1408,7 +1405,7 @@ public class PageImpl extends ChannelOwner implements Page {
   }
 
   private void waitForURL(UrlMatcher matcher, WaitForURLOptions options) {
-    withLogging("Page.waitForURL", () -> mainFrame.waitForURLImpl(matcher, convertViaJson(options, Frame.WaitForURLOptions.class)));
+    withLogging("Page.waitForURL", () -> mainFrame.waitForURLImpl(matcher, convertType(options, Frame.WaitForURLOptions.class)));
   }
 
   @Override


### PR DESCRIPTION
Use reflection to convert between option types like `Page.ClickOptions` => `Frame.ClickOptions`. The converter does only shallow copy so it doesn't suffer from cyclic references. Also it shouldn't look into internal fields of JDK classes which could trigger errors like https://github.com/microsoft/playwright-java/issues/423