### PR TITLE
chore: proper driver URL detection

### DIFF
--- a/scripts/download_driver_for_all_platforms.sh
+++ b/scripts/download_driver_for_all_platforms.sh
@@ -45,7 +45,7 @@ do
   echo "Downloading driver for $PLATFORM to $(pwd)"
 
   URL=https://playwright.azureedge.net/builds/driver
-  if ! [[ $CLI_VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  if [[ "$CLI_VERSION" == *-alpha* || "$CLI_VERSION" == *-beta* || "$CLI_VERSION" == *-next* ]]; then
     URL=$URL/next
   fi
   URL=$URL/$FILE_NAME


### PR DESCRIPTION
Since Nov 16, 2021, we have the following conventions:

- Drivers published from tip-of-tree have an `-alpha` version and are
  stored at `/next` subfolder on Azure Storage.
- Drivers auto-published for each commit of the release branch have a `-beta` version and are
  stored at `/next` subfolder on Azure Storage.
- Drivers published due to a release might have `-rc` as part of the
  version, and are stored in root subfolder on Azure Storage.

We no longer have driver versions that include "next" as part of the
version. I kept it for backwards compatibility.