### PR TITLE
test: fix WARNING: sendResponseHeaders:...

### DIFF
--- a/playwright/src/test/java/com/microsoft/playwright/TestGlobalFetch.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestGlobalFetch.java
@@ -63,15 +63,15 @@ public class TestGlobalFetch extends TestBase {
   @Test
   void headShouldWork() {
     APIRequestContext request = playwright.request().newContext();
-    APIResponse response = request.head(server.PREFIX + "/simple.json");
-    assertEquals(server.PREFIX + "/simple.json", response.url());
+    APIResponse response = request.head(server.EMPTY_PAGE);
+    assertEquals(server.EMPTY_PAGE, response.url());
     assertEquals(200, response.status());
     assertEquals("OK", response.statusText());
     assertTrue(response.ok());
-    assertEquals("application/json", response.headers().get("content-type"));
+    assertEquals("text/html", response.headers().get("content-type"));
     Optional<HttpHeader> contentType = response.headersArray().stream().filter(h -> "content-type".equals(h.name.toLowerCase())).findFirst();
     assertTrue(contentType.isPresent());
-    assertEquals("application/json", contentType.get().value);
+    assertEquals("text/html", contentType.get().value);
     assertEquals("", response.text());
   }
 

--- a/playwright/src/test/java/com/microsoft/playwright/TestPageNavigate.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestPageNavigate.java
@@ -110,7 +110,7 @@ public class TestPageNavigate extends TestBase {
   @Test
   void shouldWorkWithSubframesReturn204() {
     server.setRoute("/frames/frame.html", exchange -> {
-      exchange.sendResponseHeaders(204, 0);
+      exchange.sendResponseHeaders(204, -1);
       exchange.getResponseBody().close();
     });
     page.navigate(server.PREFIX + "/frames/one-frame.html");
@@ -119,7 +119,7 @@ public class TestPageNavigate extends TestBase {
   @Test
   void shouldWorkWithSubframesReturn204WithDomcontentloaded() {
     server.setRoute("/frames/frame.html", exchange -> {
-      exchange.sendResponseHeaders(204, 0);
+      exchange.sendResponseHeaders(204, -1);
       exchange.getResponseBody().close();
     });
     page.navigate(server.PREFIX + "/frames/one-frame.html", new Page.NavigateOptions().setWaitUntil(WaitUntilState.DOMCONTENTLOADED));
@@ -129,7 +129,7 @@ public class TestPageNavigate extends TestBase {
   void shouldFailWhenServerReturns204() {
     // WebKit just loads an empty page.
     server.setRoute("/empty.html", exchange -> {
-      exchange.sendResponseHeaders(204, 0);
+      exchange.sendResponseHeaders(204, -1);
       exchange.getResponseBody().close();
     });
     try {


### PR DESCRIPTION
Fix following warnings:

```
Nov 18, 2021 11:46:33 PM sun.net.httpserver.ExchangeImpl sendResponseHeaders
WARNING: sendResponseHeaders: being invoked with a content length for a HEAD request
```

```
Nov 18, 2021 11:51:33 PM sun.net.httpserver.ExchangeImpl sendResponseHeaders
WARNING: sendResponseHeaders: rCode = 204: forcing contentLen = -1
```