### PR TITLE
feat: custom temp dir for driver via playwright.driver.tmpdir property

### DIFF
--- a/driver-bundle/src/test/java/com/microsoft/playwright/TestInstall.java
+++ b/driver-bundle/src/test/java/com/microsoft/playwright/TestInstall.java
@@ -17,7 +17,9 @@
 package com.microsoft.playwright;
 
 import com.microsoft.playwright.impl.Driver;
+import com.microsoft.playwright.impl.DriverJar;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -40,5 +42,12 @@ public class TestInstall {
     Process p = pb.start();
     boolean result = p.waitFor(1, TimeUnit.MINUTES);
     assertTrue(result, "Timed out waiting for browsers to install");
+  }
+
+  @Test
+  void playwrightDriverInAlternativeTmpdir(@TempDir Path tmpdir) throws Exception {
+    System.setProperty("playwright.driver.tmpdir", tmpdir.toString());
+    DriverJar driver = new DriverJar();
+    assertTrue(driver.driverPath().startsWith(tmpdir), "Driver path: " + driver.driverPath() + " tmp: " + tmpdir);
   }
 }

--- a/driver-bundle/src/test/java/com/microsoft/playwright/TestInstall.java
+++ b/driver-bundle/src/test/java/com/microsoft/playwright/TestInstall.java
@@ -18,6 +18,8 @@ package com.microsoft.playwright;
 
 import com.microsoft.playwright.impl.Driver;
 import com.microsoft.playwright.impl.DriverJar;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -29,10 +31,15 @@ import java.util.concurrent.TimeUnit;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestInstall {
-  @Test
-  void playwrightCliInstalled() throws Exception {
+  @BeforeEach
+  void clearSystemProperties() {
     // Clear system property to ensure that the driver is loaded from jar.
     System.clearProperty("playwright.cli.dir");
+    System.clearProperty("playwright.driver.tmpdir");
+  }
+
+  @Test
+  void playwrightCliInstalled() throws Exception {
     Path cli = Driver.ensureDriverInstalled(Collections.emptyMap());
     assertTrue(Files.exists(cli));
 

--- a/driver/src/main/java/com/microsoft/playwright/impl/Driver.java
+++ b/driver/src/main/java/com/microsoft/playwright/impl/Driver.java
@@ -54,15 +54,15 @@ public abstract class Driver {
         throw new RuntimeException("Failed to create driver", exception);
       }
     }
-    String name = instance.cliFileName();
-    return instance.driverDir().resolve(name);
+    return instance.driverPath();
   }
 
   protected abstract void initialize(Map<String, String> env) throws Exception;
 
-  protected String cliFileName() {
-    return System.getProperty("os.name").toLowerCase().contains("windows") ?
+  public Path driverPath() {
+    String cliFileName = System.getProperty("os.name").toLowerCase().contains("windows") ?
       "playwright.cmd" : "playwright.sh";
+    return driverDir().resolve(cliFileName);
   }
 
   private static Driver createDriver() throws Exception {


### PR DESCRIPTION
Allow specifying custom temp directory for extracting driver binaries when running playwright. As requested in the bug it can now be provided as `-D playwright.driver.tmpdir=/path/to/somewhere`

Fixes #728