### PR TITLE
cherry-pick(1.18): hide internal call from inspector log (#783)

### DIFF
--- a/playwright/src/main/java/com/microsoft/playwright/impl/Connection.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/Connection.java
@@ -121,11 +121,15 @@ public class Connection {
     message.addProperty("method", method);
     message.add("params", params);
     JsonObject metadata = new JsonObject();
-    if (stackTraceCollector != null) {
-      metadata.add("stack", stackTraceCollector.currentStackTrace());
-    }
-    if (apiName != null) {
+    if (apiName == null) {
+      metadata.addProperty("internal", true);
+    } else {
       metadata.addProperty("apiName", apiName);
+      // All but first message in an API call are considered internal and will be hidden from the inspector.
+      apiName = null;
+      if (stackTraceCollector != null) {
+        metadata.add("stack", stackTraceCollector.currentStackTrace());
+      }
     }
     message.add("metadata", metadata);
     transport.send(message);


### PR DESCRIPTION
2aef5c674214c274f192206c9e408ac1463e2d57