### PR TITLE
devops: trigger Java publish workflow on release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,6 +2,9 @@ name: Publish
 on:
   release:
     types: [published]
+  push:
+    branches:
+      - main
 jobs:
   build:
     timeout-minutes: 30

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,7 @@
 name: Publish
 on:
-  workflow_dispatch:
-  push:
-    branches:
-      - main
+  release:
+    types: [published]
 jobs:
   build:
     timeout-minutes: 30


### PR DESCRIPTION
Thats how it is in Python, Node.js, vscode extension etc.