### PR TITLE
fix(tracing): support explicit StartOptions().setSources(false)

### DIFF
--- a/playwright/src/main/java/com/microsoft/playwright/impl/TracingImpl.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/TracingImpl.java
@@ -28,7 +28,6 @@ import static com.microsoft.playwright.impl.Serialization.gson;
 class TracingImpl extends ChannelOwner implements Tracing {
   LocalUtils localUtils;
   boolean isRemote;
-  private boolean includeSources;
 
   TracingImpl(ChannelOwner parent, String type, String guid, JsonObject initializer) {
     super(parent, type, guid, initializer);
@@ -90,7 +89,7 @@ class TracingImpl extends ChannelOwner implements Tracing {
       options = new StartOptions();
     }
     JsonObject params = gson().toJsonTree(options).getAsJsonObject();
-    includeSources = options.sources != null;
+    boolean includeSources = options.sources != null && options.sources;
     if (includeSources) {
       if (!connection.isCollectingStacks()) {
         throw new PlaywrightException("Source root directory must be specified via PLAYWRIGHT_JAVA_SRC environment variable when source collection is enabled");

--- a/playwright/src/test/java/com/microsoft/playwright/TestTracing.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestTracing.java
@@ -126,4 +126,10 @@ public class TestTracing extends TestBase {
     assertEquals(new String(thisFile, UTF_8), new String(sources.values().iterator().next(), UTF_8));
   }
 
+  @Test
+  void shouldNotFailWhenSourcesSetExplicitlyToFalse() throws IOException {
+    Assumptions.assumeTrue(System.getenv("PLAYWRIGHT_JAVA_SRC") == null, "PLAYWRIGHT_JAVA_SRC must not be set for this test");
+    context.tracing().start(new Tracing.StartOptions().setSources(false));
+  }
+
 }


### PR DESCRIPTION
Prior to this commit using `new Tracing.StartOptions().setSources(false) was
was wrongfully treated as `.setSources(true)` since it only tested the `Boolean` to be non-null.
Also, `includeSources` was converted into a local variable as it is not used anywhere else.