### PR TITLE
Add Linux/arm64 support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Install git, Java JDK (version >= 8), Maven (tested with version 3.6.3), on Ubun
 just run the following command:
 
 ```sh
-sudo apt-get install git openjdk-11-jdk maven
+sudo apt-get install git openjdk-11-jdk maven unzip
 ```
 
 ### Getting the Code

--- a/driver-bundle/src/main/java/com/microsoft/playwright/impl/DriverJar.java
+++ b/driver-bundle/src/main/java/com/microsoft/playwright/impl/DriverJar.java
@@ -139,11 +139,17 @@ public class DriverJar extends Driver {
 
   private static String platformDir() {
     String name = System.getProperty("os.name").toLowerCase();
+    String arch = System.getProperty("os.arch").toLowerCase();
+
     if (name.contains("windows")) {
       return "win32_x64";
     }
     if (name.contains("linux")) {
-      return "linux";
+      if (arch.equals("aarch64")) {
+        return "linux-arm64";
+      } else {
+        return "linux";
+      }
     }
     if (name.contains("mac os x")) {
       return "mac";

--- a/scripts/download_driver_for_all_platforms.sh
+++ b/scripts/download_driver_for_all_platforms.sh
@@ -33,7 +33,7 @@ fi
 mkdir -p driver
 cd driver
 
-for PLATFORM in mac linux win32_x64
+for PLATFORM in mac linux linux-arm64 win32_x64
 do
   FILE_NAME=$FILE_PREFIX-$PLATFORM.zip
   if [[ -d $PLATFORM ]]; then


### PR DESCRIPTION
Allow playwright-java to use existing support in https://github.com/microsoft/playwright for Linux on arm64, available since version 1.17.

Since playwright itself only supports Linux/arm64 on Ubuntu today, so must playwright-java until support for other distros is added.

All tests currently pass on this distribution and architecture.

References: #836