### PR TITLE
Revert "Add Linux/arm64 support (#883)"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Install git, Java JDK (version >= 8), Maven (tested with version 3.6.3), on Ubun
 just run the following command:
 
 ```sh
-sudo apt-get install git openjdk-11-jdk maven unzip
+sudo apt-get install git openjdk-11-jdk maven
 ```
 
 ### Getting the Code

--- a/driver-bundle/src/main/java/com/microsoft/playwright/impl/DriverJar.java
+++ b/driver-bundle/src/main/java/com/microsoft/playwright/impl/DriverJar.java
@@ -139,17 +139,11 @@ public class DriverJar extends Driver {
 
   private static String platformDir() {
     String name = System.getProperty("os.name").toLowerCase();
-    String arch = System.getProperty("os.arch").toLowerCase();
-
     if (name.contains("windows")) {
       return "win32_x64";
     }
     if (name.contains("linux")) {
-      if (arch.equals("aarch64")) {
-        return "linux-arm64";
-      } else {
-        return "linux";
-      }
+      return "linux";
     }
     if (name.contains("mac os x")) {
       return "mac";

--- a/scripts/download_driver_for_all_platforms.sh
+++ b/scripts/download_driver_for_all_platforms.sh
@@ -33,7 +33,7 @@ fi
 mkdir -p driver
 cd driver
 
-for PLATFORM in mac linux linux-arm64 win32_x64
+for PLATFORM in mac linux win32_x64
 do
   FILE_NAME=$FILE_PREFIX-$PLATFORM.zip
   if [[ -d $PLATFORM ]]; then


### PR DESCRIPTION
This reverts commit 7eddd2d2b2ee1230381c095ebdaa1148218aa15d.

Reverting this change as we are going to branch for the next release and amr support
* is not covert by tests yet
* inclreases the size of the driver bundle which we'll likely want to fix before
release.

References https://github.com/microsoft/playwright-java/issues/836