### PR TITLE
test: unflake TestInstall.shouldThrowWhenBrowserPathIsInvalid

### DIFF
--- a/driver-bundle/src/test/java/com/microsoft/playwright/TestInstall.java
+++ b/driver-bundle/src/test/java/com/microsoft/playwright/TestInstall.java
@@ -45,9 +45,11 @@ public class TestInstall {
 
   @Test
   @Tags({@Tag("isolated"), @Tag("driverThrowTest")})
-  void shouldThrowWhenBrowserPathIsInvalid() {
+  void shouldThrowWhenBrowserPathIsInvalid(@TempDir Path tmpDir) {
     Map<String,String> env = new HashMap<>();
-    env.put("PLAYWRIGHT_BROWSERS_PATH", "/some/bad/path/that/should/not/exist/i/hope");
+    env.put("PLAYWRIGHT_DOWNLOAD_HOST", "https://127.0.0.127");
+    // Make sure the browsers are not installed yet by pointing at an empty dir.
+    env.put("PLAYWRIGHT_BROWSERS_PATH", tmpDir.toString());
 
     assertThrows(RuntimeException.class, () -> Driver.ensureDriverInstalled(env, true));
     assertThrows(RuntimeException.class, () -> Driver.ensureDriverInstalled(env, true));


### PR DESCRIPTION
The test is failing on the bots, especially [on windows](https://github.com/microsoft/playwright-java/runs/6266381222?check_suite_focus=true):

```
Error:  Failures: 
Error:    TestInstall.shouldThrowWhenBrowserPathIsInvalid:52 Expected java.lang.RuntimeException to be thrown, but nothing was thrown.
```

#853