### PR TITLE
Added Selectors and Keyboard Manipulation Example

### DIFF
--- a/examples/src/main/java/org/example/SelectorsAndKeyboardManipulation.java
+++ b/examples/src/main/java/org/example/SelectorsAndKeyboardManipulation.java
@@ -24,14 +24,12 @@ public class SelectorsAndKeyboardManipulation {
       Browser browser = playwright.firefox().launch();
       BrowserContext context = browser.newContext();
       Page page = context.newPage();
-      page.navigate("https://playwright.dev/");
-      page.click("#__docusaurus > nav > div.navbar__inner > div.navbar__items.navbar__items--right > div.searchBox_qEbK > button");
-      page.waitForSelector("#docsearch-input");
-      page.type("#docsearch-input", "getting started");
-      page.waitForSelector("#docsearch-item-0 > a > div");
-      page.click("#docsearch-item-0 > a > div");
-      page.waitForSelector("#__docusaurus > div.main-wrapper > div > main > div > div > div.col.docItemCol_DM6M > div > article > div.theme-doc-markdown.markdown > header > h1");
-      page.screenshot(new Page.ScreenshotOptions().setPath(Paths.get("screenshot.png")));
+      page.navigate("https://playwright.dev/java/");
+      page.locator("text=SearchK").click();
+      page.locator("[placeholder=\"Search docs\"]").fill("getting started");
+      page.locator("div[role=\"button\"]:has-text(\"CancelIntroductionGetting startedInstallation​Getting startedUsage​Getting start\")").click();
+      page.waitForSelector("h1:has-text(\"Getting started\")"); // Waits for the new page to load before screenshotting.
+      page.screenshot(new Page.ScreenshotOptions().setPath(Paths.get("Screenshot.png")));
     }
   }
 }

--- a/examples/src/main/java/org/example/SelectorsAndKeyboardManipulation.java
+++ b/examples/src/main/java/org/example/SelectorsAndKeyboardManipulation.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.example;
+
+import com.microsoft.playwright.*;
+
+public class SelectorsAndKeyboardManipulation {
+  public class void main(String[] args) {
+    try(Playwright playwright = Playwright.create()) {
+      Browser browser = playwright.firefox().launch();
+      BrowserContext context = browser.newContext();
+      Page page = context.newPage();
+      page.navigate("https://playwright.dev/");
+      page.click("#__docusaurus > nav > div.navbar__inner > div.navbar__items.navbar__items--right > div.searchBox_qEbK > button");
+      page.waitForSelector("#docsearch-input");
+      page.type("#docsearch-input", "getting started");
+      page.waitForSelector("#docsearch-item-0 > a > div");
+      page.click("#docsearch-item-0 > a > div");
+      page.waitForSelector("#__docusaurus > div.main-wrapper > div > main > div > div > div.col.docItemCol_DM6M > div > article > div.theme-doc-markdown.markdown > header > h1");
+      page.screenshot(new Page.ScreenshotOptions().setPath(Paths.get("screenshot.png")));
+    }
+  }
+}

--- a/examples/src/main/java/org/example/SelectorsAndKeyboardManipulation.java
+++ b/examples/src/main/java/org/example/SelectorsAndKeyboardManipulation.java
@@ -19,7 +19,7 @@ package org.example;
 import com.microsoft.playwright.*;
 
 public class SelectorsAndKeyboardManipulation {
-  public class void main(String[] args) {
+  public static void main(String[] args) {
     try(Playwright playwright = Playwright.create()) {
       Browser browser = playwright.firefox().launch();
       BrowserContext context = browser.newContext();


### PR DESCRIPTION
I've noticed that in the examples, there weren't any showcases on how to use selectors and keyboard manipulation, so I've created one.

One of the main things that makes Playwright "Playwright" and just a web scraper is keyboard manipulation. One of the main things that Playwright can do that other web scrapers can't, is click on different selectors and manipulate the keyboard into accessing certain pages. 

I've made a simple example of how Playwright works with selectors. This example is quite simple. All it does is just go to "https://playwright.dev/java/", searches up "getting started" clicks on the First Script button, and takes a screenshot once new page loads.