### PR TITLE
An excessive "." has been removed in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ public class InterceptNetworkRequests {
 
 ## Documentation
 
-Check out our [new documentation site](https://playwright.dev/java)!.
+Check out our [new documentation site](https://playwright.dev/java)!
 
 You can also browse [javadoc online](https://www.javadoc.io/doc/com.microsoft.playwright/playwright/latest/index.html).
 


### PR DESCRIPTION
Just a small typo fix to demonstrate on my YouTube channel for those who are just starting with the OpenSource.