### PR TITLE
fix: use same eol setting in gitattributes as upstream

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,5 @@
 # text files must be lf for golden file tests to work
-*.txt eol=lf
-*.json eol=lf
+* text=auto eol=lf
+
+# make project show as TS on GitHub
+*.js linguist-detectable=false


### PR DESCRIPTION
This should fix TestHar failures on Windows.