### PR TITLE
chore: remove isolated tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,18 +31,14 @@ jobs:
     - name: Build & Install
       run: mvn -B install -D skipTests --no-transfer-progress
     - name: Run tests
-      run: mvn test -DexcludedGroups=isolated --no-transfer-progress --fail-at-end
+      run: mvn test --no-transfer-progress --fail-at-end
       env:
         BROWSER: ${{ matrix.browser }}
     - name: Run tracing tests w/ sources
-      run: mvn test -DexcludedGroups=isolated --no-transfer-progress --fail-at-end -D test=*TestTracing*
+      run: mvn test --no-transfer-progress --fail-at-end -D test=*TestTracing*
       env:
         BROWSER: ${{ matrix.browser }}
         PLAYWRIGHT_JAVA_SRC: src/test/java
-    - name: Run driver throw tests
-      run: mvn test -Dgroups=driverThrowTest --no-transfer-progress --fail-at-end
-      env:
-        BROWSER: ${{ matrix.browser }}
     - name: Test Spring Boot Starter
       shell: bash
       env:
@@ -83,12 +79,7 @@ jobs:
       - name: Build & Install
         run: mvn -B install -D skipTests --no-transfer-progress
       - name: Run tests
-        run: mvn test -DexcludedGroups=isolated --no-transfer-progress --fail-at-end
-        env:
-          BROWSER: chromium
-          BROWSER_CHANNEL: ${{ matrix.browser-channel }}
-      - name: Run driver throw tests
-        run: mvn test -Dgroups=driverThrowTest --no-transfer-progress --fail-at-end
+        run: mvn test --no-transfer-progress --fail-at-end
         env:
           BROWSER: chromium
           BROWSER_CHANNEL: ${{ matrix.browser-channel }}


### PR DESCRIPTION
The test was failing in Docker and flaky on other bots (apparently because the browsers were already downloaded). Instead of running it in "isolation" just use reflection to temporarily clear singleton instance reference field.