### PR TITLE
fix: no split packages for compatibility with modules

### DIFF
--- a/driver-bundle/src/main/java/com/microsoft/playwright/impl/driver/jar/DriverJar.java
+++ b/driver-bundle/src/main/java/com/microsoft/playwright/impl/driver/jar/DriverJar.java
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 
-package com.microsoft.playwright.impl;
+package com.microsoft.playwright.impl.driver.jar;
+
+import com.microsoft.playwright.impl.driver.Driver;
 
 import java.io.IOException;
 import java.net.URI;
@@ -163,7 +165,7 @@ public class DriverJar extends Driver {
   }
 
   @Override
-  Path driverDir() {
+  protected Path driverDir() {
     return driverTempDir;
   }
 }

--- a/driver-bundle/src/test/java/com/microsoft/playwright/TestInstall.java
+++ b/driver-bundle/src/test/java/com/microsoft/playwright/TestInstall.java
@@ -16,8 +16,8 @@
 
 package com.microsoft.playwright;
 
-import com.microsoft.playwright.impl.Driver;
-import com.microsoft.playwright.impl.DriverJar;
+import com.microsoft.playwright.impl.driver.Driver;
+import com.microsoft.playwright.impl.driver.jar.DriverJar;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;

--- a/driver/src/main/java/com/microsoft/playwright/impl/driver/Driver.java
+++ b/driver/src/main/java/com/microsoft/playwright/impl/driver/Driver.java
@@ -14,14 +14,13 @@
  * limitations under the License.
  */
 
-package com.microsoft.playwright.impl;
+package com.microsoft.playwright.impl.driver;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.time.ZonedDateTime;
 import java.util.Map;
 
-import static com.microsoft.playwright.impl.DriverLogging.logWithTimestamp;
+import static com.microsoft.playwright.impl.driver.DriverLogging.logWithTimestamp;
 
 /**
  * This class provides access to playwright-cli. It can be either preinstalled
@@ -44,7 +43,7 @@ public abstract class Driver {
     }
 
     @Override
-    Path driverDir() {
+    protected Path driverDir() {
       return driverDir;
     }
   }
@@ -100,12 +99,12 @@ public abstract class Driver {
     }
 
     String driverImpl =
-      System.getProperty("playwright.driver.impl", "com.microsoft.playwright.impl.DriverJar");
+      System.getProperty("playwright.driver.impl", "com.microsoft.playwright.impl.driver.jar.DriverJar");
     Class<?> jarDriver = Class.forName(driverImpl);
     return (Driver) jarDriver.getDeclaredConstructor().newInstance();
   }
 
-  abstract Path driverDir();
+  protected abstract Path driverDir();
 
   protected static void logMessage(String message) {
     // This matches log format produced by the server.

--- a/driver/src/main/java/com/microsoft/playwright/impl/driver/DriverLogging.java
+++ b/driver/src/main/java/com/microsoft/playwright/impl/driver/DriverLogging.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.microsoft.playwright.impl;
+package com.microsoft.playwright.impl.driver;
 
 import java.time.ZoneId;
 import java.time.ZonedDateTime;

--- a/playwright/src/main/java/com/microsoft/playwright/CLI.java
+++ b/playwright/src/main/java/com/microsoft/playwright/CLI.java
@@ -16,7 +16,7 @@
 
 package com.microsoft.playwright;
 
-import com.microsoft.playwright.impl.Driver;
+import com.microsoft.playwright.impl.driver.Driver;
 
 import java.io.IOException;
 import java.nio.file.Path;

--- a/playwright/src/main/java/com/microsoft/playwright/impl/PlaywrightImpl.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/PlaywrightImpl.java
@@ -21,6 +21,7 @@ import com.microsoft.playwright.APIRequest;
 import com.microsoft.playwright.Playwright;
 import com.microsoft.playwright.PlaywrightException;
 import com.microsoft.playwright.Selectors;
+import com.microsoft.playwright.impl.driver.Driver;
 
 import java.io.IOException;
 import java.nio.file.Path;

--- a/playwright/src/test/java/com/microsoft/playwright/TestBrowserTypeConnect.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestBrowserTypeConnect.java
@@ -16,7 +16,7 @@
 
 package com.microsoft.playwright;
 
-import com.microsoft.playwright.impl.Driver;
+import com.microsoft.playwright.impl.driver.Driver;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeAll;

--- a/playwright/src/test/java/com/microsoft/playwright/TestPageRequestFallback.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestPageRequestFallback.java
@@ -133,14 +133,10 @@ public class TestPageRequestFallback extends TestBase {
   @Test
   void shouldChainOnce() {
     page.route("**/empty.html", route -> {
-      System.out.println("before fulfill");
       route.fulfill(new Route.FulfillOptions().setStatus(200).setBody("fulfilled one"));
-      System.out.println("after fulfill");
     }, new Page.RouteOptions().setTimes(1));
     page.route("**/empty.html", route -> {
-      System.out.println("before fallback");
       route.fallback();
-      System.out.println("after fallback");
     }, new Page.RouteOptions().setTimes(1));
     Response response = page.navigate(server.EMPTY_PAGE);
     assertEquals("fulfilled one", response.text());


### PR DESCRIPTION
Java 9 module system doesn't allow split packages (i.e. when same package is defined in more than one module). This PR makes each Playwright Maven module define unique package names. Only implementation (driver) packages are affected.

Fixes #996