### PR TITLE
fix: prevent video.saveAs() from hanging

### DIFF
--- a/playwright/src/main/java/com/microsoft/playwright/impl/VideoImpl.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/VideoImpl.java
@@ -72,6 +72,9 @@ class VideoImpl implements Video {
   @Override
   public void saveAs(Path path) {
     page.withLogging("Video.saveAs", () -> {
+      if (!page.isClosed()) {
+        throw new PlaywrightException("Page is not yet closed. Close the page prior to calling saveAs");
+      }
       try {
         waitForArtifact().saveAs(path);
       } catch (PlaywrightException e) {

--- a/playwright/src/test/java/com/microsoft/playwright/TestScreencast.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestScreencast.java
@@ -127,4 +127,17 @@ public class TestScreencast extends TestBase {
     assertTrue(Files.exists(files.get(0)));
     assertTrue(Files.size(files.get(0)) > 0);
   }
+
+  @Test
+  void shouldErrorIfPageNotClosedBeforeSaveAs(@TempDir Path tmpDir) {
+    try (Page page = browser.newPage(new Browser.NewPageOptions().setRecordVideoDir(tmpDir))) {
+      page.navigate(server.PREFIX + "/grid.html");
+      Path outPath = tmpDir.resolve("some-video.webm");
+      Video video = page.video();
+      PlaywrightException exception = assertThrows(PlaywrightException.class, () -> video.saveAs(outPath));
+      assertTrue(
+        exception.getMessage().contains("Page is not yet closed. Close the page prior to calling saveAs"),
+        exception.getMessage());
+    }
+  }
 }


### PR DESCRIPTION
Copy python logic from https://github.com/microsoft/playwright-python/pull/1474