### PR TITLE
tests: unflake TestBrowserContextAddCookies.shouldRoundtripCookie

### DIFF
--- a/playwright/src/test/java/com/microsoft/playwright/TestBase.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestBase.java
@@ -18,6 +18,8 @@ package com.microsoft.playwright;
 
 import org.junit.jupiter.api.*;
 
+import com.microsoft.playwright.options.SameSiteAttribute;
+
 import java.io.IOException;
 
 import static com.microsoft.playwright.Utils.getBrowserNameFromEnv;
@@ -35,9 +37,11 @@ public class TestBase {
   static final boolean isMac = Utils.getOS() == Utils.OS.MAC;
   static final boolean isWindows = Utils.getOS() == Utils.OS.WINDOWS;
   static final boolean headful;
+  static final SameSiteAttribute defaultSameSiteCookieValue;
   static {
     String headfulEnv = System.getenv("HEADFUL");
     headful = headfulEnv != null && !"0".equals(headfulEnv) && !"false".equals(headfulEnv);
+    defaultSameSiteCookieValue = initSameSiteAttribute();
   }
 
   // Fields reset before each test.
@@ -144,5 +148,12 @@ public class TestBase {
       context = null;
       page = null;
     }
+  }
+
+  private static SameSiteAttribute initSameSiteAttribute() {
+    if (isChromium()) return SameSiteAttribute.LAX;
+    if (isWebKit()) return SameSiteAttribute.NONE;
+    // for firefox version >= 103 'None' is used.
+    return SameSiteAttribute.NONE;
   }
 }

--- a/playwright/src/test/java/com/microsoft/playwright/TestBrowserContextAddCookies.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestBrowserContextAddCookies.java
@@ -51,15 +51,21 @@ public class TestBrowserContextAddCookies extends TestBase {
       "}");
     assertEquals("username=John Doe", documentCookie);
     List<Cookie> cookies = context.cookies();
-    context.clearCookies();
-    assertEquals(emptyList(), context.cookies());
-    context.addCookies(asList(new Cookie(cookies.get(0).name, cookies.get(0).value)
-      .setDomain(cookies.get(0).domain)
-      .setPath(cookies.get(0).path)
-      .setExpires(cookies.get(0).expires)
-      .setSameSite(cookies.get(0).sameSite)
-    ));
-    assertJsonEquals(new Gson().toJson(cookies), context.cookies());
+    assertEquals(1, cookies.size());
+    assertEquals("username", cookies.get(0).name);
+    assertEquals("John Doe", cookies.get(0).value);
+    assertEquals("localhost", cookies.get(0).domain);
+    assertEquals("/", cookies.get(0).path);
+    assertFalse(cookies.get(0).httpOnly);
+    assertEquals(defaultSameSiteCookieValue, cookies.get(0).sameSite);
+
+    // Browsers start to cap cookies with 400 days max expires value.
+    // See https://github.com/httpwg/http-extensions/pull/1732
+    // Chromium patch: https://chromium.googlesource.com/chromium/src/+/aaa5d2b55478eac2ee642653dcd77a50ac3faff6
+    // We want to make sure that expires date is at least 400 days in future.
+    int FOUR_HUNDRED_DAYS = 1000 * 60 * 60 * 24 * 400;
+    int FIVE_MINUTES = 1000 * 60 * 5; // relax condition a bit to make sure test is not flaky.
+    assertTrue(cookies.get(0).expires > ((System.currentTimeMillis() + FOUR_HUNDRED_DAYS - FIVE_MINUTES) / 1000));
   }
 
   @Test


### PR DESCRIPTION
an example failure: (see https://github.com/microsoft/playwright-java/runs/8146887116?check_suite_focus=true#step:7:345 )

Failures: 
Error:    TestBrowserContextAddCookies.shouldRoundtripCookie:62 expected: <[{"name":"username","value":"John Doe","domain":"localhost","path":"/","expires":1.696635616179373E9,"httpOnly":false,"secure":false,"sameSite":"LAX"}]> but was: <[{"name":"username","value":"John Doe","domain":"localhost","path":"/","expires":1.69663561617426E9,"httpOnly":false,"secure":false,"sameSite":"LAX"}]>

notice the `expires` property is different by a fraction.
in https://github.com/microsoft/playwright/blob/c58bfd0552da433cf69cc3ed8eadd1041e75a364/tests/library/browsercontext-cookies.spec.ts#L43-L73 this property is tested seperately