### PR TITLE
fix: serialize LocalDateTime parameters as Date

### DIFF
--- a/playwright/src/main/java/com/microsoft/playwright/impl/Serialization.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/Serialization.java
@@ -33,6 +33,8 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.*;
 import java.util.regex.Pattern;
 
@@ -150,6 +152,8 @@ class Serialization {
         result.s = (String) value;
       } else if (value instanceof Date) {
         result.d = ((Date)value).toInstant().toString();
+      } else if (value instanceof LocalDateTime) {
+        result.d = ((LocalDateTime)value).atZone(ZoneId.systemDefault()).toInstant().toString();
       } else if (value instanceof URL) {
         result.u = ((URL)value).toString();
       } else if (value instanceof Pattern) {

--- a/playwright/src/test/java/com/microsoft/playwright/TestPageEvaluate.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestPageEvaluate.java
@@ -19,12 +19,12 @@ package com.microsoft.playwright;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIf;
 
+import java.time.*;
 import java.util.Map;
 import java.util.regex.Pattern;
 import java.util.Date;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.time.ZonedDateTime;
 
 import static com.microsoft.playwright.Utils.mapOf;
 import static java.util.Arrays.asList;
@@ -628,5 +628,14 @@ public class TestPageEvaluate extends TestBase {
     Map<String, Object> map = (Map<String, Object>) result;
     assertEquals(1, map.size());
     assertTrue(map == map.get("b"));
+  }
+
+  @Test
+  void shouldAcceptParameter() {
+    Instant instant = Instant.now();
+    LocalDateTime localDateTime = instant.atZone(ZoneId.systemDefault()).toLocalDateTime();
+    Object object = page.evaluate("p => p", localDateTime);
+    assertTrue(object instanceof Date);
+    assertEquals(Date.from(instant), object);
   }
 }


### PR DESCRIPTION
Since LocalDateTime is "cannot represent an instant on the time-line without additional information such as an offset or time-zone." we use system default time zone to serialize its value to protocol. All parsed timestamps are still represented as Date.

Fixes https://github.com/microsoft/playwright-java/issues/1044