### PR TITLE
feat(docker): bump jdk version to 17

### DIFF
--- a/utils/docker/Dockerfile.focal
+++ b/utils/docker/Dockerfile.focal
@@ -6,7 +6,7 @@ ARG DOCKER_IMAGE_NAME_TEMPLATE="mcr.microsoft.com/playwright/java:v%version%-foc
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-    openjdk-11-jdk maven \
+    openjdk-17-jdk maven \
     # Install utilities required for downloading browsers
     curl \
     # Install utilities required for downloading driver


### PR DESCRIPTION
Playwright itself is still compiled with JDK 8 to ensure it runs on JDK 8+ but there is no reason not to use latest available JDK version in the Docker.

Fixes https://github.com/microsoft/playwright-java/issues/1050