### PR TITLE
fix: asynchronous route handling

### DIFF
--- a/playwright/src/main/java/com/microsoft/playwright/impl/BrowserContextImpl.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/BrowserContextImpl.java
@@ -539,10 +539,10 @@ class BrowserContextImpl extends ChannelOwner implements BrowserContext {
 
   void handleRoute(RouteImpl route) {
     Router.HandleResult handled = routes.handle(route);
-    if (handled == Router.HandleResult.FoundMatchingHandler) {
+    if (handled != Router.HandleResult.NoMatchingHandler) {
       maybeDisableNetworkInterception();
     }
-    if (!route.isHandled()){
+    if (handled != Router.HandleResult.PendingHandler) {
       route.resume();
     }
   }

--- a/playwright/src/main/java/com/microsoft/playwright/impl/BrowserContextImpl.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/BrowserContextImpl.java
@@ -542,7 +542,7 @@ class BrowserContextImpl extends ChannelOwner implements BrowserContext {
     if (handled != Router.HandleResult.NoMatchingHandler) {
       maybeDisableNetworkInterception();
     }
-    if (handled != Router.HandleResult.PendingHandler) {
+    if (handled == Router.HandleResult.NoMatchingHandler || handled == Router.HandleResult.Fallback) {
       route.resume();
     }
   }

--- a/playwright/src/main/java/com/microsoft/playwright/impl/PageImpl.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/PageImpl.java
@@ -188,10 +188,10 @@ public class PageImpl extends ChannelOwner implements Page {
     } else if ("route".equals(event)) {
       RouteImpl route = connection.getExistingObject(params.getAsJsonObject("route").get("guid").getAsString());
       Router.HandleResult handled = routes.handle(route);
-      if (handled == Router.HandleResult.FoundMatchingHandler) {
+      if (handled != Router.HandleResult.NoMatchingHandler) {
         maybeDisableNetworkInterception();
       }
-      if (!route.isHandled()) {
+      if (handled == Router.HandleResult.NoMatchingHandler || handled == Router.HandleResult.Fallback) {
         browserContext.handleRoute(route);
       }
     } else if ("video".equals(event)) {

--- a/playwright/src/main/java/com/microsoft/playwright/impl/RouteImpl.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/RouteImpl.java
@@ -34,6 +34,9 @@ public class RouteImpl extends ChannelOwner implements Route {
   private final RequestImpl request;
   private boolean handled;
 
+  boolean fallbackCalled;
+  boolean shouldResumeIfFallbackIsCalled;
+
   public RouteImpl(ChannelOwner parent, String type, String guid, JsonObject initializer) {
     super(parent, type, guid, initializer);
     request = connection.getExistingObject(initializer.getAsJsonObject("request").get("guid").getAsString());
@@ -62,10 +65,14 @@ public class RouteImpl extends ChannelOwner implements Route {
 
   @Override
   public void fallback(FallbackOptions options) {
+    fallbackCalled = true;
     if (handled) {
       throw new PlaywrightException("Route is already handled!");
     }
     applyOverrides(options);
+    if (shouldResumeIfFallbackIsCalled) {
+      resume();
+    }
   }
 
   private void applyOverrides(FallbackOptions options) {


### PR DESCRIPTION
Allow to handle Route asynchronously. If a route handler matches but doesn't call any methods synchronously we assume it will handle the route later and stop iterating through other handlers in the list. If `fallback()` is called asynchronously it is equivalent to calling `resume()`.

Fixes https://github.com/microsoft/playwright-java/issues/1136