### PR TITLE
fix(docker): adduser error

### DIFF
--- a/utils/docker/Dockerfile.focal
+++ b/utils/docker/Dockerfile.focal
@@ -24,7 +24,7 @@ RUN apt-get update && \
     # Create the pwuser
     adduser pwuser
 
-RUN VERSION=3.8.6 && \
+RUN VERSION=3.8.7 && \
     curl -o - https://dlcdn.apache.org/maven/maven-3/$VERSION/binaries/apache-maven-$VERSION-bin.tar.gz | tar zxfv - -C /opt/ && \
     ln -s /opt/apache-maven-$VERSION/bin/mvn /usr/local/bin/
 

--- a/utils/docker/Dockerfile.focal
+++ b/utils/docker/Dockerfile.focal
@@ -1,5 +1,7 @@
 FROM ubuntu:focal
 
+ARG DEBIAN_FRONTEND=noninteractive
+ARG TZ=America/Los_Angeles
 ARG DOCKER_IMAGE_NAME_TEMPLATE="mcr.microsoft.com/playwright/java:v%version%-focal"
 
 # === INSTALL JDK and Maven ===


### PR DESCRIPTION
Fixes the following error:
```sh
Adding user `pwuser' ...
Adding new group `pwuser' (1000) ...
Adding new user `pwuser' (1000) with group `pwuser' ...
Creating home directory `/home/pwuser' ...
Copying files from `/etc/skel' ...
New password: Password change aborted.
passwd: Authentication token manipulation error
passwd: password unchanged
Use of uninitialized value $answer in chop at /usr/sbin/adduser line 591.
Use of uninitialized value $answer in pattern match (m//) at /usr/sbin/adduser line 592.
Try again? [y/N] Changing the user information for pwuser
Enter the new value, or press ENTER for the default
	Full Name []: 	Room Number []: 	Work Phone []: 	Home Phone []: 	Other []: Use of uninitialized value $answer in chop at /usr/sbin/adduser line 621.
Use of uninitialized value $answer in pattern match (m//) at /usr/sbin/adduser line 622.
Is the information correct? [Y/n] Removing intermediate container 6e37018401b3
```

Also bumped Maven version 3.8.6 -> 3.8.7 as their CDN only has latest version.