### PR TITLE
Add a yieldUntil(Supplier) method to Page and Frame objects

### DIFF
--- a/playwright/src/main/java/com/microsoft/playwright/Frame.java
+++ b/playwright/src/main/java/com/microsoft/playwright/Frame.java
@@ -20,6 +20,7 @@ import com.microsoft.playwright.options.*;
 import java.nio.file.Path;
 import java.util.*;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 import java.util.regex.Pattern;
 
 /**
@@ -5087,5 +5088,12 @@ public interface Frame {
    * @since v1.11
    */
   void waitForURL(Predicate<String> url, WaitForURLOptions options);
+
+  /**
+   * Yields to the Playwright event loop until the {@link Supplier} given returns true.
+   *
+   * @param condition The condition under which the yield will end.
+   */
+  void yieldUntil(Supplier<Boolean> condition);
 }
 

--- a/playwright/src/main/java/com/microsoft/playwright/Page.java
+++ b/playwright/src/main/java/com/microsoft/playwright/Page.java
@@ -21,6 +21,7 @@ import java.nio.file.Path;
 import java.util.*;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 import java.util.regex.Pattern;
 
 /**
@@ -321,6 +322,13 @@ public interface Page extends AutoCloseable {
    * Removes handler that was previously added with {@link #onWorker onWorker(handler)}.
    */
   void offWorker(Consumer<Worker> handler);
+
+  /**
+   * Yields to the Playwright event loop until the {@link Supplier} given returns true.
+   *
+   * @param condition The condition under which the yield will end.
+   */
+  void yieldUntil(Supplier<Boolean> condition);
 
   class AddScriptTagOptions {
     /**

--- a/playwright/src/main/java/com/microsoft/playwright/impl/FrameImpl.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/FrameImpl.java
@@ -29,6 +29,7 @@ import java.nio.file.Path;
 import java.util.*;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 import java.util.regex.Pattern;
 
 import static com.microsoft.playwright.impl.LocatorUtils.*;
@@ -1093,6 +1094,26 @@ public class FrameImpl extends ChannelOwner implements Frame {
   @Override
   public void waitForURL(Predicate<String> url, WaitForURLOptions options) {
     waitForURL(new UrlMatcher(url), options);
+  }
+
+  @Override
+  public void yieldUntil(Supplier<Boolean> condition) {
+    runUntil(() -> {}, new Waitable<Object>() {
+      @Override
+      public boolean isDone() {
+        return condition.get();
+      }
+
+      @Override
+      public Object get() {
+        return null;
+      }
+
+      @Override
+      public void dispose() {
+
+      }
+    });
   }
 
   private void waitForURL(UrlMatcher matcher, WaitForURLOptions options) {

--- a/playwright/src/main/java/com/microsoft/playwright/impl/PageImpl.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/PageImpl.java
@@ -27,6 +27,7 @@ import java.nio.file.Path;
 import java.util.*;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 import java.util.regex.Pattern;
 
 import static com.microsoft.playwright.impl.Serialization.gson;
@@ -1499,6 +1500,26 @@ public class PageImpl extends ChannelOwner implements Page {
         } finally {
           offDialog(this);
         }
+      }
+    });
+  }
+
+  @Override
+  public void yieldUntil(Supplier<Boolean> condition) {
+    runUntil(() -> {}, new Waitable<Object>() {
+      @Override
+      public boolean isDone() {
+        return condition.get();
+      }
+
+      @Override
+      public Object get() {
+        return null;
+      }
+
+      @Override
+      public void dispose() {
+
       }
     });
   }


### PR DESCRIPTION
Adds a yieldUntil(Supplier) method to the Page and Frame objects. This allows Playwright users to yield to the Playwright event loop until an external condition is met.

See microsoft/playwright-java#1228 for more details.