### PR TITLE
test: Restrain sending http credentials on a specific origin (for roll 1.33 driver)

### DIFF
--- a/playwright/src/test/java/com/microsoft/playwright/TestBrowserContextCredentials.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestBrowserContextCredentials.java
@@ -77,6 +77,32 @@ public class TestBrowserContextCredentials extends TestBase {
   }
 
   @Test
+  void shouldWorkWithCorrectCredentialsAndMatchingOrigin() {
+    server.setAuth("/empty.html", "user", "pass");
+    final HttpCredentials httpCredentials = new HttpCredentials("user", "pass");
+    httpCredentials.setOrigin(server.PREFIX);
+    try (BrowserContext context = browser.newContext(new Browser.NewContextOptions()
+      .setHttpCredentials(httpCredentials))) {
+      Page page = context.newPage();
+      Response response = page.navigate(server.EMPTY_PAGE);
+      assertEquals(200, response.status());
+    }
+  }
+
+  @Test
+  void shouldWorkWithCorrectCredentialsAndMatchingOriginCaseInsensitive() {
+    server.setAuth("/empty.html", "user", "pass");
+    final HttpCredentials httpCredentials = new HttpCredentials("user", "pass");
+    httpCredentials.setOrigin(server.PREFIX.toUpperCase());
+    try (BrowserContext context = browser.newContext(new Browser.NewContextOptions()
+      .setHttpCredentials(httpCredentials))) {
+      Page page = context.newPage();
+      Response response = page.navigate(server.EMPTY_PAGE);
+      assertEquals(200, response.status());
+    }
+  }
+
+  @Test
   void shouldFailWithCorrectCredentialsAndWrongOriginScheme() {
     server.setAuth("/empty.html", "user", "pass");
     final HttpCredentials httpCredentials = new HttpCredentials("user", "pass");

--- a/playwright/src/test/java/com/microsoft/playwright/TestBrowserContextCredentials.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestBrowserContextCredentials.java
@@ -16,6 +16,7 @@
 
 package com.microsoft.playwright;
 
+import com.microsoft.playwright.options.HttpCredentials;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIf;
 
@@ -72,6 +73,42 @@ public class TestBrowserContextCredentials extends TestBase {
       assertEquals(200, response.status());
       assertEquals("Playground", page.title());
       assertTrue(new String(response.body()).contains("Playground"));
+    }
+  }
+
+  @Test
+  void shouldFailWithCorrectCredentialsAndWrongOriginScheme() {
+    server.setAuth("/empty.html", "user", "pass");
+    final HttpCredentials httpCredentials = new HttpCredentials("user", "pass");
+    httpCredentials.setOrigin(Utils.generateDifferentOriginScheme(server));
+    try (BrowserContext context = browser.newContext(new Browser.NewContextOptions().setHttpCredentials(httpCredentials))) {
+      Page page = context.newPage();
+      Response response = page.navigate(server.EMPTY_PAGE);
+      assertEquals(401, response.status());
+    }
+  }
+
+  @Test
+  void shouldFailWithCorrectCredentialsAndWrongOriginHostname() {
+    server.setAuth("/empty.html", "user", "pass");
+    final HttpCredentials httpCredentials = new HttpCredentials("user", "pass");
+    httpCredentials.setOrigin(Utils.generateDifferentOriginHostname(server));
+    try (BrowserContext context = browser.newContext(new Browser.NewContextOptions().setHttpCredentials(httpCredentials))) {
+      Page page = context.newPage();
+      Response response = page.navigate(server.EMPTY_PAGE);
+      assertEquals(401, response.status());
+    }
+  }
+
+  @Test
+  void shouldFailWithCorrectCredentialsAndWrongOriginPort() {
+    server.setAuth("/empty.html", "user", "pass");
+    final HttpCredentials httpCredentials = new HttpCredentials("user", "pass");
+    httpCredentials.setOrigin(Utils.generateDifferentOriginPort(server));
+    try (BrowserContext context = browser.newContext(new Browser.NewContextOptions().setHttpCredentials(httpCredentials))) {
+      Page page = context.newPage();
+      Response response = page.navigate(server.EMPTY_PAGE);
+      assertEquals(401, response.status());
     }
   }
 }

--- a/playwright/src/test/java/com/microsoft/playwright/TestBrowserContextFetch.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestBrowserContextFetch.java
@@ -671,4 +671,37 @@ public class TestBrowserContextFetch extends TestBase {
     e = assertThrows(PlaywrightException.class, () ->  context.request().post(server.EMPTY_PAGE));
     assertTrue(e.getMessage().contains("Target page, context or browser has been closed"), e.getMessage());
   }
+
+  @Test
+  void shouldReturnErrorWithCorrectCredentialsAndWrongOriginScheme() {
+    server.setAuth("/empty.html", "user", "pass");
+    final HttpCredentials httpCredentials = new HttpCredentials("user", "pass");
+    httpCredentials.setOrigin(Utils.generateDifferentOriginScheme(server));
+    try (BrowserContext context = browser.newContext(new Browser.NewContextOptions().setHttpCredentials(httpCredentials))) {
+      APIResponse response = context.request().get(server.EMPTY_PAGE);
+      assertEquals(401, response.status());
+    }
+  }
+
+  @Test
+  void shouldReturnErrorWithCorrectCredentialsAndWrongOriginHostname() {
+    server.setAuth("/empty.html", "user", "pass");
+    final HttpCredentials httpCredentials = new HttpCredentials("user", "pass");
+    httpCredentials.setOrigin(Utils.generateDifferentOriginHostname(server));
+    try (BrowserContext context = browser.newContext(new Browser.NewContextOptions().setHttpCredentials(httpCredentials))) {
+      APIResponse response = context.request().get(server.EMPTY_PAGE);
+      assertEquals(401, response.status());
+    }
+  }
+
+  @Test
+  void shouldReturnErrorWithCorrectCredentialsAndWrongOriginPort() {
+    server.setAuth("/empty.html", "user", "pass");
+    final HttpCredentials httpCredentials = new HttpCredentials("user", "pass");
+    httpCredentials.setOrigin(Utils.generateDifferentOriginPort(server));
+    try (BrowserContext context = browser.newContext(new Browser.NewContextOptions().setHttpCredentials(httpCredentials))) {
+      APIResponse response = context.request().get(server.EMPTY_PAGE);
+      assertEquals(401, response.status());
+    }
+  }
 }

--- a/playwright/src/test/java/com/microsoft/playwright/TestBrowserContextFetch.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestBrowserContextFetch.java
@@ -673,6 +673,36 @@ public class TestBrowserContextFetch extends TestBase {
   }
 
   @Test
+  void shouldWorkWithSetHTTPCredentialsAndMatchingOrigin() throws ExecutionException, InterruptedException {
+    server.setAuth("/empty.html", "user", "pass");
+    APIResponse response1 = context.request().get(server.EMPTY_PAGE);
+    assertEquals(401, response1.status());
+
+    final HttpCredentials httpCredentials = new HttpCredentials("user", "pass");
+    httpCredentials.setOrigin(server.PREFIX);
+    try (BrowserContext context2 = browser.newContext(
+      new Browser.NewContextOptions().setHttpCredentials(httpCredentials))) {
+      APIResponse response2 = context2.request().get(server.EMPTY_PAGE);
+      assertEquals(200, response2.status());
+    }
+  }
+
+  @Test
+  void shouldWorkWithSetHTTPCredentialsAndMatchingOriginCaseInsensitive() throws ExecutionException, InterruptedException {
+    server.setAuth("/empty.html", "user", "pass");
+    APIResponse response1 = context.request().get(server.EMPTY_PAGE);
+    assertEquals(401, response1.status());
+
+    final HttpCredentials httpCredentials = new HttpCredentials("user", "pass");
+    httpCredentials.setOrigin(server.PREFIX.toUpperCase());
+    try (BrowserContext context2 = browser.newContext(
+      new Browser.NewContextOptions().setHttpCredentials(httpCredentials))) {
+      APIResponse response2 = context2.request().get(server.EMPTY_PAGE);
+      assertEquals(200, response2.status());
+    }
+  }
+
+  @Test
   void shouldReturnErrorWithCorrectCredentialsAndWrongOriginScheme() {
     server.setAuth("/empty.html", "user", "pass");
     final HttpCredentials httpCredentials = new HttpCredentials("user", "pass");

--- a/playwright/src/test/java/com/microsoft/playwright/TestGlobalFetch.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestGlobalFetch.java
@@ -413,6 +413,38 @@ public class TestGlobalFetch extends TestBase {
   }
 
   @Test
+  void shouldSupportGlobalHttpCredentialsOptionAndMatchingOrigin() {
+    server.setAuth("/empty.html", "user", "pass");
+    APIRequestContext request1 = playwright.request().newContext();
+    APIResponse response1 = request1.get(server.EMPTY_PAGE);
+    assertEquals(401, response1.status());
+    request1.dispose();
+
+    final HttpCredentials httpCredentials = new HttpCredentials("user", "pass");
+    httpCredentials.setOrigin(server.PREFIX);
+    APIRequestContext request2 = playwright.request().newContext(new APIRequest.NewContextOptions().setHttpCredentials(httpCredentials));
+    APIResponse response2 = request2.get(server.EMPTY_PAGE);
+    assertEquals(200, response2.status());
+    request2.dispose();
+  }
+
+  @Test
+  void shouldSupportGlobalHttpCredentialsOptionAndMatchingOriginCaseInsensitive() {
+    server.setAuth("/empty.html", "user", "pass");
+    APIRequestContext request1 = playwright.request().newContext();
+    APIResponse response1 = request1.get(server.EMPTY_PAGE);
+    assertEquals(401, response1.status());
+    request1.dispose();
+
+    final HttpCredentials httpCredentials = new HttpCredentials("user", "pass");
+    httpCredentials.setOrigin(server.PREFIX.toUpperCase());
+    APIRequestContext request2 = playwright.request().newContext(new APIRequest.NewContextOptions().setHttpCredentials(httpCredentials));
+    APIResponse response2 = request2.get(server.EMPTY_PAGE);
+    assertEquals(200, response2.status());
+    request2.dispose();
+  }
+
+  @Test
   void shouldReturnErrorWithCorrectCredentialsAndWrongOriginScheme() {
     server.setAuth("/empty.html", "user", "pass");
     final HttpCredentials httpCredentials = new HttpCredentials("user", "pass");

--- a/playwright/src/test/java/com/microsoft/playwright/TestGlobalFetch.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestGlobalFetch.java
@@ -1,6 +1,7 @@
 package com.microsoft.playwright;
 
 import com.google.gson.Gson;
+import com.microsoft.playwright.options.HttpCredentials;
 import com.microsoft.playwright.options.HttpHeader;
 import com.microsoft.playwright.options.RequestOptions;
 import org.junit.jupiter.api.Disabled;
@@ -409,6 +410,36 @@ public class TestGlobalFetch extends TestBase {
       assertEquals("PUT", response.text());
     }
     request.dispose();
+  }
+
+  @Test
+  void shouldReturnErrorWithCorrectCredentialsAndWrongOriginScheme() {
+    server.setAuth("/empty.html", "user", "pass");
+    final HttpCredentials httpCredentials = new HttpCredentials("user", "pass");
+    httpCredentials.setOrigin(Utils.generateDifferentOriginScheme(server));
+    APIRequestContext request = playwright.request().newContext(new APIRequest.NewContextOptions().setHttpCredentials(httpCredentials));
+    APIResponse response = request.get(server.EMPTY_PAGE);
+    assertEquals(401, response.status());
+  }
+
+  @Test
+  void shouldReturnErrorWithCorrectCredentialsAndWrongOriginHostname() {
+    server.setAuth("/empty.html", "user", "pass");
+    final HttpCredentials httpCredentials = new HttpCredentials("user", "pass");
+    httpCredentials.setOrigin(Utils.generateDifferentOriginHostname(server));
+    APIRequestContext request = playwright.request().newContext(new APIRequest.NewContextOptions().setHttpCredentials(httpCredentials));
+    APIResponse response = request.get(server.EMPTY_PAGE);
+    assertEquals(401, response.status());
+  }
+
+  @Test
+  void shouldReturnErrorWithCorrectCredentialsAndWrongOriginPort() {
+    server.setAuth("/empty.html", "user", "pass");
+    final HttpCredentials httpCredentials = new HttpCredentials("user", "pass");
+    httpCredentials.setOrigin(Utils.generateDifferentOriginPort(server));
+    APIRequestContext request = playwright.request().newContext(new APIRequest.NewContextOptions().setHttpCredentials(httpCredentials));
+    APIResponse response = request.get(server.EMPTY_PAGE);
+    assertEquals(401, response.status());
   }
 
 }

--- a/playwright/src/test/java/com/microsoft/playwright/Utils.java
+++ b/playwright/src/test/java/com/microsoft/playwright/Utils.java
@@ -196,4 +196,18 @@ class Utils {
     assertEquals(width, page.evaluate("window.innerWidth"));
     assertEquals(height, page.evaluate("window.innerHeight"));
   }
+
+  static String generateDifferentOriginScheme(final Server server){
+    return server.PREFIX.startsWith("http://") ?
+      server.PREFIX.replace("http://", "https://") :
+      server.PREFIX.replace("https://", "http://");
+  }
+
+  static String generateDifferentOriginHostname(final Server server){
+    return server.PREFIX.replace("localhost", "mismatching-hostname");
+  }
+
+  static String generateDifferentOriginPort(final Server server){
+    return server.PREFIX.replace(String.valueOf(server.PORT), String.valueOf(server.PORT+1));
+  }
 }


### PR DESCRIPTION
Verify that the httpCredentials are not sent when origin mismatches (scheme or hostname or port different). See https://github.com/microsoft/playwright/pull/20374

It works on my side with roll of driver version 1.33.0-alpha-mar-28-2023 (I did not push the actual roll, I'll let you guys do it since other implementation may also need tests).