### PR TITLE
Updated dead links to use Playwright homepage in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ You can find Maven project with the examples [here](./examples).
 
 #### Page screenshot
 
-This code snippet navigates to whatsmyuseragent.org in Chromium, Firefox and WebKit, and saves 3 screenshots.
+This code snippet navigates to Playwright homepage in Chromium, Firefox and WebKit, and saves 3 screenshots.
 
 ```java
 import com.microsoft.playwright.*;
@@ -86,7 +86,7 @@ public class PageScreenshot {
         try (Browser browser = browserType.launch()) {
           BrowserContext context = browser.newContext();
           Page page = context.newPage();
-          page.navigate("http://whatsmyuseragent.org/");
+          page.navigate("https://playwright.dev/");
           page.screenshot(new Page.ScreenshotOptions().setPath(Paths.get("screenshot-" + browserType.name() + ".png")));
         }
       }

--- a/examples/src/main/java/org/example/PageScreenshot.java
+++ b/examples/src/main/java/org/example/PageScreenshot.java
@@ -34,7 +34,7 @@ public class PageScreenshot {
         try (Browser browser = browserType.launch()) {
           BrowserContext context = browser.newContext();
           Page page = context.newPage();
-          page.navigate("http://whatsmyuseragent.org/");
+          page.navigate("https://playwright.dev/");
           page.screenshot(new Page.ScreenshotOptions().setPath(Paths.get("screenshot-" + browserType.name() + ".png")));
         }
       }

--- a/examples/src/main/java/org/example/WebKitScreenshot.java
+++ b/examples/src/main/java/org/example/WebKitScreenshot.java
@@ -24,7 +24,7 @@ public class WebKitScreenshot {
     try (Playwright playwright = Playwright.create()) {
       Browser browser = playwright.webkit().launch();
       Page page = browser.newPage();
-      page.navigate("http://whatsmyuseragent.org/");
+      page.navigate("https://playwright.dev/");
       page.screenshot(new Page.ScreenshotOptions().setPath(Paths.get("example.png")));
     }
   }


### PR DESCRIPTION
Currently, the documentation uses `http://whatsmyuseragent.org/` which is now a dead link filled with ads

![image](https://github.com/microsoft/playwright-java/assets/59550818/16bd4783-ffe9-467c-9247-1691542fe366)

It should instead be consistant and use the Playwright homepage