### PR TITLE
chore: unflake TestBrowserContextProxy.shouldExcludePatterns

### DIFF
--- a/playwright/src/test/java/com/microsoft/playwright/TestBrowserContextProxy.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestBrowserContextProxy.java
@@ -175,17 +175,33 @@ public class TestBrowserContextProxy extends TestBase {
       // @see https://gist.github.com/CollinChaffin/24f6c9652efb3d6d5ef2f5502720ef00
       .setBypass("1.non.existent.domain.for.the.test, 2.non.existent.domain.for.the.test, .another.test")));
 
-    Page page = context.newPage();
-    page.navigate("http://0.non.existent.domain.for.the.test/target.html");
-    assertEquals("Served by the proxy", page.title());
-
-    assertThrows(PlaywrightException.class, () -> page.navigate("http://1.non.existent.domain.for.the.test/target.html"));
-    assertThrows(PlaywrightException.class, () -> page.navigate("http://2.non.existent.domain.for.the.test/target.html"));
-    assertThrows(PlaywrightException.class, () -> page.navigate("http://foo.is.the.another.test/target.html"));
-
-    page.navigate("http://3.non.existent.domain.for.the.test/target.html");
-    assertEquals("Served by the proxy", page.title());
-
+    {
+      Page page = context.newPage();
+      page.navigate("http://0.non.existent.domain.for.the.test/target.html");
+      assertEquals("Served by the proxy", page.title());
+      page.close();
+    }
+    {
+      Page page = context.newPage();
+      assertThrows(PlaywrightException.class, () -> page.navigate("http://1.non.existent.domain.for.the.test/target.html"));
+      page.close();
+    }
+    {
+      Page page = context.newPage();
+      assertThrows(PlaywrightException.class, () -> page.navigate("http://2.non.existent.domain.for.the.test/target.html"));
+      page.close();
+    }
+    {
+      Page page = context.newPage();
+      assertThrows(PlaywrightException.class, () -> page.navigate("http://foo.is.the.another.test/target.html"));
+      page.close();
+    }
+    {
+      Page page = context.newPage();
+      page.navigate("http://3.non.existent.domain.for.the.test/target.html");
+      assertEquals("Served by the proxy", page.title());
+      page.close();
+    }
     context.close();
   }
 


### PR DESCRIPTION
Fixes the following errors:

```
Error: 8 [ERROR] com.microsoft.playwright.TestBrowserContextProxy.shouldExcludePatterns  Time elapsed: 0.706 s  <<< ERROR!
com.microsoft.playwright.PlaywrightException: 
Error {
  message='Navigation to "http://3.non.existent.domain.for.the.test/target.html" is interrupted by another navigation to "http://foo.is.the.another.test/target.html"
=========================== logs ===========================
navigating to "http://3.non.existent.domain.for.the.test/target.html", waiting until "load"
============================================================
  name='Error
  stack='Error: Navigation to "http://3.non.existent.domain.for.the.test/target.html" is interrupted by another navigation to "http://foo.is.the.another.test/target.html"
=========================== logs ===========================
navigating to "http://3.non.existent.domain.for.the.test/target.html", waiting until "load"
============================================================
    at Frame._gotoAction (C:\Users\RUNNER~1\AppData\Local\Temp\playwright-java-2380[313](https://github.com/microsoft/playwright-java/actions/runs/6486747739/job/17615569982#step:7:314)377835283093\package\lib\server\frames.js:546:15)
    at runNextTicks (node:internal/process/task_queues:60:5)
    at process.processImmediate (node:internal/timers:447:9)
}
	at com.microsoft.playwright.TestBrowserContextProxy.shouldExcludePatterns(TestBrowserContextProxy.java:186)
Caused by: com.microsoft.playwright.impl.DriverException: 
Error {
  message='Navigation to "http://3.non.existent.domain.for.the.test/target.html" is interrupted by another navigation to "http://foo.is.the.another.test/target.html"
=========================== logs ===========================
navigating to "http://3.non.existent.domain.for.the.test/target.html", waiting until "load"
============================================================
  name='Error
  stack='Error: Navigation to "http://3.non.existent.domain.for.the.test/target.html" is interrupted by another navigation to "http://foo.is.the.another.test/target.html"
=========================== logs ===========================
navigating to "http://3.non.existent.domain.for.the.test/target.html", waiting until "load"
============================================================
    at Frame._gotoAction (C:\Users\RUNNER~1\AppData\Local\Temp\playwright-java-2380313377835283093\package\lib\server\frames.js:546:15)
    at runNextTicks (node:internal/process/task_queues:60:5)
    at process.processImmediate (node:internal/timers:447:9)
}
	at com.microsoft.playwright.TestBrowserContextProxy.shouldExcludePatterns(TestBrowserContextProxy.java:186)
```