### PR TITLE
test: do not rely on channel: chrome

### DIFF
--- a/playwright/src/test/java/com/microsoft/playwright/TestPlaywrightCustomOptionFixtures.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestPlaywrightCustomOptionFixtures.java
@@ -17,7 +17,7 @@ public class TestPlaywrightCustomOptionFixtures {
   public static class CustomOptions implements OptionsFactory {
     @Override
     public Options getOptions() {
-      return new Options().setChannel("chrome").setApiRequestOptions(new APIRequest.NewContextOptions().setBaseURL(serverMap.get(TestPlaywrightCustomOptionFixtures.class).EMPTY_PAGE)).setContextOption(new Browser.NewContextOptions().setBaseURL(serverMap.get(TestPlaywrightCustomOptionFixtures.class).EMPTY_PAGE));
+      return new Options().setApiRequestOptions(new APIRequest.NewContextOptions().setBaseURL(serverMap.get(TestPlaywrightCustomOptionFixtures.class).EMPTY_PAGE)).setContextOption(new Browser.NewContextOptions().setBaseURL(serverMap.get(TestPlaywrightCustomOptionFixtures.class).EMPTY_PAGE));
     }
   }
 


### PR DESCRIPTION
Motivation: There is no Google Chrome for `linux-arm64`.

Relates https://github.com/microsoft/playwright-browsers/pull/872.