### PR TITLE
test(junit): restore browser channel test

### DIFF
--- a/playwright/src/test/java/com/microsoft/playwright/TestPlaywrightCurtomFixturesChannel.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestPlaywrightCurtomFixturesChannel.java
@@ -1,0 +1,49 @@
+package com.microsoft.playwright;
+
+import com.microsoft.playwright.junit.Options;
+import com.microsoft.playwright.junit.OptionsFactory;
+import com.microsoft.playwright.junit.UsePlaywright;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIf;
+
+import static com.microsoft.playwright.ServerLifecycle.serverMap;
+import static org.junit.jupiter.api.Assertions.*;
+
+@FixtureTest
+@UsePlaywright(TestPlaywrightCurtomFixturesChannel.CustomOptions.class)
+@EnabledIf("isChannelSpecified")
+public class TestPlaywrightCurtomFixturesChannel {
+
+  public static class CustomOptions implements OptionsFactory {
+    @Override
+    public Options getOptions() {
+      return new Options().setChannel(channel());
+    }
+  }
+
+  public static boolean isChannelSpecified() {
+    return channel() != null;
+  }
+
+  public static String channel() {
+    return System.getenv("BROWSER_CHANNEL");
+  }
+
+  private Server server() {
+    return serverMap.get(this.getClass());
+  }
+
+  @Test
+  public void testBrowserChannel(Browser browser, Page page) {
+    assertEquals(browser.browserType().name(), "chromium");
+    page.navigate(server().EMPTY_PAGE);
+    String brands = (String) page.evaluate("navigator.userAgentData?.brands.map(b => b.brand).join(', ') || ''");
+    if (channel().contains("chrome")) {
+      assertTrue(brands.contains("Google Chrome") || brands.contains("HeadlessChrome"), brands);
+    } else if (channel().contains("msedge")) {
+      assertTrue(brands.contains("Microsoft Edge") || brands.contains("HeadlessEdg"), brands);
+    } else {
+      fail("Unknown channel: " + channel());
+    }
+  }
+}

--- a/playwright/src/test/java/com/microsoft/playwright/TestPlaywrightCustomFixturesChannel.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestPlaywrightCustomFixturesChannel.java
@@ -10,9 +10,9 @@ import static com.microsoft.playwright.ServerLifecycle.serverMap;
 import static org.junit.jupiter.api.Assertions.*;
 
 @FixtureTest
-@UsePlaywright(TestPlaywrightCurtomFixturesChannel.CustomOptions.class)
+@UsePlaywright(TestPlaywrightCustomFixturesChannel.CustomOptions.class)
 @EnabledIf("isChannelSpecified")
-public class TestPlaywrightCurtomFixturesChannel {
+public class TestPlaywrightCustomFixturesChannel {
 
   public static class CustomOptions implements OptionsFactory {
     @Override


### PR DESCRIPTION
The test only runs when `BROWSER_CHANNEL` env variable is provided.

Fixes https://github.com/microsoft/playwright-java/issues/1478