### PR TITLE
devops: do not ship .m2 directory

### DIFF
--- a/utils/docker/Dockerfile.focal
+++ b/utils/docker/Dockerfile.focal
@@ -54,4 +54,5 @@ RUN cd /tmp/pw-java && \
     mvn exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI \
                      -D exec.args="mark-docker-image '${DOCKER_IMAGE_NAME_TEMPLATE}'" -f playwright/pom.xml --no-transfer-progress && \
     rm -rf /tmp/pw-java && \
+    rm -rf /root/.m2/ && \
     chmod -R 777 $PLAYWRIGHT_BROWSERS_PATH

--- a/utils/docker/Dockerfile.jammy
+++ b/utils/docker/Dockerfile.jammy
@@ -54,6 +54,7 @@ RUN cd /tmp/pw-java && \
     mvn exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI \
                      -D exec.args="mark-docker-image '${DOCKER_IMAGE_NAME_TEMPLATE}'" -f playwright/pom.xml --no-transfer-progress && \
     rm -rf /tmp/pw-java && \
+    rm -rf /root/.m2/ && \
     # Workaround for https://github.com/microsoft/playwright/issues/27313
     # While the gstreamer plugin load process can be in-process, it ended up throwing
     # an error that it can't have libsoup2 and libsoup3 in the same process because


### PR DESCRIPTION
The `.m2` directory contains not only the production dependencies, it also contains the development dependencies in order to develop Playwright.