### PR TITLE
feat(junit): Close Playwright after test run

### DIFF
--- a/playwright/src/main/java/com/microsoft/playwright/junit/impl/PlaywrightExtension.java
+++ b/playwright/src/main/java/com/microsoft/playwright/junit/impl/PlaywrightExtension.java
@@ -5,6 +5,7 @@ import com.microsoft.playwright.junit.Options;
 import org.junit.jupiter.api.extension.*;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
@@ -22,7 +23,7 @@ public class PlaywrightExtension implements ParameterResolver, BeforeAllCallback
     isTestRunStarted = false;
     beforeLock = new ReentrantLock();
     threadLocalPlaywright = new ThreadLocal<>();
-    playwrightList = new ArrayList<>();
+    playwrightList = Collections.synchronizedList(new ArrayList<>());
   }
 
   // Before a Test class starts, we register a closeable resource

--- a/playwright/src/main/java/com/microsoft/playwright/junit/impl/PlaywrightExtension.java
+++ b/playwright/src/main/java/com/microsoft/playwright/junit/impl/PlaywrightExtension.java
@@ -18,6 +18,7 @@ public class PlaywrightExtension implements ParameterResolver, BeforeAllCallback
   private static final List<Playwright> playwrightList;
   private final static Lock beforeLock;
   private static boolean isTestRunStarted;
+  private static final ExtensionContext.Namespace namespace = ExtensionContext.Namespace.create(PlaywrightExtension.class);
 
   static {
     isTestRunStarted = false;
@@ -34,7 +35,7 @@ public class PlaywrightExtension implements ParameterResolver, BeforeAllCallback
       beforeLock.lock();
       if (!isTestRunStarted) {
         isTestRunStarted = true;
-        context.getRoot().getStore(ExtensionContext.Namespace.GLOBAL).put(context.getUniqueId(), this);
+        context.getRoot().getStore(namespace).put(context.getUniqueId(), this);
       }
     } finally {
       beforeLock.unlock();

--- a/playwright/src/main/java/com/microsoft/playwright/junit/impl/PlaywrightExtension.java
+++ b/playwright/src/main/java/com/microsoft/playwright/junit/impl/PlaywrightExtension.java
@@ -46,10 +46,9 @@ public class PlaywrightExtension implements ParameterResolver, BeforeAllCallback
   @Override
   public void close() throws Throwable {
     for (Playwright playwright : playwrightList) {
-      if (playwright != null) {
-        playwright.close();
-      }
+      playwright.close();
     }
+    playwrightList.clear();
   }
 
   @Override

--- a/playwright/src/test/java/com/microsoft/playwright/junit/ServerLifecycle.java
+++ b/playwright/src/test/java/com/microsoft/playwright/junit/ServerLifecycle.java
@@ -1,16 +1,15 @@
 package com.microsoft.playwright.junit;
 
 import com.microsoft.playwright.Server;
-import org.junit.jupiter.api.extension.AfterAllCallback;
-import org.junit.jupiter.api.extension.BeforeAllCallback;
-import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.*;
 
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
 import static com.microsoft.playwright.Utils.nextFreePort;
 
-public class ServerLifecycle implements BeforeAllCallback, AfterAllCallback {
+public class ServerLifecycle implements AfterAllCallback, ParameterResolver {
   // This is a public map so that objects outside test scope can access the server.
   // For example, nested classes inside test classes that define custom options and need the server.
   public static Map<Class<?>, Server> serverMap;
@@ -28,8 +27,21 @@ public class ServerLifecycle implements BeforeAllCallback, AfterAllCallback {
   }
 
   @Override
-  public void beforeAll(ExtensionContext extensionContext) throws Exception {
-    Server server = Server.createHttp(nextFreePort());
-    serverMap.put(extensionContext.getRequiredTestClass(), server);
+  public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext) throws ParameterResolutionException {
+    return Server.class.equals(parameterContext.getParameter().getType());
+  }
+
+  @Override
+  public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext) throws ParameterResolutionException {
+    Server server = serverMap.get(extensionContext.getRequiredTestClass());
+    if(server == null) {
+      try {
+        server = Server.createHttp(nextFreePort());
+        serverMap.put(extensionContext.getRequiredTestClass(), server);
+      } catch (IOException e) {
+        throw new ParameterResolutionException(e.getMessage());
+      }
+    }
+    return server;
   }
 }

--- a/playwright/src/test/java/com/microsoft/playwright/junit/ServerLifecycle.java
+++ b/playwright/src/test/java/com/microsoft/playwright/junit/ServerLifecycle.java
@@ -9,13 +9,18 @@ import java.util.Map;
 
 import static com.microsoft.playwright.Utils.nextFreePort;
 
-public class ServerLifecycle implements AfterAllCallback, ParameterResolver {
+public class ServerLifecycle implements BeforeAllCallback, AfterAllCallback, ParameterResolver {
   // This is a public map so that objects outside test scope can access the server.
   // For example, nested classes inside test classes that define custom options and need the server.
   public static Map<Class<?>, Server> serverMap;
 
   static {
     serverMap = new HashMap<>();
+  }
+
+  @Override
+  public void beforeAll(ExtensionContext extensionContext) throws Exception {
+    getOrCreateServer(extensionContext);
   }
 
   @Override
@@ -33,6 +38,10 @@ public class ServerLifecycle implements AfterAllCallback, ParameterResolver {
 
   @Override
   public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext) throws ParameterResolutionException {
+    return getOrCreateServer(extensionContext);
+  }
+
+  private Server getOrCreateServer(ExtensionContext extensionContext) {
     Server server = serverMap.get(extensionContext.getRequiredTestClass());
     if(server == null) {
       try {

--- a/playwright/src/test/java/com/microsoft/playwright/junit/TestFixtureChannelOption.java
+++ b/playwright/src/test/java/com/microsoft/playwright/junit/TestFixtureChannelOption.java
@@ -29,14 +29,10 @@ public class TestFixtureChannelOption {
     return System.getenv("BROWSER_CHANNEL");
   }
 
-  private Server server() {
-    return serverMap.get(this.getClass());
-  }
-
   @Test
-  public void testBrowserChannel(Browser browser, Page page) {
+  public void testBrowserChannel(Server server, Browser browser, Page page) {
     assertEquals(browser.browserType().name(), "chromium");
-    page.navigate(server().EMPTY_PAGE);
+    page.navigate(server.EMPTY_PAGE);
     String brands = (String) page.evaluate("navigator.userAgentData?.brands.map(b => b.brand).join(', ') || ''");
     if (channel().contains("chrome")) {
       assertTrue(brands.contains("Google Chrome") || brands.contains("HeadlessChrome"), brands);

--- a/playwright/src/test/java/com/microsoft/playwright/junit/TestFixtureDeviceOption.java
+++ b/playwright/src/test/java/com/microsoft/playwright/junit/TestFixtureDeviceOption.java
@@ -19,13 +19,9 @@ public class TestFixtureDeviceOption {
     }
   }
 
-  private Server server() {
-    return serverMap.get(this.getClass());
-  }
-
   @Test
-  public void testPredifinedDeviceParameters(Page page) {
-    page.navigate(server().EMPTY_PAGE);
+  public void testPredefinedDeviceParameters(Server server, Page page) {
+    page.navigate(server.EMPTY_PAGE);
     assertEquals("webkit", page.context().browser().browserType().name());
     assertEquals(3, page.evaluate("window.devicePixelRatio"));
     assertEquals(980, page.evaluate("window.innerWidth"));


### PR DESCRIPTION
This PR adds the ability to close Playwright objects after the entire test run.  I also added a `ParameterResolver` for server so we don't have to create methods to access it from the `serverMap`.

Ref: https://github.com/microsoft/playwright-java/issues/1369#issuecomment-1924579887