### PR TITLE
fix(junit): Fixes fixtures not working in nested junit test classes

### DIFF
--- a/playwright/src/main/java/com/microsoft/playwright/junit/UsePlaywright.java
+++ b/playwright/src/main/java/com/microsoft/playwright/junit/UsePlaywright.java
@@ -16,7 +16,6 @@
 
 package com.microsoft.playwright.junit;
 
-import com.microsoft.playwright.Browser;
 import com.microsoft.playwright.junit.impl.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 

--- a/playwright/src/main/java/com/microsoft/playwright/junit/UsePlaywright.java
+++ b/playwright/src/main/java/com/microsoft/playwright/junit/UsePlaywright.java
@@ -19,10 +19,7 @@ package com.microsoft.playwright.junit;
 import com.microsoft.playwright.junit.impl.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+import java.lang.annotation.*;
 
 /**
  * <strong>NOTE:</strong> this API is experimental and is subject to changes.
@@ -79,6 +76,7 @@ import java.lang.annotation.Target;
              PageExtension.class, APIRequestContextExtension.class})
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
+@Inherited
 public @interface UsePlaywright {
   Class<? extends OptionsFactory> value() default DefaultOptions.class;
 }

--- a/playwright/src/main/java/com/microsoft/playwright/junit/impl/ExtensionUtils.java
+++ b/playwright/src/main/java/com/microsoft/playwright/junit/impl/ExtensionUtils.java
@@ -54,7 +54,7 @@ class ExtensionUtils {
   }
 
   private static Class<?> getOuterClass(Class<?> clazz) {
-    if (clazz.getEnclosingClass() == null) {
+    if (clazz.getDeclaringClass() == null) {
       return clazz;
     } else {
       return getOuterClass(clazz.getDeclaringClass());

--- a/playwright/src/main/java/com/microsoft/playwright/junit/impl/ExtensionUtils.java
+++ b/playwright/src/main/java/com/microsoft/playwright/junit/impl/ExtensionUtils.java
@@ -54,7 +54,7 @@ class ExtensionUtils {
   }
 
   private static Class<?> getOuterClass(Class<?> clazz) {
-    if (clazz.getDeclaringClass() == null) {
+    if (clazz.getEnclosingClass() == null) {
       return clazz;
     } else {
       return getOuterClass(clazz.getDeclaringClass());

--- a/playwright/src/main/java/com/microsoft/playwright/junit/impl/ExtensionUtils.java
+++ b/playwright/src/main/java/com/microsoft/playwright/junit/impl/ExtensionUtils.java
@@ -27,11 +27,13 @@ import static org.junit.platform.commons.support.AnnotationSupport.findAnnotatio
 
 class ExtensionUtils {
   static boolean hasUsePlaywrightAnnotation(ExtensionContext extensionContext) {
-    return AnnotationSupport.isAnnotated(extensionContext.getTestClass(), UsePlaywright.class);
+    Class<?> topLevelClass = getOuterClass(extensionContext.getRequiredTestClass());
+    return AnnotationSupport.isAnnotated(topLevelClass, UsePlaywright.class);
   }
 
   static UsePlaywright getUsePlaywrightAnnotation(ExtensionContext extensionContext) {
-    return findAnnotation(extensionContext.getTestClass(), UsePlaywright.class).get();
+    Class<?> topLevelClass = getOuterClass(extensionContext.getRequiredTestClass());
+    return findAnnotation(topLevelClass, UsePlaywright.class).get();
   }
 
   static boolean isClassHook(ExtensionContext extensionContext) {
@@ -49,6 +51,13 @@ class ExtensionUtils {
   static void setTestIdAttribute(Playwright playwright, Options options) {
     String testIdAttribute = options.testIdAttribute == null ? "data-testid" : options.testIdAttribute;
     playwright.selectors().setTestIdAttribute(testIdAttribute);
+  }
 
+  private static Class<?> getOuterClass(Class<?> clazz) {
+    if (clazz.getDeclaringClass() == null) {
+      return clazz;
+    } else {
+      return getOuterClass(clazz.getDeclaringClass());
+    }
   }
 }

--- a/playwright/src/main/java/com/microsoft/playwright/junit/impl/ExtensionUtils.java
+++ b/playwright/src/main/java/com/microsoft/playwright/junit/impl/ExtensionUtils.java
@@ -27,8 +27,8 @@ import static org.junit.platform.commons.support.AnnotationSupport.findAnnotatio
 
 class ExtensionUtils {
   static boolean hasUsePlaywrightAnnotation(ExtensionContext extensionContext) {
-    Class<?> topLevelClass = getOuterClass(extensionContext.getRequiredTestClass());
-    return AnnotationSupport.isAnnotated(topLevelClass, UsePlaywright.class);
+    Class<?> outerClass = getOuterClass(extensionContext.getRequiredTestClass());
+    return AnnotationSupport.isAnnotated(outerClass, UsePlaywright.class);
   }
 
   static UsePlaywright getUsePlaywrightAnnotation(ExtensionContext extensionContext) {

--- a/playwright/src/test/java/com/microsoft/playwright/junit/FixtureAbstractClass.java
+++ b/playwright/src/test/java/com/microsoft/playwright/junit/FixtureAbstractClass.java
@@ -1,0 +1,6 @@
+package com.microsoft.playwright.junit;
+
+@UsePlaywright
+public abstract class FixtureAbstractClass {
+
+}

--- a/playwright/src/test/java/com/microsoft/playwright/junit/TestFixtureWithBaseClass.java
+++ b/playwright/src/test/java/com/microsoft/playwright/junit/TestFixtureWithBaseClass.java
@@ -1,0 +1,24 @@
+package com.microsoft.playwright.junit;
+
+import com.microsoft.playwright.Page;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class TestFixtureWithBaseClass extends FixtureAbstractClass {
+
+  @Test
+  void worksWithBaseClassProvidingFixtures(Page page) {
+    assertNotNull(page);
+  }
+
+  @Nested
+  public class NestedClass {
+    @Test
+    void worksWithNestedClassInsideClassThatExtendsBaseClassThatProvidesFixtures(Page page) {
+      assertNotNull(page);
+    }
+  }
+
+}

--- a/playwright/src/test/java/com/microsoft/playwright/junit/TestFixturesWithNestedClass.java
+++ b/playwright/src/test/java/com/microsoft/playwright/junit/TestFixturesWithNestedClass.java
@@ -1,0 +1,32 @@
+package com.microsoft.playwright.junit;
+
+import com.microsoft.playwright.Page;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@UsePlaywright
+public class TestFixturesWithNestedClass {
+
+  @Test
+  void worksWithParentClass(Page page) {
+    assertNotNull(page);
+  }
+
+  @Nested
+  class NestedClass {
+    @Test
+    void worksWithNestedClasses(Page page) {
+      assertNotNull(page);
+    }
+
+    @Nested
+    class DeeplyNestedClass {
+      @Test
+      void worksWithDeeplyNestedClass(Page page) {
+        assertNotNull(page);
+      }
+    }
+  }
+}

--- a/playwright/src/test/java/com/microsoft/playwright/junit/TestFixturesWithNestedClass.java
+++ b/playwright/src/test/java/com/microsoft/playwright/junit/TestFixturesWithNestedClass.java
@@ -10,7 +10,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 public class TestFixturesWithNestedClass {
 
   @Test
-  void worksWithParentClass(Page page) {
+  void worksWithOuterClass(Page page) {
     assertNotNull(page);
   }
 

--- a/playwright/src/test/java/com/microsoft/playwright/junit/TestFixturesWithNestedClass.java
+++ b/playwright/src/test/java/com/microsoft/playwright/junit/TestFixturesWithNestedClass.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+@FixtureTest
 @UsePlaywright
 public class TestFixturesWithNestedClass {
 


### PR DESCRIPTION
Resolves #1514 

Allows fixtures to be used inside nested class and allows inheriting fixtures from base classes.