### PR TITLE
fix(docs): generate javadocs

### DIFF
--- a/playwright/pom.xml
+++ b/playwright/pom.xml
@@ -26,7 +26,7 @@
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration combine.self="append">
           <subpackages>com.microsoft.playwright</subpackages>
-          <excludePackageNames>com.microsoft.playwright.impl</excludePackageNames>
+          <excludePackageNames>com.microsoft.playwright.impl,com.microsoft.playwright.junit.impl</excludePackageNames>
         </configuration>
       </plugin>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -135,6 +135,8 @@
           <configuration>
             <additionalOptions>--allow-script-in-comments</additionalOptions>
             <failOnError>false</failOnError>
+            <!-- passing 8 causes an assertion in javadoc tool, see https://github.com/microsoft/playwright-java/issues/1533 -->
+            <release>11</release>
           </configuration>
         </plugin>
         <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -136,7 +136,7 @@
             <additionalOptions>--allow-script-in-comments</additionalOptions>
             <failOnError>false</failOnError>
             <!-- passing 8 causes an assertion in javadoc tool, see https://github.com/microsoft/playwright-java/issues/1533 -->
-            <release>11</release>
+            <source>11</source>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
Javadoc options generated by the plugin have changed to include `-source 8`:

```
$ diff good.txt bad.txt 
5a6,7
> -source
> '8'
24a27,28
> 'https://docs.oracle.com/javase/8/docs/api' '/Users/yurys/playwright-java/playwright/target/javadoc-bundle-options'
> -linkoffline
```

The options are from the following:
```
Command line was: /Library/Java/JavaVirtualMachines/jdk-21.jdk/Contents/Home/bin/javadoc @options

Refer to the generated Javadoc files in '/Users/<user>/playwright-java/playwright/target/site/apidocs' dir.
```

Turns out `-source '8'` triggers an assertion in the javadoc tool, so for now we just pass `11` as the source version. Our sources are compiled with java 8 compatibility mode, so it shouldn't make any difference in the generated docs.

Reference https://github.com/microsoft/playwright-java/issues/1533