### PR TITLE
docs: fix broken class links, format details and usage

### DIFF
--- a/playwright/src/main/java/com/microsoft/playwright/APIRequest.java
+++ b/playwright/src/main/java/com/microsoft/playwright/APIRequest.java
@@ -23,14 +23,14 @@ import java.util.*;
 /**
  * Exposes API that can be used for the Web API testing. This class is used for creating {@code APIRequestContext} instance
  * which in turn can be used for sending web requests. An instance of this class can be obtained via {@link
- * Playwright#request Playwright.request()}. For more information see {@code APIRequestContext}.
+ * com.microsoft.playwright.Playwright#request Playwright.request()}. For more information see {@code APIRequestContext}.
  */
 public interface APIRequest {
   class NewContextOptions {
     /**
-     * Methods like {@link APIRequestContext#get APIRequestContext.get()} take the base URL into consideration by using the <a
-     * href="https://developer.mozilla.org/en-US/docs/Web/API/URL/URL">{@code URL()}</a> constructor for building the
-     * corresponding URL. Examples:
+     * Methods like {@link com.microsoft.playwright.APIRequestContext#get APIRequestContext.get()} take the base URL into
+     * consideration by using the <a href="https://developer.mozilla.org/en-US/docs/Web/API/URL/URL">{@code URL()}</a>
+     * constructor for building the corresponding URL. Examples:
      * <ul>
      * <li> baseURL: {@code http://localhost:3000} and sending request to {@code /bar.html} results in {@code
      * http://localhost:3000/bar.html}</li>
@@ -60,16 +60,17 @@ public interface APIRequest {
     public Proxy proxy;
     /**
      * Populates context with given storage state. This option can be used to initialize context with logged-in information
-     * obtained via {@link BrowserContext#storageState BrowserContext.storageState()} or {@link APIRequestContext#storageState
-     * APIRequestContext.storageState()}. Either a path to the file with saved storage, or the value returned by one of {@link
-     * BrowserContext#storageState BrowserContext.storageState()} or {@link APIRequestContext#storageState
+     * obtained via {@link com.microsoft.playwright.BrowserContext#storageState BrowserContext.storageState()} or {@link
+     * com.microsoft.playwright.APIRequestContext#storageState APIRequestContext.storageState()}. Either a path to the file
+     * with saved storage, or the value returned by one of {@link com.microsoft.playwright.BrowserContext#storageState
+     * BrowserContext.storageState()} or {@link com.microsoft.playwright.APIRequestContext#storageState
      * APIRequestContext.storageState()} methods.
      */
     public String storageState;
     /**
      * Populates context with given storage state. This option can be used to initialize context with logged-in information
-     * obtained via {@link BrowserContext#storageState BrowserContext.storageState()}. Path to the file with saved storage
-     * state.
+     * obtained via {@link com.microsoft.playwright.BrowserContext#storageState BrowserContext.storageState()}. Path to the
+     * file with saved storage state.
      */
     public Path storageStatePath;
     /**
@@ -83,9 +84,9 @@ public interface APIRequest {
     public String userAgent;
 
     /**
-     * Methods like {@link APIRequestContext#get APIRequestContext.get()} take the base URL into consideration by using the <a
-     * href="https://developer.mozilla.org/en-US/docs/Web/API/URL/URL">{@code URL()}</a> constructor for building the
-     * corresponding URL. Examples:
+     * Methods like {@link com.microsoft.playwright.APIRequestContext#get APIRequestContext.get()} take the base URL into
+     * consideration by using the <a href="https://developer.mozilla.org/en-US/docs/Web/API/URL/URL">{@code URL()}</a>
+     * constructor for building the corresponding URL. Examples:
      * <ul>
      * <li> baseURL: {@code http://localhost:3000} and sending request to {@code /bar.html} results in {@code
      * http://localhost:3000/bar.html}</li>
@@ -143,9 +144,10 @@ public interface APIRequest {
     }
     /**
      * Populates context with given storage state. This option can be used to initialize context with logged-in information
-     * obtained via {@link BrowserContext#storageState BrowserContext.storageState()} or {@link APIRequestContext#storageState
-     * APIRequestContext.storageState()}. Either a path to the file with saved storage, or the value returned by one of {@link
-     * BrowserContext#storageState BrowserContext.storageState()} or {@link APIRequestContext#storageState
+     * obtained via {@link com.microsoft.playwright.BrowserContext#storageState BrowserContext.storageState()} or {@link
+     * com.microsoft.playwright.APIRequestContext#storageState APIRequestContext.storageState()}. Either a path to the file
+     * with saved storage, or the value returned by one of {@link com.microsoft.playwright.BrowserContext#storageState
+     * BrowserContext.storageState()} or {@link com.microsoft.playwright.APIRequestContext#storageState
      * APIRequestContext.storageState()} methods.
      */
     public NewContextOptions setStorageState(String storageState) {
@@ -154,8 +156,8 @@ public interface APIRequest {
     }
     /**
      * Populates context with given storage state. This option can be used to initialize context with logged-in information
-     * obtained via {@link BrowserContext#storageState BrowserContext.storageState()}. Path to the file with saved storage
-     * state.
+     * obtained via {@link com.microsoft.playwright.BrowserContext#storageState BrowserContext.storageState()}. Path to the
+     * file with saved storage state.
      */
     public NewContextOptions setStorageStatePath(Path storageStatePath) {
       this.storageStatePath = storageStatePath;

--- a/playwright/src/main/java/com/microsoft/playwright/APIRequestContext.java
+++ b/playwright/src/main/java/com/microsoft/playwright/APIRequestContext.java
@@ -24,21 +24,23 @@ import java.nio.file.Path;
  * environment or the service to your e2e test.
  *
  * <p> Each Playwright browser context has associated with it {@code APIRequestContext} instance which shares cookie storage
- * with the browser context and can be accessed via {@link BrowserContext#request BrowserContext.request()} or {@link
- * Page#request Page.request()}. It is also possible to create a new APIRequestContext instance manually by calling {@link
- * APIRequest#newContext APIRequest.newContext()}.
+ * with the browser context and can be accessed via {@link com.microsoft.playwright.BrowserContext#request
+ * BrowserContext.request()} or {@link com.microsoft.playwright.Page#request Page.request()}. It is also possible to create
+ * a new APIRequestContext instance manually by calling {@link com.microsoft.playwright.APIRequest#newContext
+ * APIRequest.newContext()}.
  *
- * <p> **Cookie management**
+ * <p> <strong>Cookie management</strong>
  *
- * <p> {@code APIRequestContext} returned by {@link BrowserContext#request BrowserContext.request()} and {@link Page#request
- * Page.request()} shares cookie storage with the corresponding {@code BrowserContext}. Each API request will have {@code
- * Cookie} header populated with the values from the browser context. If the API response contains {@code Set-Cookie}
- * header it will automatically update {@code BrowserContext} cookies and requests made from the page will pick them up.
- * This means that if you log in using this API, your e2e test will be logged in and vice versa.
+ * <p> {@code APIRequestContext} returned by {@link com.microsoft.playwright.BrowserContext#request BrowserContext.request()}
+ * and {@link com.microsoft.playwright.Page#request Page.request()} shares cookie storage with the corresponding {@code
+ * BrowserContext}. Each API request will have {@code Cookie} header populated with the values from the browser context. If
+ * the API response contains {@code Set-Cookie} header it will automatically update {@code BrowserContext} cookies and
+ * requests made from the page will pick them up. This means that if you log in using this API, your e2e test will be
+ * logged in and vice versa.
  *
  * <p> If you want API requests to not interfere with the browser cookies you should create a new {@code APIRequestContext} by
- * calling {@link APIRequest#newContext APIRequest.newContext()}. Such {@code APIRequestContext} object will have its own
- * isolated cookie storage.
+ * calling {@link com.microsoft.playwright.APIRequest#newContext APIRequest.newContext()}. Such {@code APIRequestContext}
+ * object will have its own isolated cookie storage.
  */
 public interface APIRequestContext {
   class StorageStateOptions {
@@ -79,9 +81,10 @@ public interface APIRequestContext {
    */
   APIResponse delete(String url, RequestOptions params);
   /**
-   * All responses returned by {@link APIRequestContext#get APIRequestContext.get()} and similar methods are stored in the
-   * memory, so that you can later call {@link APIResponse#body APIResponse.body()}.This method discards all its resources,
-   * calling any method on disposed {@code APIRequestContext} will throw an exception.
+   * All responses returned by {@link com.microsoft.playwright.APIRequestContext#get APIRequestContext.get()} and similar
+   * methods are stored in the memory, so that you can later call {@link com.microsoft.playwright.APIResponse#body
+   * APIResponse.body()}.This method discards all its resources, calling any method on disposed {@code APIRequestContext}
+   * will throw an exception.
    *
    * @since v1.16
    */
@@ -91,7 +94,7 @@ public interface APIRequestContext {
    * context cookies from the response. The method will automatically follow redirects. JSON objects can be passed directly
    * to the request.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * Map<String, Object> data = new HashMap();
    * data.put("title", "Book Title");
@@ -127,7 +130,7 @@ public interface APIRequestContext {
    * context cookies from the response. The method will automatically follow redirects. JSON objects can be passed directly
    * to the request.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * Map<String, Object> data = new HashMap();
    * data.put("title", "Book Title");
@@ -162,7 +165,7 @@ public interface APIRequestContext {
    * context cookies from the response. The method will automatically follow redirects. JSON objects can be passed directly
    * to the request.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * Map<String, Object> data = new HashMap();
    * data.put("title", "Book Title");
@@ -198,7 +201,7 @@ public interface APIRequestContext {
    * context cookies from the response. The method will automatically follow redirects. JSON objects can be passed directly
    * to the request.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * Map<String, Object> data = new HashMap();
    * data.put("title", "Book Title");
@@ -233,7 +236,7 @@ public interface APIRequestContext {
    * response. The method will populate request cookies from the context and update context cookies from the response. The
    * method will automatically follow redirects.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> Request parameters can be configured with {@code params} option, they will be serialized into the URL search parameters:
    * <pre>{@code
@@ -253,7 +256,7 @@ public interface APIRequestContext {
    * response. The method will populate request cookies from the context and update context cookies from the response. The
    * method will automatically follow redirects.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> Request parameters can be configured with {@code params} option, they will be serialized into the URL search parameters:
    * <pre>{@code
@@ -314,7 +317,7 @@ public interface APIRequestContext {
    * response. The method will populate request cookies from the context and update context cookies from the response. The
    * method will automatically follow redirects.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> JSON objects can be passed directly to the request:
    * <pre>{@code
@@ -361,7 +364,7 @@ public interface APIRequestContext {
    * response. The method will populate request cookies from the context and update context cookies from the response. The
    * method will automatically follow redirects.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> JSON objects can be passed directly to the request:
    * <pre>{@code

--- a/playwright/src/main/java/com/microsoft/playwright/APIResponse.java
+++ b/playwright/src/main/java/com/microsoft/playwright/APIResponse.java
@@ -20,8 +20,8 @@ import com.microsoft.playwright.options.*;
 import java.util.*;
 
 /**
- * {@code APIResponse} class represents responses returned by {@link APIRequestContext#get APIRequestContext.get()} and
- * similar methods.
+ * {@code APIResponse} class represents responses returned by {@link com.microsoft.playwright.APIRequestContext#get
+ * APIRequestContext.get()} and similar methods.
  */
 public interface APIResponse {
   /**

--- a/playwright/src/main/java/com/microsoft/playwright/Browser.java
+++ b/playwright/src/main/java/com/microsoft/playwright/Browser.java
@@ -23,8 +23,8 @@ import java.util.function.Consumer;
 import java.util.regex.Pattern;
 
 /**
- * A Browser is created via {@link BrowserType#launch BrowserType.launch()}. An example of using a {@code Browser} to
- * create a {@code Page}:
+ * A Browser is created via {@link com.microsoft.playwright.BrowserType#launch BrowserType.launch()}. An example of using a
+ * {@code Browser} to create a {@code Page}:
  * <pre>{@code
  * import com.microsoft.playwright.*;
  *
@@ -47,7 +47,7 @@ public interface Browser extends AutoCloseable {
    * Emitted when Browser gets disconnected from the browser application. This might happen because of one of the following:
    * <ul>
    * <li> Browser application is closed or crashed.</li>
-   * <li> The {@link Browser#close Browser.close()} method was called.</li>
+   * <li> The {@link com.microsoft.playwright.Browser#close Browser.close()} method was called.</li>
    * </ul>
    */
   void onDisconnected(Consumer<Browser> handler);
@@ -76,10 +76,11 @@ public interface Browser extends AutoCloseable {
      */
     public Boolean acceptDownloads;
     /**
-     * When using {@link Page#navigate Page.navigate()}, {@link Page#route Page.route()}, {@link Page#waitForURL
-     * Page.waitForURL()}, {@link Page#waitForRequest Page.waitForRequest()}, or {@link Page#waitForResponse
-     * Page.waitForResponse()} it takes the base URL in consideration by using the <a
-     * href="https://developer.mozilla.org/en-US/docs/Web/API/URL/URL">{@code URL()}</a> constructor for building the
+     * When using {@link com.microsoft.playwright.Page#navigate Page.navigate()}, {@link com.microsoft.playwright.Page#route
+     * Page.route()}, {@link com.microsoft.playwright.Page#waitForURL Page.waitForURL()}, {@link
+     * com.microsoft.playwright.Page#waitForRequest Page.waitForRequest()}, or {@link
+     * com.microsoft.playwright.Page#waitForResponse Page.waitForResponse()} it takes the base URL in consideration by using
+     * the <a href="https://developer.mozilla.org/en-US/docs/Web/API/URL/URL">{@code URL()}</a> constructor for building the
      * corresponding URL. Unset by default. Examples:
      * <ul>
      * <li> baseURL: {@code http://localhost:3000} and navigating to {@code /bar.html} results in {@code
@@ -97,8 +98,8 @@ public interface Browser extends AutoCloseable {
     public Boolean bypassCSP;
     /**
      * Emulates {@code "prefers-colors-scheme"} media feature, supported values are {@code "light"}, {@code "dark"}, {@code
-     * "no-preference"}. See {@link Page#emulateMedia Page.emulateMedia()} for more details. Passing {@code null} resets
-     * emulation to system defaults. Defaults to {@code "light"}.
+     * "no-preference"}. See {@link com.microsoft.playwright.Page#emulateMedia Page.emulateMedia()} for more details. Passing
+     * {@code null} resets emulation to system defaults. Defaults to {@code "light"}.
      */
     public Optional<ColorScheme> colorScheme;
     /**
@@ -112,8 +113,8 @@ public interface Browser extends AutoCloseable {
     public Map<String, String> extraHTTPHeaders;
     /**
      * Emulates {@code "forced-colors"} media feature, supported values are {@code "active"}, {@code "none"}. See {@link
-     * Page#emulateMedia Page.emulateMedia()} for more details. Passing {@code null} resets emulation to system defaults.
-     * Defaults to {@code "none"}.
+     * com.microsoft.playwright.Page#emulateMedia Page.emulateMedia()} for more details. Passing {@code null} resets emulation
+     * to system defaults. Defaults to {@code "none"}.
      */
     public Optional<ForcedColors> forcedColors;
     public Geolocation geolocation;
@@ -155,8 +156,9 @@ public interface Browser extends AutoCloseable {
      */
     public Boolean offline;
     /**
-     * A list of permissions to grant to all pages in this context. See {@link BrowserContext#grantPermissions
-     * BrowserContext.grantPermissions()} for more details. Defaults to none.
+     * A list of permissions to grant to all pages in this context. See {@link
+     * com.microsoft.playwright.BrowserContext#grantPermissions BrowserContext.grantPermissions()} for more details. Defaults
+     * to none.
      */
     public List<String> permissions;
     /**
@@ -185,14 +187,14 @@ public interface Browser extends AutoCloseable {
     public Boolean recordHarOmitContent;
     /**
      * Enables <a href="http://www.softwareishard.com/blog/har-12-spec">HAR</a> recording for all pages into the specified HAR
-     * file on the filesystem. If not specified, the HAR is not recorded. Make sure to call {@link BrowserContext#close
-     * BrowserContext.close()} for the HAR to be saved.
+     * file on the filesystem. If not specified, the HAR is not recorded. Make sure to call {@link
+     * com.microsoft.playwright.BrowserContext#close BrowserContext.close()} for the HAR to be saved.
      */
     public Path recordHarPath;
     public Object recordHarUrlFilter;
     /**
      * Enables video recording for all pages into the specified directory. If not specified videos are not recorded. Make sure
-     * to call {@link BrowserContext#close BrowserContext.close()} for videos to be saved.
+     * to call {@link com.microsoft.playwright.BrowserContext#close BrowserContext.close()} for videos to be saved.
      */
     public Path recordVideoDir;
     /**
@@ -203,8 +205,8 @@ public interface Browser extends AutoCloseable {
     public RecordVideoSize recordVideoSize;
     /**
      * Emulates {@code "prefers-reduced-motion"} media feature, supported values are {@code "reduce"}, {@code "no-preference"}.
-     * See {@link Page#emulateMedia Page.emulateMedia()} for more details. Passing {@code null} resets emulation to system
-     * defaults. Defaults to {@code "no-preference"}.
+     * See {@link com.microsoft.playwright.Page#emulateMedia Page.emulateMedia()} for more details. Passing {@code null} resets
+     * emulation to system defaults. Defaults to {@code "no-preference"}.
      */
     public Optional<ReducedMotion> reducedMotion;
     /**
@@ -223,13 +225,13 @@ public interface Browser extends AutoCloseable {
     public ServiceWorkerPolicy serviceWorkers;
     /**
      * Populates context with given storage state. This option can be used to initialize context with logged-in information
-     * obtained via {@link BrowserContext#storageState BrowserContext.storageState()}.
+     * obtained via {@link com.microsoft.playwright.BrowserContext#storageState BrowserContext.storageState()}.
      */
     public String storageState;
     /**
      * Populates context with given storage state. This option can be used to initialize context with logged-in information
-     * obtained via {@link BrowserContext#storageState BrowserContext.storageState()}. Path to the file with saved storage
-     * state.
+     * obtained via {@link com.microsoft.playwright.BrowserContext#storageState BrowserContext.storageState()}. Path to the
+     * file with saved storage state.
      */
     public Path storageStatePath;
     /**
@@ -267,10 +269,11 @@ public interface Browser extends AutoCloseable {
       return this;
     }
     /**
-     * When using {@link Page#navigate Page.navigate()}, {@link Page#route Page.route()}, {@link Page#waitForURL
-     * Page.waitForURL()}, {@link Page#waitForRequest Page.waitForRequest()}, or {@link Page#waitForResponse
-     * Page.waitForResponse()} it takes the base URL in consideration by using the <a
-     * href="https://developer.mozilla.org/en-US/docs/Web/API/URL/URL">{@code URL()}</a> constructor for building the
+     * When using {@link com.microsoft.playwright.Page#navigate Page.navigate()}, {@link com.microsoft.playwright.Page#route
+     * Page.route()}, {@link com.microsoft.playwright.Page#waitForURL Page.waitForURL()}, {@link
+     * com.microsoft.playwright.Page#waitForRequest Page.waitForRequest()}, or {@link
+     * com.microsoft.playwright.Page#waitForResponse Page.waitForResponse()} it takes the base URL in consideration by using
+     * the <a href="https://developer.mozilla.org/en-US/docs/Web/API/URL/URL">{@code URL()}</a> constructor for building the
      * corresponding URL. Unset by default. Examples:
      * <ul>
      * <li> baseURL: {@code http://localhost:3000} and navigating to {@code /bar.html} results in {@code
@@ -294,8 +297,8 @@ public interface Browser extends AutoCloseable {
     }
     /**
      * Emulates {@code "prefers-colors-scheme"} media feature, supported values are {@code "light"}, {@code "dark"}, {@code
-     * "no-preference"}. See {@link Page#emulateMedia Page.emulateMedia()} for more details. Passing {@code null} resets
-     * emulation to system defaults. Defaults to {@code "light"}.
+     * "no-preference"}. See {@link com.microsoft.playwright.Page#emulateMedia Page.emulateMedia()} for more details. Passing
+     * {@code null} resets emulation to system defaults. Defaults to {@code "light"}.
      */
     public NewContextOptions setColorScheme(ColorScheme colorScheme) {
       this.colorScheme = Optional.ofNullable(colorScheme);
@@ -318,8 +321,8 @@ public interface Browser extends AutoCloseable {
     }
     /**
      * Emulates {@code "forced-colors"} media feature, supported values are {@code "active"}, {@code "none"}. See {@link
-     * Page#emulateMedia Page.emulateMedia()} for more details. Passing {@code null} resets emulation to system defaults.
-     * Defaults to {@code "none"}.
+     * com.microsoft.playwright.Page#emulateMedia Page.emulateMedia()} for more details. Passing {@code null} resets emulation
+     * to system defaults. Defaults to {@code "none"}.
      */
     public NewContextOptions setForcedColors(ForcedColors forcedColors) {
       this.forcedColors = Optional.ofNullable(forcedColors);
@@ -398,8 +401,9 @@ public interface Browser extends AutoCloseable {
       return this;
     }
     /**
-     * A list of permissions to grant to all pages in this context. See {@link BrowserContext#grantPermissions
-     * BrowserContext.grantPermissions()} for more details. Defaults to none.
+     * A list of permissions to grant to all pages in this context. See {@link
+     * com.microsoft.playwright.BrowserContext#grantPermissions BrowserContext.grantPermissions()} for more details. Defaults
+     * to none.
      */
     public NewContextOptions setPermissions(List<String> permissions) {
       this.permissions = permissions;
@@ -453,8 +457,8 @@ public interface Browser extends AutoCloseable {
     }
     /**
      * Enables <a href="http://www.softwareishard.com/blog/har-12-spec">HAR</a> recording for all pages into the specified HAR
-     * file on the filesystem. If not specified, the HAR is not recorded. Make sure to call {@link BrowserContext#close
-     * BrowserContext.close()} for the HAR to be saved.
+     * file on the filesystem. If not specified, the HAR is not recorded. Make sure to call {@link
+     * com.microsoft.playwright.BrowserContext#close BrowserContext.close()} for the HAR to be saved.
      */
     public NewContextOptions setRecordHarPath(Path recordHarPath) {
       this.recordHarPath = recordHarPath;
@@ -470,7 +474,7 @@ public interface Browser extends AutoCloseable {
     }
     /**
      * Enables video recording for all pages into the specified directory. If not specified videos are not recorded. Make sure
-     * to call {@link BrowserContext#close BrowserContext.close()} for videos to be saved.
+     * to call {@link com.microsoft.playwright.BrowserContext#close BrowserContext.close()} for videos to be saved.
      */
     public NewContextOptions setRecordVideoDir(Path recordVideoDir) {
       this.recordVideoDir = recordVideoDir;
@@ -495,8 +499,8 @@ public interface Browser extends AutoCloseable {
     }
     /**
      * Emulates {@code "prefers-reduced-motion"} media feature, supported values are {@code "reduce"}, {@code "no-preference"}.
-     * See {@link Page#emulateMedia Page.emulateMedia()} for more details. Passing {@code null} resets emulation to system
-     * defaults. Defaults to {@code "no-preference"}.
+     * See {@link com.microsoft.playwright.Page#emulateMedia Page.emulateMedia()} for more details. Passing {@code null} resets
+     * emulation to system defaults. Defaults to {@code "no-preference"}.
      */
     public NewContextOptions setReducedMotion(ReducedMotion reducedMotion) {
       this.reducedMotion = Optional.ofNullable(reducedMotion);
@@ -531,7 +535,7 @@ public interface Browser extends AutoCloseable {
     }
     /**
      * Populates context with given storage state. This option can be used to initialize context with logged-in information
-     * obtained via {@link BrowserContext#storageState BrowserContext.storageState()}.
+     * obtained via {@link com.microsoft.playwright.BrowserContext#storageState BrowserContext.storageState()}.
      */
     public NewContextOptions setStorageState(String storageState) {
       this.storageState = storageState;
@@ -539,8 +543,8 @@ public interface Browser extends AutoCloseable {
     }
     /**
      * Populates context with given storage state. This option can be used to initialize context with logged-in information
-     * obtained via {@link BrowserContext#storageState BrowserContext.storageState()}. Path to the file with saved storage
-     * state.
+     * obtained via {@link com.microsoft.playwright.BrowserContext#storageState BrowserContext.storageState()}. Path to the
+     * file with saved storage state.
      */
     public NewContextOptions setStorageStatePath(Path storageStatePath) {
       this.storageStatePath = storageStatePath;
@@ -602,10 +606,11 @@ public interface Browser extends AutoCloseable {
      */
     public Boolean acceptDownloads;
     /**
-     * When using {@link Page#navigate Page.navigate()}, {@link Page#route Page.route()}, {@link Page#waitForURL
-     * Page.waitForURL()}, {@link Page#waitForRequest Page.waitForRequest()}, or {@link Page#waitForResponse
-     * Page.waitForResponse()} it takes the base URL in consideration by using the <a
-     * href="https://developer.mozilla.org/en-US/docs/Web/API/URL/URL">{@code URL()}</a> constructor for building the
+     * When using {@link com.microsoft.playwright.Page#navigate Page.navigate()}, {@link com.microsoft.playwright.Page#route
+     * Page.route()}, {@link com.microsoft.playwright.Page#waitForURL Page.waitForURL()}, {@link
+     * com.microsoft.playwright.Page#waitForRequest Page.waitForRequest()}, or {@link
+     * com.microsoft.playwright.Page#waitForResponse Page.waitForResponse()} it takes the base URL in consideration by using
+     * the <a href="https://developer.mozilla.org/en-US/docs/Web/API/URL/URL">{@code URL()}</a> constructor for building the
      * corresponding URL. Unset by default. Examples:
      * <ul>
      * <li> baseURL: {@code http://localhost:3000} and navigating to {@code /bar.html} results in {@code
@@ -623,8 +628,8 @@ public interface Browser extends AutoCloseable {
     public Boolean bypassCSP;
     /**
      * Emulates {@code "prefers-colors-scheme"} media feature, supported values are {@code "light"}, {@code "dark"}, {@code
-     * "no-preference"}. See {@link Page#emulateMedia Page.emulateMedia()} for more details. Passing {@code null} resets
-     * emulation to system defaults. Defaults to {@code "light"}.
+     * "no-preference"}. See {@link com.microsoft.playwright.Page#emulateMedia Page.emulateMedia()} for more details. Passing
+     * {@code null} resets emulation to system defaults. Defaults to {@code "light"}.
      */
     public Optional<ColorScheme> colorScheme;
     /**
@@ -638,8 +643,8 @@ public interface Browser extends AutoCloseable {
     public Map<String, String> extraHTTPHeaders;
     /**
      * Emulates {@code "forced-colors"} media feature, supported values are {@code "active"}, {@code "none"}. See {@link
-     * Page#emulateMedia Page.emulateMedia()} for more details. Passing {@code null} resets emulation to system defaults.
-     * Defaults to {@code "none"}.
+     * com.microsoft.playwright.Page#emulateMedia Page.emulateMedia()} for more details. Passing {@code null} resets emulation
+     * to system defaults. Defaults to {@code "none"}.
      */
     public Optional<ForcedColors> forcedColors;
     public Geolocation geolocation;
@@ -681,8 +686,9 @@ public interface Browser extends AutoCloseable {
      */
     public Boolean offline;
     /**
-     * A list of permissions to grant to all pages in this context. See {@link BrowserContext#grantPermissions
-     * BrowserContext.grantPermissions()} for more details. Defaults to none.
+     * A list of permissions to grant to all pages in this context. See {@link
+     * com.microsoft.playwright.BrowserContext#grantPermissions BrowserContext.grantPermissions()} for more details. Defaults
+     * to none.
      */
     public List<String> permissions;
     /**
@@ -711,14 +717,14 @@ public interface Browser extends AutoCloseable {
     public Boolean recordHarOmitContent;
     /**
      * Enables <a href="http://www.softwareishard.com/blog/har-12-spec">HAR</a> recording for all pages into the specified HAR
-     * file on the filesystem. If not specified, the HAR is not recorded. Make sure to call {@link BrowserContext#close
-     * BrowserContext.close()} for the HAR to be saved.
+     * file on the filesystem. If not specified, the HAR is not recorded. Make sure to call {@link
+     * com.microsoft.playwright.BrowserContext#close BrowserContext.close()} for the HAR to be saved.
      */
     public Path recordHarPath;
     public Object recordHarUrlFilter;
     /**
      * Enables video recording for all pages into the specified directory. If not specified videos are not recorded. Make sure
-     * to call {@link BrowserContext#close BrowserContext.close()} for videos to be saved.
+     * to call {@link com.microsoft.playwright.BrowserContext#close BrowserContext.close()} for videos to be saved.
      */
     public Path recordVideoDir;
     /**
@@ -729,8 +735,8 @@ public interface Browser extends AutoCloseable {
     public RecordVideoSize recordVideoSize;
     /**
      * Emulates {@code "prefers-reduced-motion"} media feature, supported values are {@code "reduce"}, {@code "no-preference"}.
-     * See {@link Page#emulateMedia Page.emulateMedia()} for more details. Passing {@code null} resets emulation to system
-     * defaults. Defaults to {@code "no-preference"}.
+     * See {@link com.microsoft.playwright.Page#emulateMedia Page.emulateMedia()} for more details. Passing {@code null} resets
+     * emulation to system defaults. Defaults to {@code "no-preference"}.
      */
     public Optional<ReducedMotion> reducedMotion;
     /**
@@ -749,13 +755,13 @@ public interface Browser extends AutoCloseable {
     public ServiceWorkerPolicy serviceWorkers;
     /**
      * Populates context with given storage state. This option can be used to initialize context with logged-in information
-     * obtained via {@link BrowserContext#storageState BrowserContext.storageState()}.
+     * obtained via {@link com.microsoft.playwright.BrowserContext#storageState BrowserContext.storageState()}.
      */
     public String storageState;
     /**
      * Populates context with given storage state. This option can be used to initialize context with logged-in information
-     * obtained via {@link BrowserContext#storageState BrowserContext.storageState()}. Path to the file with saved storage
-     * state.
+     * obtained via {@link com.microsoft.playwright.BrowserContext#storageState BrowserContext.storageState()}. Path to the
+     * file with saved storage state.
      */
     public Path storageStatePath;
     /**
@@ -793,10 +799,11 @@ public interface Browser extends AutoCloseable {
       return this;
     }
     /**
-     * When using {@link Page#navigate Page.navigate()}, {@link Page#route Page.route()}, {@link Page#waitForURL
-     * Page.waitForURL()}, {@link Page#waitForRequest Page.waitForRequest()}, or {@link Page#waitForResponse
-     * Page.waitForResponse()} it takes the base URL in consideration by using the <a
-     * href="https://developer.mozilla.org/en-US/docs/Web/API/URL/URL">{@code URL()}</a> constructor for building the
+     * When using {@link com.microsoft.playwright.Page#navigate Page.navigate()}, {@link com.microsoft.playwright.Page#route
+     * Page.route()}, {@link com.microsoft.playwright.Page#waitForURL Page.waitForURL()}, {@link
+     * com.microsoft.playwright.Page#waitForRequest Page.waitForRequest()}, or {@link
+     * com.microsoft.playwright.Page#waitForResponse Page.waitForResponse()} it takes the base URL in consideration by using
+     * the <a href="https://developer.mozilla.org/en-US/docs/Web/API/URL/URL">{@code URL()}</a> constructor for building the
      * corresponding URL. Unset by default. Examples:
      * <ul>
      * <li> baseURL: {@code http://localhost:3000} and navigating to {@code /bar.html} results in {@code
@@ -820,8 +827,8 @@ public interface Browser extends AutoCloseable {
     }
     /**
      * Emulates {@code "prefers-colors-scheme"} media feature, supported values are {@code "light"}, {@code "dark"}, {@code
-     * "no-preference"}. See {@link Page#emulateMedia Page.emulateMedia()} for more details. Passing {@code null} resets
-     * emulation to system defaults. Defaults to {@code "light"}.
+     * "no-preference"}. See {@link com.microsoft.playwright.Page#emulateMedia Page.emulateMedia()} for more details. Passing
+     * {@code null} resets emulation to system defaults. Defaults to {@code "light"}.
      */
     public NewPageOptions setColorScheme(ColorScheme colorScheme) {
       this.colorScheme = Optional.ofNullable(colorScheme);
@@ -844,8 +851,8 @@ public interface Browser extends AutoCloseable {
     }
     /**
      * Emulates {@code "forced-colors"} media feature, supported values are {@code "active"}, {@code "none"}. See {@link
-     * Page#emulateMedia Page.emulateMedia()} for more details. Passing {@code null} resets emulation to system defaults.
-     * Defaults to {@code "none"}.
+     * com.microsoft.playwright.Page#emulateMedia Page.emulateMedia()} for more details. Passing {@code null} resets emulation
+     * to system defaults. Defaults to {@code "none"}.
      */
     public NewPageOptions setForcedColors(ForcedColors forcedColors) {
       this.forcedColors = Optional.ofNullable(forcedColors);
@@ -924,8 +931,9 @@ public interface Browser extends AutoCloseable {
       return this;
     }
     /**
-     * A list of permissions to grant to all pages in this context. See {@link BrowserContext#grantPermissions
-     * BrowserContext.grantPermissions()} for more details. Defaults to none.
+     * A list of permissions to grant to all pages in this context. See {@link
+     * com.microsoft.playwright.BrowserContext#grantPermissions BrowserContext.grantPermissions()} for more details. Defaults
+     * to none.
      */
     public NewPageOptions setPermissions(List<String> permissions) {
       this.permissions = permissions;
@@ -979,8 +987,8 @@ public interface Browser extends AutoCloseable {
     }
     /**
      * Enables <a href="http://www.softwareishard.com/blog/har-12-spec">HAR</a> recording for all pages into the specified HAR
-     * file on the filesystem. If not specified, the HAR is not recorded. Make sure to call {@link BrowserContext#close
-     * BrowserContext.close()} for the HAR to be saved.
+     * file on the filesystem. If not specified, the HAR is not recorded. Make sure to call {@link
+     * com.microsoft.playwright.BrowserContext#close BrowserContext.close()} for the HAR to be saved.
      */
     public NewPageOptions setRecordHarPath(Path recordHarPath) {
       this.recordHarPath = recordHarPath;
@@ -996,7 +1004,7 @@ public interface Browser extends AutoCloseable {
     }
     /**
      * Enables video recording for all pages into the specified directory. If not specified videos are not recorded. Make sure
-     * to call {@link BrowserContext#close BrowserContext.close()} for videos to be saved.
+     * to call {@link com.microsoft.playwright.BrowserContext#close BrowserContext.close()} for videos to be saved.
      */
     public NewPageOptions setRecordVideoDir(Path recordVideoDir) {
       this.recordVideoDir = recordVideoDir;
@@ -1021,8 +1029,8 @@ public interface Browser extends AutoCloseable {
     }
     /**
      * Emulates {@code "prefers-reduced-motion"} media feature, supported values are {@code "reduce"}, {@code "no-preference"}.
-     * See {@link Page#emulateMedia Page.emulateMedia()} for more details. Passing {@code null} resets emulation to system
-     * defaults. Defaults to {@code "no-preference"}.
+     * See {@link com.microsoft.playwright.Page#emulateMedia Page.emulateMedia()} for more details. Passing {@code null} resets
+     * emulation to system defaults. Defaults to {@code "no-preference"}.
      */
     public NewPageOptions setReducedMotion(ReducedMotion reducedMotion) {
       this.reducedMotion = Optional.ofNullable(reducedMotion);
@@ -1057,7 +1065,7 @@ public interface Browser extends AutoCloseable {
     }
     /**
      * Populates context with given storage state. This option can be used to initialize context with logged-in information
-     * obtained via {@link BrowserContext#storageState BrowserContext.storageState()}.
+     * obtained via {@link com.microsoft.playwright.BrowserContext#storageState BrowserContext.storageState()}.
      */
     public NewPageOptions setStorageState(String storageState) {
       this.storageState = storageState;
@@ -1065,8 +1073,8 @@ public interface Browser extends AutoCloseable {
     }
     /**
      * Populates context with given storage state. This option can be used to initialize context with logged-in information
-     * obtained via {@link BrowserContext#storageState BrowserContext.storageState()}. Path to the file with saved storage
-     * state.
+     * obtained via {@link com.microsoft.playwright.BrowserContext#storageState BrowserContext.storageState()}. Path to the
+     * file with saved storage state.
      */
     public NewPageOptions setStorageStatePath(Path storageStatePath) {
       this.storageStatePath = storageStatePath;
@@ -1165,15 +1173,16 @@ public interface Browser extends AutoCloseable {
    */
   BrowserType browserType();
   /**
-   * In case this browser is obtained using {@link BrowserType#launch BrowserType.launch()}, closes the browser and all of
-   * its pages (if any were opened).
+   * In case this browser is obtained using {@link com.microsoft.playwright.BrowserType#launch BrowserType.launch()}, closes
+   * the browser and all of its pages (if any were opened).
    *
    * <p> In case this browser is connected to, clears all created contexts belonging to this browser and disconnects from the
    * browser server.
    *
-   * <p> <strong>NOTE:</strong> This is similar to force quitting the browser. Therefore, you should call {@link BrowserContext#close
-   * BrowserContext.close()} on any {@code BrowserContext}'s you explicitly created earlier with {@link Browser#newContext
-   * Browser.newContext()} **before** calling {@link Browser#close Browser.close()}.
+   * <p> <strong>NOTE:</strong> This is similar to force quitting the browser. Therefore, you should call {@link
+   * com.microsoft.playwright.BrowserContext#close BrowserContext.close()} on any {@code BrowserContext}'s you explicitly
+   * created earlier with {@link com.microsoft.playwright.Browser#newContext Browser.newContext()} **before** calling {@link
+   * com.microsoft.playwright.Browser#close Browser.close()}.
    *
    * <p> The {@code Browser} object itself is considered to be disposed and cannot be used anymore.
    *
@@ -1183,15 +1192,16 @@ public interface Browser extends AutoCloseable {
     close(null);
   }
   /**
-   * In case this browser is obtained using {@link BrowserType#launch BrowserType.launch()}, closes the browser and all of
-   * its pages (if any were opened).
+   * In case this browser is obtained using {@link com.microsoft.playwright.BrowserType#launch BrowserType.launch()}, closes
+   * the browser and all of its pages (if any were opened).
    *
    * <p> In case this browser is connected to, clears all created contexts belonging to this browser and disconnects from the
    * browser server.
    *
-   * <p> <strong>NOTE:</strong> This is similar to force quitting the browser. Therefore, you should call {@link BrowserContext#close
-   * BrowserContext.close()} on any {@code BrowserContext}'s you explicitly created earlier with {@link Browser#newContext
-   * Browser.newContext()} **before** calling {@link Browser#close Browser.close()}.
+   * <p> <strong>NOTE:</strong> This is similar to force quitting the browser. Therefore, you should call {@link
+   * com.microsoft.playwright.BrowserContext#close BrowserContext.close()} on any {@code BrowserContext}'s you explicitly
+   * created earlier with {@link com.microsoft.playwright.Browser#newContext Browser.newContext()} **before** calling {@link
+   * com.microsoft.playwright.Browser#close Browser.close()}.
    *
    * <p> The {@code Browser} object itself is considered to be disposed and cannot be used anymore.
    *
@@ -1201,7 +1211,7 @@ public interface Browser extends AutoCloseable {
   /**
    * Returns an array of all open browser contexts. In a newly created browser, this will return zero browser contexts.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * Browser browser = pw.webkit().launch();
    * System.out.println(browser.contexts().size()); // prints "0"
@@ -1230,11 +1240,11 @@ public interface Browser extends AutoCloseable {
    * Creates a new browser context. It won't share cookies/cache with other browser contexts.
    *
    * <p> <strong>NOTE:</strong> If directly using this method to create {@code BrowserContext}s, it is best practice to explicitly close the returned
-   * context via {@link BrowserContext#close BrowserContext.close()} when your code is done with the {@code BrowserContext},
-   * and before calling {@link Browser#close Browser.close()}. This will ensure the {@code context} is closed gracefully and
-   * any artifacts—like HARs and videos—are fully flushed and saved.
+   * context via {@link com.microsoft.playwright.BrowserContext#close BrowserContext.close()} when your code is done with the
+   * {@code BrowserContext}, and before calling {@link com.microsoft.playwright.Browser#close Browser.close()}. This will
+   * ensure the {@code context} is closed gracefully and any artifacts—like HARs and videos—are fully flushed and saved.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * Browser browser = playwright.firefox().launch();  // Or 'chromium' or 'webkit'.
    * // Create a new incognito browser context.
@@ -1257,11 +1267,11 @@ public interface Browser extends AutoCloseable {
    * Creates a new browser context. It won't share cookies/cache with other browser contexts.
    *
    * <p> <strong>NOTE:</strong> If directly using this method to create {@code BrowserContext}s, it is best practice to explicitly close the returned
-   * context via {@link BrowserContext#close BrowserContext.close()} when your code is done with the {@code BrowserContext},
-   * and before calling {@link Browser#close Browser.close()}. This will ensure the {@code context} is closed gracefully and
-   * any artifacts—like HARs and videos—are fully flushed and saved.
+   * context via {@link com.microsoft.playwright.BrowserContext#close BrowserContext.close()} when your code is done with the
+   * {@code BrowserContext}, and before calling {@link com.microsoft.playwright.Browser#close Browser.close()}. This will
+   * ensure the {@code context} is closed gracefully and any artifacts—like HARs and videos—are fully flushed and saved.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * Browser browser = playwright.firefox().launch();  // Or 'chromium' or 'webkit'.
    * // Create a new incognito browser context.
@@ -1282,8 +1292,9 @@ public interface Browser extends AutoCloseable {
    * Creates a new page in a new browser context. Closing this page will close the context as well.
    *
    * <p> This is a convenience API that should only be used for the single-page scenarios and short snippets. Production code and
-   * testing frameworks should explicitly create {@link Browser#newContext Browser.newContext()} followed by the {@link
-   * BrowserContext#newPage BrowserContext.newPage()} to control their exact life times.
+   * testing frameworks should explicitly create {@link com.microsoft.playwright.Browser#newContext Browser.newContext()}
+   * followed by the {@link com.microsoft.playwright.BrowserContext#newPage BrowserContext.newPage()} to control their exact
+   * life times.
    *
    * @since v1.8
    */
@@ -1294,8 +1305,9 @@ public interface Browser extends AutoCloseable {
    * Creates a new page in a new browser context. Closing this page will close the context as well.
    *
    * <p> This is a convenience API that should only be used for the single-page scenarios and short snippets. Production code and
-   * testing frameworks should explicitly create {@link Browser#newContext Browser.newContext()} followed by the {@link
-   * BrowserContext#newPage BrowserContext.newPage()} to control their exact life times.
+   * testing frameworks should explicitly create {@link com.microsoft.playwright.Browser#newContext Browser.newContext()}
+   * followed by the {@link com.microsoft.playwright.BrowserContext#newPage BrowserContext.newPage()} to control their exact
+   * life times.
    *
    * @since v1.8
    */
@@ -1306,10 +1318,11 @@ public interface Browser extends AutoCloseable {
    * href="https://playwright.dev/java/docs/trace-viewer">Playwright Tracing</a> could be found <a
    * href="https://playwright.dev/java/docs/api/class-tracing">here</a>.
    *
-   * <p> You can use {@link Browser#startTracing Browser.startTracing()} and {@link Browser#stopTracing Browser.stopTracing()} to
-   * create a trace file that can be opened in Chrome DevTools performance panel.
+   * <p> You can use {@link com.microsoft.playwright.Browser#startTracing Browser.startTracing()} and {@link
+   * com.microsoft.playwright.Browser#stopTracing Browser.stopTracing()} to create a trace file that can be opened in Chrome
+   * DevTools performance panel.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * browser.startTracing(page, new Browser.StartTracingOptions()
    *   .setPath(Paths.get("trace.json")));
@@ -1329,10 +1342,11 @@ public interface Browser extends AutoCloseable {
    * href="https://playwright.dev/java/docs/trace-viewer">Playwright Tracing</a> could be found <a
    * href="https://playwright.dev/java/docs/api/class-tracing">here</a>.
    *
-   * <p> You can use {@link Browser#startTracing Browser.startTracing()} and {@link Browser#stopTracing Browser.stopTracing()} to
-   * create a trace file that can be opened in Chrome DevTools performance panel.
+   * <p> You can use {@link com.microsoft.playwright.Browser#startTracing Browser.startTracing()} and {@link
+   * com.microsoft.playwright.Browser#stopTracing Browser.stopTracing()} to create a trace file that can be opened in Chrome
+   * DevTools performance panel.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * browser.startTracing(page, new Browser.StartTracingOptions()
    *   .setPath(Paths.get("trace.json")));
@@ -1351,10 +1365,11 @@ public interface Browser extends AutoCloseable {
    * href="https://playwright.dev/java/docs/trace-viewer">Playwright Tracing</a> could be found <a
    * href="https://playwright.dev/java/docs/api/class-tracing">here</a>.
    *
-   * <p> You can use {@link Browser#startTracing Browser.startTracing()} and {@link Browser#stopTracing Browser.stopTracing()} to
-   * create a trace file that can be opened in Chrome DevTools performance panel.
+   * <p> You can use {@link com.microsoft.playwright.Browser#startTracing Browser.startTracing()} and {@link
+   * com.microsoft.playwright.Browser#stopTracing Browser.stopTracing()} to create a trace file that can be opened in Chrome
+   * DevTools performance panel.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * browser.startTracing(page, new Browser.StartTracingOptions()
    *   .setPath(Paths.get("trace.json")));

--- a/playwright/src/main/java/com/microsoft/playwright/BrowserContext.java
+++ b/playwright/src/main/java/com/microsoft/playwright/BrowserContext.java
@@ -30,8 +30,8 @@ import java.util.regex.Pattern;
  * <p> If a page opens another page, e.g. with a {@code window.open} call, the popup will belong to the parent page's browser
  * context.
  *
- * <p> Playwright allows creating "incognito" browser contexts with {@link Browser#newContext Browser.newContext()} method.
- * "Incognito" browser contexts don't write any browsing data to disk.
+ * <p> Playwright allows creating "incognito" browser contexts with {@link com.microsoft.playwright.Browser#newContext
+ * Browser.newContext()} method. "Incognito" browser contexts don't write any browsing data to disk.
  * <pre>{@code
  * // Create a new incognito browser context
  * BrowserContext context = browser.newContext();
@@ -66,7 +66,7 @@ public interface BrowserContext extends AutoCloseable {
    * <ul>
    * <li> Browser context is closed.</li>
    * <li> Browser application is closed or crashed.</li>
-   * <li> The {@link Browser#close Browser.close()} method was called.</li>
+   * <li> The {@link com.microsoft.playwright.Browser#close Browser.close()} method was called.</li>
    * </ul>
    */
   void onClose(Consumer<BrowserContext> handler);
@@ -82,7 +82,7 @@ public interface BrowserContext extends AutoCloseable {
    * <p> The arguments passed into {@code console.log} and the page are available on the {@code ConsoleMessage} event handler
    * argument.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * context.onConsoleMessage(msg -> {
    *   for (int i = 0; i < msg.args().size(); ++i)
@@ -99,20 +99,21 @@ public interface BrowserContext extends AutoCloseable {
 
   /**
    * Emitted when a JavaScript dialog appears, such as {@code alert}, {@code prompt}, {@code confirm} or {@code
-   * beforeunload}. Listener **must** either {@link Dialog#accept Dialog.accept()} or {@link Dialog#dismiss Dialog.dismiss()}
-   * the dialog - otherwise the page will <a
+   * beforeunload}. Listener **must** either {@link com.microsoft.playwright.Dialog#accept Dialog.accept()} or {@link
+   * com.microsoft.playwright.Dialog#dismiss Dialog.dismiss()} the dialog - otherwise the page will <a
    * href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/EventLoop#never_blocking">freeze</a> waiting for the
    * dialog, and actions like click will never finish.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * context.onDialog(dialog -> {
    *   dialog.accept();
    * });
    * }</pre>
    *
-   * <p> <strong>NOTE:</strong> When no {@link Page#onDialog Page.onDialog()} or {@link BrowserContext#onDialog BrowserContext.onDialog()} listeners are
-   * present, all dialogs are automatically dismissed.
+   * <p> <strong>NOTE:</strong> When no {@link com.microsoft.playwright.Page#onDialog Page.onDialog()} or {@link
+   * com.microsoft.playwright.BrowserContext#onDialog BrowserContext.onDialog()} listeners are present, all dialogs are
+   * automatically dismissed.
    */
   void onDialog(Consumer<Dialog> handler);
   /**
@@ -122,8 +123,8 @@ public interface BrowserContext extends AutoCloseable {
 
   /**
    * The event is emitted when a new Page is created in the BrowserContext. The page may still be loading. The event will
-   * also fire for popup pages. See also {@link Page#onPopup Page.onPopup()} to receive events about popups relevant to a
-   * specific page.
+   * also fire for popup pages. See also {@link com.microsoft.playwright.Page#onPopup Page.onPopup()} to receive events about
+   * popups relevant to a specific page.
    *
    * <p> The earliest moment that page is available is when it has navigated to the initial url. For example, when opening a
    * popup with {@code window.open('http://example.com')}, this event will fire when the network request to
@@ -135,8 +136,8 @@ public interface BrowserContext extends AutoCloseable {
    * System.out.println(newPage.evaluate("location.href"));
    * }</pre>
    *
-   * <p> <strong>NOTE:</strong> Use {@link Page#waitForLoadState Page.waitForLoadState()} to wait until the page gets to a particular state (you should
-   * not need it in most cases).
+   * <p> <strong>NOTE:</strong> Use {@link com.microsoft.playwright.Page#waitForLoadState Page.waitForLoadState()} to wait until the page gets to a
+   * particular state (you should not need it in most cases).
    */
   void onPage(Consumer<Page> handler);
   /**
@@ -146,7 +147,7 @@ public interface BrowserContext extends AutoCloseable {
 
   /**
    * Emitted when exception is unhandled in any of the pages in this context. To listen for errors from a particular page,
-   * use {@link Page#onPageError Page.onPageError()} instead.
+   * use {@link com.microsoft.playwright.Page#onPageError Page.onPageError()} instead.
    */
   void onWebError(Consumer<WebError> handler);
   /**
@@ -156,10 +157,10 @@ public interface BrowserContext extends AutoCloseable {
 
   /**
    * Emitted when a request is issued from any pages created through this context. The [request] object is read-only. To only
-   * listen for requests from a particular page, use {@link Page#onRequest Page.onRequest()}.
+   * listen for requests from a particular page, use {@link com.microsoft.playwright.Page#onRequest Page.onRequest()}.
    *
-   * <p> In order to intercept and mutate requests, see {@link BrowserContext#route BrowserContext.route()} or {@link Page#route
-   * Page.route()}.
+   * <p> In order to intercept and mutate requests, see {@link com.microsoft.playwright.BrowserContext#route
+   * BrowserContext.route()} or {@link com.microsoft.playwright.Page#route Page.route()}.
    */
   void onRequest(Consumer<Request> handler);
   /**
@@ -169,11 +170,11 @@ public interface BrowserContext extends AutoCloseable {
 
   /**
    * Emitted when a request fails, for example by timing out. To only listen for failed requests from a particular page, use
-   * {@link Page#onRequestFailed Page.onRequestFailed()}.
+   * {@link com.microsoft.playwright.Page#onRequestFailed Page.onRequestFailed()}.
    *
    * <p> <strong>NOTE:</strong> HTTP Error responses, such as 404 or 503, are still successful responses from HTTP standpoint, so request will complete
-   * with {@link BrowserContext#onRequestFinished BrowserContext.onRequestFinished()} event and not with {@link
-   * BrowserContext#onRequestFailed BrowserContext.onRequestFailed()}.
+   * with {@link com.microsoft.playwright.BrowserContext#onRequestFinished BrowserContext.onRequestFinished()} event and not
+   * with {@link com.microsoft.playwright.BrowserContext#onRequestFailed BrowserContext.onRequestFailed()}.
    */
   void onRequestFailed(Consumer<Request> handler);
   /**
@@ -184,7 +185,7 @@ public interface BrowserContext extends AutoCloseable {
   /**
    * Emitted when a request finishes successfully after downloading the response body. For a successful response, the
    * sequence of events is {@code request}, {@code response} and {@code requestfinished}. To listen for successful requests
-   * from a particular page, use {@link Page#onRequestFinished Page.onRequestFinished()}.
+   * from a particular page, use {@link com.microsoft.playwright.Page#onRequestFinished Page.onRequestFinished()}.
    */
   void onRequestFinished(Consumer<Request> handler);
   /**
@@ -195,7 +196,7 @@ public interface BrowserContext extends AutoCloseable {
   /**
    * Emitted when [response] status and headers are received for a request. For a successful response, the sequence of events
    * is {@code request}, {@code response} and {@code requestfinished}. To listen for response events from a particular page,
-   * use {@link Page#onResponse Page.onResponse()}.
+   * use {@link com.microsoft.playwright.Page#onResponse Page.onResponse()}.
    */
   void onResponse(Consumer<Response> handler);
   /**
@@ -330,7 +331,7 @@ public interface BrowserContext extends AutoCloseable {
     public HarNotFound notFound;
     /**
      * If specified, updates the given HAR with the actual network information instead of serving from file. The file is
-     * written to disk when {@link BrowserContext#close BrowserContext.close()} is called.
+     * written to disk when {@link com.microsoft.playwright.BrowserContext#close BrowserContext.close()} is called.
      */
     public Boolean update;
     /**
@@ -364,7 +365,7 @@ public interface BrowserContext extends AutoCloseable {
     }
     /**
      * If specified, updates the given HAR with the actual network information instead of serving from file. The file is
-     * written to disk when {@link BrowserContext#close BrowserContext.close()} is called.
+     * written to disk when {@link com.microsoft.playwright.BrowserContext#close BrowserContext.close()} is called.
      */
     public RouteFromHAROptions setUpdate(boolean update) {
       this.update = update;
@@ -423,15 +424,17 @@ public interface BrowserContext extends AutoCloseable {
   class WaitForConditionOptions {
     /**
      * Maximum time to wait for in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The
-     * default value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or
-     * {@link Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * default value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
 
     /**
      * Maximum time to wait for in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The
-     * default value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or
-     * {@link Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * default value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public WaitForConditionOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -445,7 +448,8 @@ public interface BrowserContext extends AutoCloseable {
     public Predicate<ConsoleMessage> predicate;
     /**
      * Maximum time to wait for in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The
-     * default value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()}.
+     * default value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()}.
      */
     public Double timeout;
 
@@ -458,7 +462,8 @@ public interface BrowserContext extends AutoCloseable {
     }
     /**
      * Maximum time to wait for in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The
-     * default value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()}.
+     * default value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()}.
      */
     public WaitForConsoleMessageOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -472,7 +477,8 @@ public interface BrowserContext extends AutoCloseable {
     public Predicate<Page> predicate;
     /**
      * Maximum time to wait for in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The
-     * default value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()}.
+     * default value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()}.
      */
     public Double timeout;
 
@@ -485,7 +491,8 @@ public interface BrowserContext extends AutoCloseable {
     }
     /**
      * Maximum time to wait for in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The
-     * default value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()}.
+     * default value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()}.
      */
     public WaitForPageOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -494,9 +501,9 @@ public interface BrowserContext extends AutoCloseable {
   }
   /**
    * Adds cookies into this browser context. All pages within this context will have these cookies installed. Cookies can be
-   * obtained via {@link BrowserContext#cookies BrowserContext.cookies()}.
+   * obtained via {@link com.microsoft.playwright.BrowserContext#cookies BrowserContext.cookies()}.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * browserContext.addCookies(Arrays.asList(cookieObject1, cookieObject2));
    * }</pre>
@@ -518,7 +525,7 @@ public interface BrowserContext extends AutoCloseable {
    * <p> The script is evaluated after the document was created but before any of its scripts were run. This is useful to amend
    * the JavaScript environment, e.g. to seed {@code Math.random}.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> An example of overriding {@code Math.random} before the page loads:
    * <pre>{@code
@@ -526,8 +533,9 @@ public interface BrowserContext extends AutoCloseable {
    * browserContext.addInitScript(Paths.get("preload.js"));
    * }</pre>
    *
-   * <p> <strong>NOTE:</strong> The order of evaluation of multiple scripts installed via {@link BrowserContext#addInitScript
-   * BrowserContext.addInitScript()} and {@link Page#addInitScript Page.addInitScript()} is not defined.
+   * <p> <strong>NOTE:</strong> The order of evaluation of multiple scripts installed via {@link com.microsoft.playwright.BrowserContext#addInitScript
+   * BrowserContext.addInitScript()} and {@link com.microsoft.playwright.Page#addInitScript Page.addInitScript()} is not
+   * defined.
    *
    * @param script Script to be evaluated in all pages in the browser context.
    * @since v1.8
@@ -544,7 +552,7 @@ public interface BrowserContext extends AutoCloseable {
    * <p> The script is evaluated after the document was created but before any of its scripts were run. This is useful to amend
    * the JavaScript environment, e.g. to seed {@code Math.random}.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> An example of overriding {@code Math.random} before the page loads:
    * <pre>{@code
@@ -552,8 +560,9 @@ public interface BrowserContext extends AutoCloseable {
    * browserContext.addInitScript(Paths.get("preload.js"));
    * }</pre>
    *
-   * <p> <strong>NOTE:</strong> The order of evaluation of multiple scripts installed via {@link BrowserContext#addInitScript
-   * BrowserContext.addInitScript()} and {@link Page#addInitScript Page.addInitScript()} is not defined.
+   * <p> <strong>NOTE:</strong> The order of evaluation of multiple scripts installed via {@link com.microsoft.playwright.BrowserContext#addInitScript
+   * BrowserContext.addInitScript()} and {@link com.microsoft.playwright.Page#addInitScript Page.addInitScript()} is not
+   * defined.
    *
    * @param script Script to be evaluated in all pages in the browser context.
    * @since v1.8
@@ -576,7 +585,7 @@ public interface BrowserContext extends AutoCloseable {
   /**
    * Removes cookies from context. Accepts optional filter.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * context.clearCookies();
    * context.clearCookies(new BrowserContext.ClearCookiesOptions().setName("session-id"));
@@ -595,7 +604,7 @@ public interface BrowserContext extends AutoCloseable {
   /**
    * Removes cookies from context. Accepts optional filter.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * context.clearCookies();
    * context.clearCookies(new BrowserContext.ClearCookiesOptions().setName("session-id"));
@@ -612,7 +621,7 @@ public interface BrowserContext extends AutoCloseable {
   /**
    * Clears all permission overrides for the browser context.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * BrowserContext context = browser.newContext();
    * context.grantPermissions(Arrays.asList("clipboard-read"));
@@ -677,9 +686,9 @@ public interface BrowserContext extends AutoCloseable {
    * <p> The first argument of the {@code callback} function contains information about the caller: {@code { browserContext:
    * BrowserContext, page: Page, frame: Frame }}.
    *
-   * <p> See {@link Page#exposeBinding Page.exposeBinding()} for page-only version.
+   * <p> See {@link com.microsoft.playwright.Page#exposeBinding Page.exposeBinding()} for page-only version.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> An example of exposing page URL to all frames in all pages in the context:
    * <pre>{@code
@@ -739,9 +748,9 @@ public interface BrowserContext extends AutoCloseable {
    * <p> The first argument of the {@code callback} function contains information about the caller: {@code { browserContext:
    * BrowserContext, page: Page, frame: Frame }}.
    *
-   * <p> See {@link Page#exposeBinding Page.exposeBinding()} for page-only version.
+   * <p> See {@link com.microsoft.playwright.Page#exposeBinding Page.exposeBinding()} for page-only version.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> An example of exposing page URL to all frames in all pages in the context:
    * <pre>{@code
@@ -798,9 +807,9 @@ public interface BrowserContext extends AutoCloseable {
    * href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>, it will be
    * awaited.
    *
-   * <p> See {@link Page#exposeFunction Page.exposeFunction()} for page-only version.
+   * <p> See {@link com.microsoft.playwright.Page#exposeFunction Page.exposeFunction()} for page-only version.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> An example of adding a {@code sha256} function to all pages in the context:
    * <pre>{@code
@@ -940,11 +949,11 @@ public interface BrowserContext extends AutoCloseable {
    * Routing provides the capability to modify network requests that are made by any page in the browser context. Once route
    * is enabled, every request matching the url pattern will stall unless it's continued, fulfilled or aborted.
    *
-   * <p> <strong>NOTE:</strong> {@link BrowserContext#route BrowserContext.route()} will not intercept requests intercepted by Service Worker. See <a
-   * href="https://github.com/microsoft/playwright/issues/1090">this</a> issue. We recommend disabling Service Workers when
-   * using request interception by setting {@code Browser.newContext.serviceWorkers} to {@code "block"}.
+   * <p> <strong>NOTE:</strong> {@link com.microsoft.playwright.BrowserContext#route BrowserContext.route()} will not intercept requests intercepted by
+   * Service Worker. See <a href="https://github.com/microsoft/playwright/issues/1090">this</a> issue. We recommend disabling
+   * Service Workers when using request interception by setting {@code Browser.newContext.serviceWorkers} to {@code "block"}.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> An example of a naive handler that aborts all image requests:
    * <pre>{@code
@@ -975,10 +984,11 @@ public interface BrowserContext extends AutoCloseable {
    * });
    * }</pre>
    *
-   * <p> Page routes (set up with {@link Page#route Page.route()}) take precedence over browser context routes when request
-   * matches both handlers.
+   * <p> Page routes (set up with {@link com.microsoft.playwright.Page#route Page.route()}) take precedence over browser context
+   * routes when request matches both handlers.
    *
-   * <p> To remove a route with its handler you can use {@link BrowserContext#unroute BrowserContext.unroute()}.
+   * <p> To remove a route with its handler you can use {@link com.microsoft.playwright.BrowserContext#unroute
+   * BrowserContext.unroute()}.
    *
    * <p> <strong>NOTE:</strong> Enabling routing disables http cache.
    *
@@ -995,11 +1005,11 @@ public interface BrowserContext extends AutoCloseable {
    * Routing provides the capability to modify network requests that are made by any page in the browser context. Once route
    * is enabled, every request matching the url pattern will stall unless it's continued, fulfilled or aborted.
    *
-   * <p> <strong>NOTE:</strong> {@link BrowserContext#route BrowserContext.route()} will not intercept requests intercepted by Service Worker. See <a
-   * href="https://github.com/microsoft/playwright/issues/1090">this</a> issue. We recommend disabling Service Workers when
-   * using request interception by setting {@code Browser.newContext.serviceWorkers} to {@code "block"}.
+   * <p> <strong>NOTE:</strong> {@link com.microsoft.playwright.BrowserContext#route BrowserContext.route()} will not intercept requests intercepted by
+   * Service Worker. See <a href="https://github.com/microsoft/playwright/issues/1090">this</a> issue. We recommend disabling
+   * Service Workers when using request interception by setting {@code Browser.newContext.serviceWorkers} to {@code "block"}.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> An example of a naive handler that aborts all image requests:
    * <pre>{@code
@@ -1030,10 +1040,11 @@ public interface BrowserContext extends AutoCloseable {
    * });
    * }</pre>
    *
-   * <p> Page routes (set up with {@link Page#route Page.route()}) take precedence over browser context routes when request
-   * matches both handlers.
+   * <p> Page routes (set up with {@link com.microsoft.playwright.Page#route Page.route()}) take precedence over browser context
+   * routes when request matches both handlers.
    *
-   * <p> To remove a route with its handler you can use {@link BrowserContext#unroute BrowserContext.unroute()}.
+   * <p> To remove a route with its handler you can use {@link com.microsoft.playwright.BrowserContext#unroute
+   * BrowserContext.unroute()}.
    *
    * <p> <strong>NOTE:</strong> Enabling routing disables http cache.
    *
@@ -1048,11 +1059,11 @@ public interface BrowserContext extends AutoCloseable {
    * Routing provides the capability to modify network requests that are made by any page in the browser context. Once route
    * is enabled, every request matching the url pattern will stall unless it's continued, fulfilled or aborted.
    *
-   * <p> <strong>NOTE:</strong> {@link BrowserContext#route BrowserContext.route()} will not intercept requests intercepted by Service Worker. See <a
-   * href="https://github.com/microsoft/playwright/issues/1090">this</a> issue. We recommend disabling Service Workers when
-   * using request interception by setting {@code Browser.newContext.serviceWorkers} to {@code "block"}.
+   * <p> <strong>NOTE:</strong> {@link com.microsoft.playwright.BrowserContext#route BrowserContext.route()} will not intercept requests intercepted by
+   * Service Worker. See <a href="https://github.com/microsoft/playwright/issues/1090">this</a> issue. We recommend disabling
+   * Service Workers when using request interception by setting {@code Browser.newContext.serviceWorkers} to {@code "block"}.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> An example of a naive handler that aborts all image requests:
    * <pre>{@code
@@ -1083,10 +1094,11 @@ public interface BrowserContext extends AutoCloseable {
    * });
    * }</pre>
    *
-   * <p> Page routes (set up with {@link Page#route Page.route()}) take precedence over browser context routes when request
-   * matches both handlers.
+   * <p> Page routes (set up with {@link com.microsoft.playwright.Page#route Page.route()}) take precedence over browser context
+   * routes when request matches both handlers.
    *
-   * <p> To remove a route with its handler you can use {@link BrowserContext#unroute BrowserContext.unroute()}.
+   * <p> To remove a route with its handler you can use {@link com.microsoft.playwright.BrowserContext#unroute
+   * BrowserContext.unroute()}.
    *
    * <p> <strong>NOTE:</strong> Enabling routing disables http cache.
    *
@@ -1103,11 +1115,11 @@ public interface BrowserContext extends AutoCloseable {
    * Routing provides the capability to modify network requests that are made by any page in the browser context. Once route
    * is enabled, every request matching the url pattern will stall unless it's continued, fulfilled or aborted.
    *
-   * <p> <strong>NOTE:</strong> {@link BrowserContext#route BrowserContext.route()} will not intercept requests intercepted by Service Worker. See <a
-   * href="https://github.com/microsoft/playwright/issues/1090">this</a> issue. We recommend disabling Service Workers when
-   * using request interception by setting {@code Browser.newContext.serviceWorkers} to {@code "block"}.
+   * <p> <strong>NOTE:</strong> {@link com.microsoft.playwright.BrowserContext#route BrowserContext.route()} will not intercept requests intercepted by
+   * Service Worker. See <a href="https://github.com/microsoft/playwright/issues/1090">this</a> issue. We recommend disabling
+   * Service Workers when using request interception by setting {@code Browser.newContext.serviceWorkers} to {@code "block"}.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> An example of a naive handler that aborts all image requests:
    * <pre>{@code
@@ -1138,10 +1150,11 @@ public interface BrowserContext extends AutoCloseable {
    * });
    * }</pre>
    *
-   * <p> Page routes (set up with {@link Page#route Page.route()}) take precedence over browser context routes when request
-   * matches both handlers.
+   * <p> Page routes (set up with {@link com.microsoft.playwright.Page#route Page.route()}) take precedence over browser context
+   * routes when request matches both handlers.
    *
-   * <p> To remove a route with its handler you can use {@link BrowserContext#unroute BrowserContext.unroute()}.
+   * <p> To remove a route with its handler you can use {@link com.microsoft.playwright.BrowserContext#unroute
+   * BrowserContext.unroute()}.
    *
    * <p> <strong>NOTE:</strong> Enabling routing disables http cache.
    *
@@ -1156,11 +1169,11 @@ public interface BrowserContext extends AutoCloseable {
    * Routing provides the capability to modify network requests that are made by any page in the browser context. Once route
    * is enabled, every request matching the url pattern will stall unless it's continued, fulfilled or aborted.
    *
-   * <p> <strong>NOTE:</strong> {@link BrowserContext#route BrowserContext.route()} will not intercept requests intercepted by Service Worker. See <a
-   * href="https://github.com/microsoft/playwright/issues/1090">this</a> issue. We recommend disabling Service Workers when
-   * using request interception by setting {@code Browser.newContext.serviceWorkers} to {@code "block"}.
+   * <p> <strong>NOTE:</strong> {@link com.microsoft.playwright.BrowserContext#route BrowserContext.route()} will not intercept requests intercepted by
+   * Service Worker. See <a href="https://github.com/microsoft/playwright/issues/1090">this</a> issue. We recommend disabling
+   * Service Workers when using request interception by setting {@code Browser.newContext.serviceWorkers} to {@code "block"}.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> An example of a naive handler that aborts all image requests:
    * <pre>{@code
@@ -1191,10 +1204,11 @@ public interface BrowserContext extends AutoCloseable {
    * });
    * }</pre>
    *
-   * <p> Page routes (set up with {@link Page#route Page.route()}) take precedence over browser context routes when request
-   * matches both handlers.
+   * <p> Page routes (set up with {@link com.microsoft.playwright.Page#route Page.route()}) take precedence over browser context
+   * routes when request matches both handlers.
    *
-   * <p> To remove a route with its handler you can use {@link BrowserContext#unroute BrowserContext.unroute()}.
+   * <p> To remove a route with its handler you can use {@link com.microsoft.playwright.BrowserContext#unroute
+   * BrowserContext.unroute()}.
    *
    * <p> <strong>NOTE:</strong> Enabling routing disables http cache.
    *
@@ -1211,11 +1225,11 @@ public interface BrowserContext extends AutoCloseable {
    * Routing provides the capability to modify network requests that are made by any page in the browser context. Once route
    * is enabled, every request matching the url pattern will stall unless it's continued, fulfilled or aborted.
    *
-   * <p> <strong>NOTE:</strong> {@link BrowserContext#route BrowserContext.route()} will not intercept requests intercepted by Service Worker. See <a
-   * href="https://github.com/microsoft/playwright/issues/1090">this</a> issue. We recommend disabling Service Workers when
-   * using request interception by setting {@code Browser.newContext.serviceWorkers} to {@code "block"}.
+   * <p> <strong>NOTE:</strong> {@link com.microsoft.playwright.BrowserContext#route BrowserContext.route()} will not intercept requests intercepted by
+   * Service Worker. See <a href="https://github.com/microsoft/playwright/issues/1090">this</a> issue. We recommend disabling
+   * Service Workers when using request interception by setting {@code Browser.newContext.serviceWorkers} to {@code "block"}.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> An example of a naive handler that aborts all image requests:
    * <pre>{@code
@@ -1246,10 +1260,11 @@ public interface BrowserContext extends AutoCloseable {
    * });
    * }</pre>
    *
-   * <p> Page routes (set up with {@link Page#route Page.route()}) take precedence over browser context routes when request
-   * matches both handlers.
+   * <p> Page routes (set up with {@link com.microsoft.playwright.Page#route Page.route()}) take precedence over browser context
+   * routes when request matches both handlers.
    *
-   * <p> To remove a route with its handler you can use {@link BrowserContext#unroute BrowserContext.unroute()}.
+   * <p> To remove a route with its handler you can use {@link com.microsoft.playwright.BrowserContext#unroute
+   * BrowserContext.unroute()}.
    *
    * <p> <strong>NOTE:</strong> Enabling routing disables http cache.
    *
@@ -1291,17 +1306,17 @@ public interface BrowserContext extends AutoCloseable {
   /**
    * This setting will change the default maximum navigation time for the following methods and related shortcuts:
    * <ul>
-   * <li> {@link Page#goBack Page.goBack()}</li>
-   * <li> {@link Page#goForward Page.goForward()}</li>
-   * <li> {@link Page#navigate Page.navigate()}</li>
-   * <li> {@link Page#reload Page.reload()}</li>
-   * <li> {@link Page#setContent Page.setContent()}</li>
-   * <li> {@link Page#waitForNavigation Page.waitForNavigation()}</li>
+   * <li> {@link com.microsoft.playwright.Page#goBack Page.goBack()}</li>
+   * <li> {@link com.microsoft.playwright.Page#goForward Page.goForward()}</li>
+   * <li> {@link com.microsoft.playwright.Page#navigate Page.navigate()}</li>
+   * <li> {@link com.microsoft.playwright.Page#reload Page.reload()}</li>
+   * <li> {@link com.microsoft.playwright.Page#setContent Page.setContent()}</li>
+   * <li> {@link com.microsoft.playwright.Page#waitForNavigation Page.waitForNavigation()}</li>
    * </ul>
    *
-   * <p> <strong>NOTE:</strong> {@link Page#setDefaultNavigationTimeout Page.setDefaultNavigationTimeout()} and {@link Page#setDefaultTimeout
-   * Page.setDefaultTimeout()} take priority over {@link BrowserContext#setDefaultNavigationTimeout
-   * BrowserContext.setDefaultNavigationTimeout()}.
+   * <p> <strong>NOTE:</strong> {@link com.microsoft.playwright.Page#setDefaultNavigationTimeout Page.setDefaultNavigationTimeout()} and {@link
+   * com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()} take priority over {@link
+   * com.microsoft.playwright.BrowserContext#setDefaultNavigationTimeout BrowserContext.setDefaultNavigationTimeout()}.
    *
    * @param timeout Maximum navigation time in milliseconds
    * @since v1.8
@@ -1310,10 +1325,10 @@ public interface BrowserContext extends AutoCloseable {
   /**
    * This setting will change the default maximum time for all the methods accepting {@code timeout} option.
    *
-   * <p> <strong>NOTE:</strong> {@link Page#setDefaultNavigationTimeout Page.setDefaultNavigationTimeout()}, {@link Page#setDefaultTimeout
-   * Page.setDefaultTimeout()} and {@link BrowserContext#setDefaultNavigationTimeout
-   * BrowserContext.setDefaultNavigationTimeout()} take priority over {@link BrowserContext#setDefaultTimeout
-   * BrowserContext.setDefaultTimeout()}.
+   * <p> <strong>NOTE:</strong> {@link com.microsoft.playwright.Page#setDefaultNavigationTimeout Page.setDefaultNavigationTimeout()}, {@link
+   * com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()} and {@link
+   * com.microsoft.playwright.BrowserContext#setDefaultNavigationTimeout BrowserContext.setDefaultNavigationTimeout()} take
+   * priority over {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()}.
    *
    * @param timeout Maximum time in milliseconds
    * @since v1.8
@@ -1321,11 +1336,12 @@ public interface BrowserContext extends AutoCloseable {
   void setDefaultTimeout(double timeout);
   /**
    * The extra HTTP headers will be sent with every request initiated by any page in the context. These headers are merged
-   * with page-specific extra HTTP headers set with {@link Page#setExtraHTTPHeaders Page.setExtraHTTPHeaders()}. If page
-   * overrides a particular header, page-specific header value will be used instead of the browser context header value.
+   * with page-specific extra HTTP headers set with {@link com.microsoft.playwright.Page#setExtraHTTPHeaders
+   * Page.setExtraHTTPHeaders()}. If page overrides a particular header, page-specific header value will be used instead of
+   * the browser context header value.
    *
-   * <p> <strong>NOTE:</strong> {@link BrowserContext#setExtraHTTPHeaders BrowserContext.setExtraHTTPHeaders()} does not guarantee the order of headers
-   * in the outgoing requests.
+   * <p> <strong>NOTE:</strong> {@link com.microsoft.playwright.BrowserContext#setExtraHTTPHeaders BrowserContext.setExtraHTTPHeaders()} does not
+   * guarantee the order of headers in the outgoing requests.
    *
    * @param headers An object containing additional HTTP headers to be sent with every request. All header values must be strings.
    * @since v1.8
@@ -1334,13 +1350,13 @@ public interface BrowserContext extends AutoCloseable {
   /**
    * Sets the context's geolocation. Passing {@code null} or {@code undefined} emulates position unavailable.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * browserContext.setGeolocation(new Geolocation(59.95, 30.31667));
    * }</pre>
    *
-   * <p> <strong>NOTE:</strong> Consider using {@link BrowserContext#grantPermissions BrowserContext.grantPermissions()} to grant permissions for the
-   * browser context pages to read its geolocation.
+   * <p> <strong>NOTE:</strong> Consider using {@link com.microsoft.playwright.BrowserContext#grantPermissions BrowserContext.grantPermissions()} to
+   * grant permissions for the browser context pages to read its geolocation.
    *
    * @since v1.8
    */
@@ -1373,72 +1389,75 @@ public interface BrowserContext extends AutoCloseable {
    */
   Tracing tracing();
   /**
-   * Removes all routes created with {@link BrowserContext#route BrowserContext.route()} and {@link
-   * BrowserContext#routeFromHAR BrowserContext.routeFromHAR()}.
+   * Removes all routes created with {@link com.microsoft.playwright.BrowserContext#route BrowserContext.route()} and {@link
+   * com.microsoft.playwright.BrowserContext#routeFromHAR BrowserContext.routeFromHAR()}.
    *
    * @since v1.41
    */
   void unrouteAll();
   /**
-   * Removes a route created with {@link BrowserContext#route BrowserContext.route()}. When {@code handler} is not specified,
-   * removes all routes for the {@code url}.
+   * Removes a route created with {@link com.microsoft.playwright.BrowserContext#route BrowserContext.route()}. When {@code
+   * handler} is not specified, removes all routes for the {@code url}.
    *
-   * @param url A glob pattern, regex pattern or predicate receiving [URL] used to register a routing with {@link BrowserContext#route
-   * BrowserContext.route()}.
+   * @param url A glob pattern, regex pattern or predicate receiving [URL] used to register a routing with {@link
+   * com.microsoft.playwright.BrowserContext#route BrowserContext.route()}.
    * @since v1.8
    */
   default void unroute(String url) {
     unroute(url, null);
   }
   /**
-   * Removes a route created with {@link BrowserContext#route BrowserContext.route()}. When {@code handler} is not specified,
-   * removes all routes for the {@code url}.
+   * Removes a route created with {@link com.microsoft.playwright.BrowserContext#route BrowserContext.route()}. When {@code
+   * handler} is not specified, removes all routes for the {@code url}.
    *
-   * @param url A glob pattern, regex pattern or predicate receiving [URL] used to register a routing with {@link BrowserContext#route
+   * @param url A glob pattern, regex pattern or predicate receiving [URL] used to register a routing with {@link
+   * com.microsoft.playwright.BrowserContext#route BrowserContext.route()}.
+   * @param handler Optional handler function used to register a routing with {@link com.microsoft.playwright.BrowserContext#route
    * BrowserContext.route()}.
-   * @param handler Optional handler function used to register a routing with {@link BrowserContext#route BrowserContext.route()}.
    * @since v1.8
    */
   void unroute(String url, Consumer<Route> handler);
   /**
-   * Removes a route created with {@link BrowserContext#route BrowserContext.route()}. When {@code handler} is not specified,
-   * removes all routes for the {@code url}.
+   * Removes a route created with {@link com.microsoft.playwright.BrowserContext#route BrowserContext.route()}. When {@code
+   * handler} is not specified, removes all routes for the {@code url}.
    *
-   * @param url A glob pattern, regex pattern or predicate receiving [URL] used to register a routing with {@link BrowserContext#route
-   * BrowserContext.route()}.
+   * @param url A glob pattern, regex pattern or predicate receiving [URL] used to register a routing with {@link
+   * com.microsoft.playwright.BrowserContext#route BrowserContext.route()}.
    * @since v1.8
    */
   default void unroute(Pattern url) {
     unroute(url, null);
   }
   /**
-   * Removes a route created with {@link BrowserContext#route BrowserContext.route()}. When {@code handler} is not specified,
-   * removes all routes for the {@code url}.
+   * Removes a route created with {@link com.microsoft.playwright.BrowserContext#route BrowserContext.route()}. When {@code
+   * handler} is not specified, removes all routes for the {@code url}.
    *
-   * @param url A glob pattern, regex pattern or predicate receiving [URL] used to register a routing with {@link BrowserContext#route
+   * @param url A glob pattern, regex pattern or predicate receiving [URL] used to register a routing with {@link
+   * com.microsoft.playwright.BrowserContext#route BrowserContext.route()}.
+   * @param handler Optional handler function used to register a routing with {@link com.microsoft.playwright.BrowserContext#route
    * BrowserContext.route()}.
-   * @param handler Optional handler function used to register a routing with {@link BrowserContext#route BrowserContext.route()}.
    * @since v1.8
    */
   void unroute(Pattern url, Consumer<Route> handler);
   /**
-   * Removes a route created with {@link BrowserContext#route BrowserContext.route()}. When {@code handler} is not specified,
-   * removes all routes for the {@code url}.
+   * Removes a route created with {@link com.microsoft.playwright.BrowserContext#route BrowserContext.route()}. When {@code
+   * handler} is not specified, removes all routes for the {@code url}.
    *
-   * @param url A glob pattern, regex pattern or predicate receiving [URL] used to register a routing with {@link BrowserContext#route
-   * BrowserContext.route()}.
+   * @param url A glob pattern, regex pattern or predicate receiving [URL] used to register a routing with {@link
+   * com.microsoft.playwright.BrowserContext#route BrowserContext.route()}.
    * @since v1.8
    */
   default void unroute(Predicate<String> url) {
     unroute(url, null);
   }
   /**
-   * Removes a route created with {@link BrowserContext#route BrowserContext.route()}. When {@code handler} is not specified,
-   * removes all routes for the {@code url}.
+   * Removes a route created with {@link com.microsoft.playwright.BrowserContext#route BrowserContext.route()}. When {@code
+   * handler} is not specified, removes all routes for the {@code url}.
    *
-   * @param url A glob pattern, regex pattern or predicate receiving [URL] used to register a routing with {@link BrowserContext#route
+   * @param url A glob pattern, regex pattern or predicate receiving [URL] used to register a routing with {@link
+   * com.microsoft.playwright.BrowserContext#route BrowserContext.route()}.
+   * @param handler Optional handler function used to register a routing with {@link com.microsoft.playwright.BrowserContext#route
    * BrowserContext.route()}.
-   * @param handler Optional handler function used to register a routing with {@link BrowserContext#route BrowserContext.route()}.
    * @since v1.8
    */
   void unroute(Predicate<String> url, Consumer<Route> handler);
@@ -1446,7 +1465,7 @@ public interface BrowserContext extends AutoCloseable {
    * The method will block until the condition returns true. All Playwright events will be dispatched while the method is
    * waiting for the condition.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> Use the method to wait for a condition that depends on page events:
    * <pre>{@code
@@ -1471,7 +1490,7 @@ public interface BrowserContext extends AutoCloseable {
    * The method will block until the condition returns true. All Playwright events will be dispatched while the method is
    * waiting for the condition.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> Use the method to wait for a condition that depends on page events:
    * <pre>{@code
@@ -1494,7 +1513,7 @@ public interface BrowserContext extends AutoCloseable {
    * Performs action and waits for a {@code ConsoleMessage} to be logged by in the pages in the context. If predicate is
    * provided, it passes {@code ConsoleMessage} value into the {@code predicate} function and waits for {@code
    * predicate(message)} to return a truthy value. Will throw an error if the page is closed before the {@link
-   * BrowserContext#onConsoleMessage BrowserContext.onConsoleMessage()} event is fired.
+   * com.microsoft.playwright.BrowserContext#onConsoleMessage BrowserContext.onConsoleMessage()} event is fired.
    *
    * @param callback Callback that performs the action triggering the event.
    * @since v1.34
@@ -1506,7 +1525,7 @@ public interface BrowserContext extends AutoCloseable {
    * Performs action and waits for a {@code ConsoleMessage} to be logged by in the pages in the context. If predicate is
    * provided, it passes {@code ConsoleMessage} value into the {@code predicate} function and waits for {@code
    * predicate(message)} to return a truthy value. Will throw an error if the page is closed before the {@link
-   * BrowserContext#onConsoleMessage BrowserContext.onConsoleMessage()} event is fired.
+   * com.microsoft.playwright.BrowserContext#onConsoleMessage BrowserContext.onConsoleMessage()} event is fired.
    *
    * @param callback Callback that performs the action triggering the event.
    * @since v1.34

--- a/playwright/src/main/java/com/microsoft/playwright/BrowserType.java
+++ b/playwright/src/main/java/com/microsoft/playwright/BrowserType.java
@@ -425,10 +425,11 @@ public interface BrowserType {
      */
     public List<String> args;
     /**
-     * When using {@link Page#navigate Page.navigate()}, {@link Page#route Page.route()}, {@link Page#waitForURL
-     * Page.waitForURL()}, {@link Page#waitForRequest Page.waitForRequest()}, or {@link Page#waitForResponse
-     * Page.waitForResponse()} it takes the base URL in consideration by using the <a
-     * href="https://developer.mozilla.org/en-US/docs/Web/API/URL/URL">{@code URL()}</a> constructor for building the
+     * When using {@link com.microsoft.playwright.Page#navigate Page.navigate()}, {@link com.microsoft.playwright.Page#route
+     * Page.route()}, {@link com.microsoft.playwright.Page#waitForURL Page.waitForURL()}, {@link
+     * com.microsoft.playwright.Page#waitForRequest Page.waitForRequest()}, or {@link
+     * com.microsoft.playwright.Page#waitForResponse Page.waitForResponse()} it takes the base URL in consideration by using
+     * the <a href="https://developer.mozilla.org/en-US/docs/Web/API/URL/URL">{@code URL()}</a> constructor for building the
      * corresponding URL. Unset by default. Examples:
      * <ul>
      * <li> baseURL: {@code http://localhost:3000} and navigating to {@code /bar.html} results in {@code
@@ -456,8 +457,8 @@ public interface BrowserType {
     public Boolean chromiumSandbox;
     /**
      * Emulates {@code "prefers-colors-scheme"} media feature, supported values are {@code "light"}, {@code "dark"}, {@code
-     * "no-preference"}. See {@link Page#emulateMedia Page.emulateMedia()} for more details. Passing {@code null} resets
-     * emulation to system defaults. Defaults to {@code "light"}.
+     * "no-preference"}. See {@link com.microsoft.playwright.Page#emulateMedia Page.emulateMedia()} for more details. Passing
+     * {@code null} resets emulation to system defaults. Defaults to {@code "light"}.
      */
     public Optional<ColorScheme> colorScheme;
     /**
@@ -496,8 +497,8 @@ public interface BrowserType {
     public Map<String, Object> firefoxUserPrefs;
     /**
      * Emulates {@code "forced-colors"} media feature, supported values are {@code "active"}, {@code "none"}. See {@link
-     * Page#emulateMedia Page.emulateMedia()} for more details. Passing {@code null} resets emulation to system defaults.
-     * Defaults to {@code "none"}.
+     * com.microsoft.playwright.Page#emulateMedia Page.emulateMedia()} for more details. Passing {@code null} resets emulation
+     * to system defaults. Defaults to {@code "none"}.
      */
     public Optional<ForcedColors> forcedColors;
     public Geolocation geolocation;
@@ -568,8 +569,9 @@ public interface BrowserType {
      */
     public Boolean offline;
     /**
-     * A list of permissions to grant to all pages in this context. See {@link BrowserContext#grantPermissions
-     * BrowserContext.grantPermissions()} for more details. Defaults to none.
+     * A list of permissions to grant to all pages in this context. See {@link
+     * com.microsoft.playwright.BrowserContext#grantPermissions BrowserContext.grantPermissions()} for more details. Defaults
+     * to none.
      */
     public List<String> permissions;
     /**
@@ -594,14 +596,14 @@ public interface BrowserType {
     public Boolean recordHarOmitContent;
     /**
      * Enables <a href="http://www.softwareishard.com/blog/har-12-spec">HAR</a> recording for all pages into the specified HAR
-     * file on the filesystem. If not specified, the HAR is not recorded. Make sure to call {@link BrowserContext#close
-     * BrowserContext.close()} for the HAR to be saved.
+     * file on the filesystem. If not specified, the HAR is not recorded. Make sure to call {@link
+     * com.microsoft.playwright.BrowserContext#close BrowserContext.close()} for the HAR to be saved.
      */
     public Path recordHarPath;
     public Object recordHarUrlFilter;
     /**
      * Enables video recording for all pages into the specified directory. If not specified videos are not recorded. Make sure
-     * to call {@link BrowserContext#close BrowserContext.close()} for videos to be saved.
+     * to call {@link com.microsoft.playwright.BrowserContext#close BrowserContext.close()} for videos to be saved.
      */
     public Path recordVideoDir;
     /**
@@ -612,8 +614,8 @@ public interface BrowserType {
     public RecordVideoSize recordVideoSize;
     /**
      * Emulates {@code "prefers-reduced-motion"} media feature, supported values are {@code "reduce"}, {@code "no-preference"}.
-     * See {@link Page#emulateMedia Page.emulateMedia()} for more details. Passing {@code null} resets emulation to system
-     * defaults. Defaults to {@code "no-preference"}.
+     * See {@link com.microsoft.playwright.Page#emulateMedia Page.emulateMedia()} for more details. Passing {@code null} resets
+     * emulation to system defaults. Defaults to {@code "no-preference"}.
      */
     public Optional<ReducedMotion> reducedMotion;
     /**
@@ -688,10 +690,11 @@ public interface BrowserType {
       return this;
     }
     /**
-     * When using {@link Page#navigate Page.navigate()}, {@link Page#route Page.route()}, {@link Page#waitForURL
-     * Page.waitForURL()}, {@link Page#waitForRequest Page.waitForRequest()}, or {@link Page#waitForResponse
-     * Page.waitForResponse()} it takes the base URL in consideration by using the <a
-     * href="https://developer.mozilla.org/en-US/docs/Web/API/URL/URL">{@code URL()}</a> constructor for building the
+     * When using {@link com.microsoft.playwright.Page#navigate Page.navigate()}, {@link com.microsoft.playwright.Page#route
+     * Page.route()}, {@link com.microsoft.playwright.Page#waitForURL Page.waitForURL()}, {@link
+     * com.microsoft.playwright.Page#waitForRequest Page.waitForRequest()}, or {@link
+     * com.microsoft.playwright.Page#waitForResponse Page.waitForResponse()} it takes the base URL in consideration by using
+     * the <a href="https://developer.mozilla.org/en-US/docs/Web/API/URL/URL">{@code URL()}</a> constructor for building the
      * corresponding URL. Unset by default. Examples:
      * <ul>
      * <li> baseURL: {@code http://localhost:3000} and navigating to {@code /bar.html} results in {@code
@@ -741,8 +744,8 @@ public interface BrowserType {
     }
     /**
      * Emulates {@code "prefers-colors-scheme"} media feature, supported values are {@code "light"}, {@code "dark"}, {@code
-     * "no-preference"}. See {@link Page#emulateMedia Page.emulateMedia()} for more details. Passing {@code null} resets
-     * emulation to system defaults. Defaults to {@code "light"}.
+     * "no-preference"}. See {@link com.microsoft.playwright.Page#emulateMedia Page.emulateMedia()} for more details. Passing
+     * {@code null} resets emulation to system defaults. Defaults to {@code "light"}.
      */
     public LaunchPersistentContextOptions setColorScheme(ColorScheme colorScheme) {
       this.colorScheme = Optional.ofNullable(colorScheme);
@@ -805,8 +808,8 @@ public interface BrowserType {
     }
     /**
      * Emulates {@code "forced-colors"} media feature, supported values are {@code "active"}, {@code "none"}. See {@link
-     * Page#emulateMedia Page.emulateMedia()} for more details. Passing {@code null} resets emulation to system defaults.
-     * Defaults to {@code "none"}.
+     * com.microsoft.playwright.Page#emulateMedia Page.emulateMedia()} for more details. Passing {@code null} resets emulation
+     * to system defaults. Defaults to {@code "none"}.
      */
     public LaunchPersistentContextOptions setForcedColors(ForcedColors forcedColors) {
       this.forcedColors = Optional.ofNullable(forcedColors);
@@ -932,8 +935,9 @@ public interface BrowserType {
       return this;
     }
     /**
-     * A list of permissions to grant to all pages in this context. See {@link BrowserContext#grantPermissions
-     * BrowserContext.grantPermissions()} for more details. Defaults to none.
+     * A list of permissions to grant to all pages in this context. See {@link
+     * com.microsoft.playwright.BrowserContext#grantPermissions BrowserContext.grantPermissions()} for more details. Defaults
+     * to none.
      */
     public LaunchPersistentContextOptions setPermissions(List<String> permissions) {
       this.permissions = permissions;
@@ -979,8 +983,8 @@ public interface BrowserType {
     }
     /**
      * Enables <a href="http://www.softwareishard.com/blog/har-12-spec">HAR</a> recording for all pages into the specified HAR
-     * file on the filesystem. If not specified, the HAR is not recorded. Make sure to call {@link BrowserContext#close
-     * BrowserContext.close()} for the HAR to be saved.
+     * file on the filesystem. If not specified, the HAR is not recorded. Make sure to call {@link
+     * com.microsoft.playwright.BrowserContext#close BrowserContext.close()} for the HAR to be saved.
      */
     public LaunchPersistentContextOptions setRecordHarPath(Path recordHarPath) {
       this.recordHarPath = recordHarPath;
@@ -996,7 +1000,7 @@ public interface BrowserType {
     }
     /**
      * Enables video recording for all pages into the specified directory. If not specified videos are not recorded. Make sure
-     * to call {@link BrowserContext#close BrowserContext.close()} for videos to be saved.
+     * to call {@link com.microsoft.playwright.BrowserContext#close BrowserContext.close()} for videos to be saved.
      */
     public LaunchPersistentContextOptions setRecordVideoDir(Path recordVideoDir) {
       this.recordVideoDir = recordVideoDir;
@@ -1021,8 +1025,8 @@ public interface BrowserType {
     }
     /**
      * Emulates {@code "prefers-reduced-motion"} media feature, supported values are {@code "reduce"}, {@code "no-preference"}.
-     * See {@link Page#emulateMedia Page.emulateMedia()} for more details. Passing {@code null} resets emulation to system
-     * defaults. Defaults to {@code "no-preference"}.
+     * See {@link com.microsoft.playwright.Page#emulateMedia Page.emulateMedia()} for more details. Passing {@code null} resets
+     * emulation to system defaults. Defaults to {@code "no-preference"}.
      */
     public LaunchPersistentContextOptions setReducedMotion(ReducedMotion reducedMotion) {
       this.reducedMotion = Optional.ofNullable(reducedMotion);
@@ -1150,11 +1154,11 @@ public interface BrowserType {
   /**
    * This method attaches Playwright to an existing browser instance using the Chrome DevTools Protocol.
    *
-   * <p> The default browser context is accessible via {@link Browser#contexts Browser.contexts()}.
+   * <p> The default browser context is accessible via {@link com.microsoft.playwright.Browser#contexts Browser.contexts()}.
    *
    * <p> <strong>NOTE:</strong> Connecting over the Chrome DevTools Protocol is only supported for Chromium-based browsers.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * Browser browser = playwright.chromium().connectOverCDP("http://localhost:9222");
    * BrowserContext defaultContext = browser.contexts().get(0);
@@ -1171,11 +1175,11 @@ public interface BrowserType {
   /**
    * This method attaches Playwright to an existing browser instance using the Chrome DevTools Protocol.
    *
-   * <p> The default browser context is accessible via {@link Browser#contexts Browser.contexts()}.
+   * <p> The default browser context is accessible via {@link com.microsoft.playwright.Browser#contexts Browser.contexts()}.
    *
    * <p> <strong>NOTE:</strong> Connecting over the Chrome DevTools Protocol is only supported for Chromium-based browsers.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * Browser browser = playwright.chromium().connectOverCDP("http://localhost:9222");
    * BrowserContext defaultContext = browser.contexts().get(0);
@@ -1196,7 +1200,7 @@ public interface BrowserType {
   /**
    * Returns the browser instance.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> You can use {@code ignoreDefaultArgs} to filter out {@code --mute-audio} from default arguments:
    * <pre>{@code
@@ -1232,7 +1236,7 @@ public interface BrowserType {
   /**
    * Returns the browser instance.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> You can use {@code ignoreDefaultArgs} to filter out {@code --mute-audio} from default arguments:
    * <pre>{@code

--- a/playwright/src/main/java/com/microsoft/playwright/CDPSession.java
+++ b/playwright/src/main/java/com/microsoft/playwright/CDPSession.java
@@ -31,6 +31,7 @@ import com.google.gson.JsonObject;
  * <li> Documentation on DevTools Protocol can be found here: <a
  * href="https://chromedevtools.github.io/devtools-protocol/">DevTools Protocol Viewer</a>.</li>
  * <li> Getting Started with DevTools Protocol: https://github.com/aslushnikov/getting-started-with-cdp/blob/master/README.md</li>
+ * </ul>
  * <pre>{@code
  * CDPSession client = page.context().newCDPSession(page);
  * client.send("Runtime.enable");
@@ -45,7 +46,6 @@ import com.google.gson.JsonObject;
  * params.addProperty("playbackRate", playbackRate / 2);
  * client.send("Animation.setPlaybackRate", params);
  * }</pre>
- * </ul>
  */
 public interface CDPSession {
   /**

--- a/playwright/src/main/java/com/microsoft/playwright/ConsoleMessage.java
+++ b/playwright/src/main/java/com/microsoft/playwright/ConsoleMessage.java
@@ -19,8 +19,9 @@ package com.microsoft.playwright;
 import java.util.*;
 
 /**
- * {@code ConsoleMessage} objects are dispatched by page via the {@link Page#onConsoleMessage Page.onConsoleMessage()}
- * event. For each console messages logged in the page there will be corresponding event in the Playwright context.
+ * {@code ConsoleMessage} objects are dispatched by page via the {@link com.microsoft.playwright.Page#onConsoleMessage
+ * Page.onConsoleMessage()} event. For each console messages logged in the page there will be corresponding event in the
+ * Playwright context.
  * <pre>{@code
  * // Listen for all console messages and print them to the standard output.
  * page.onConsoleMessage(msg -> System.out.println(msg.text()));
@@ -44,8 +45,8 @@ import java.util.*;
  */
 public interface ConsoleMessage {
   /**
-   * List of arguments passed to a {@code console} function call. See also {@link Page#onConsoleMessage
-   * Page.onConsoleMessage()}.
+   * List of arguments passed to a {@code console} function call. See also {@link
+   * com.microsoft.playwright.Page#onConsoleMessage Page.onConsoleMessage()}.
    *
    * @since v1.8
    */

--- a/playwright/src/main/java/com/microsoft/playwright/Dialog.java
+++ b/playwright/src/main/java/com/microsoft/playwright/Dialog.java
@@ -18,7 +18,8 @@ package com.microsoft.playwright;
 
 
 /**
- * {@code Dialog} objects are dispatched by page via the {@link Page#onDialog Page.onDialog()} event.
+ * {@code Dialog} objects are dispatched by page via the {@link com.microsoft.playwright.Page#onDialog Page.onDialog()}
+ * event.
  *
  * <p> An example of using {@code Dialog} class:
  * <pre>{@code
@@ -41,9 +42,9 @@ package com.microsoft.playwright;
  * }
  * }</pre>
  *
- * <p> <strong>NOTE:</strong> Dialogs are dismissed automatically, unless there is a {@link Page#onDialog Page.onDialog()} listener. When listener is
- * present, it **must** either {@link Dialog#accept Dialog.accept()} or {@link Dialog#dismiss Dialog.dismiss()} the dialog
- * - otherwise the page will <a
+ * <p> <strong>NOTE:</strong> Dialogs are dismissed automatically, unless there is a {@link com.microsoft.playwright.Page#onDialog Page.onDialog()}
+ * listener. When listener is present, it **must** either {@link com.microsoft.playwright.Dialog#accept Dialog.accept()} or
+ * {@link com.microsoft.playwright.Dialog#dismiss Dialog.dismiss()} the dialog - otherwise the page will <a
  * href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/EventLoop#never_blocking">freeze</a> waiting for the
  * dialog, and actions like click will never finish.
  */

--- a/playwright/src/main/java/com/microsoft/playwright/Download.java
+++ b/playwright/src/main/java/com/microsoft/playwright/Download.java
@@ -20,7 +20,8 @@ import java.io.InputStream;
 import java.nio.file.Path;
 
 /**
- * {@code Download} objects are dispatched by page via the {@link Page#onDownload Page.onDownload()} event.
+ * {@code Download} objects are dispatched by page via the {@link com.microsoft.playwright.Page#onDownload
+ * Page.onDownload()} event.
  *
  * <p> All the downloaded files belonging to the browser context are deleted when the browser context is closed.
  *
@@ -72,8 +73,8 @@ public interface Download {
    * Returns path to the downloaded file for a successful download, or throws for a failed/canceled download. The method will
    * wait for the download to finish if necessary. The method throws when connected remotely.
    *
-   * <p> Note that the download's file name is a random GUID, use {@link Download#suggestedFilename Download.suggestedFilename()}
-   * to get suggested file name.
+   * <p> Note that the download's file name is a random GUID, use {@link com.microsoft.playwright.Download#suggestedFilename
+   * Download.suggestedFilename()} to get suggested file name.
    *
    * @since v1.8
    */
@@ -82,7 +83,7 @@ public interface Download {
    * Copy the download to a user-specified path. It is safe to call this method while the download is still in progress. Will
    * wait for the download to finish if necessary.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * download.saveAs(Paths.get("/path/to/save/at/", download.suggestedFilename()));
    * }</pre>

--- a/playwright/src/main/java/com/microsoft/playwright/ElementHandle.java
+++ b/playwright/src/main/java/com/microsoft/playwright/ElementHandle.java
@@ -21,8 +21,8 @@ import java.nio.file.Path;
 import java.util.*;
 
 /**
- * ElementHandle represents an in-page DOM element. ElementHandles can be created with the {@link Page#querySelector
- * Page.querySelector()} method.
+ * ElementHandle represents an in-page DOM element. ElementHandles can be created with the {@link
+ * com.microsoft.playwright.Page#querySelector Page.querySelector()} method.
  *
  * <p> <strong>NOTE:</strong> The use of ElementHandle is discouraged, use {@code Locator} objects and web-first assertions instead.
  * <pre>{@code
@@ -30,11 +30,12 @@ import java.util.*;
  * hrefElement.click();
  * }</pre>
  *
- * <p> ElementHandle prevents DOM element from garbage collection unless the handle is disposed with {@link JSHandle#dispose
- * JSHandle.dispose()}. ElementHandles are auto-disposed when their origin frame gets navigated.
+ * <p> ElementHandle prevents DOM element from garbage collection unless the handle is disposed with {@link
+ * com.microsoft.playwright.JSHandle#dispose JSHandle.dispose()}. ElementHandles are auto-disposed when their origin frame
+ * gets navigated.
  *
- * <p> ElementHandle instances can be used as an argument in {@link Page#evalOnSelector Page.evalOnSelector()} and {@link
- * Page#evaluate Page.evaluate()} methods.
+ * <p> ElementHandle instances can be used as an argument in {@link com.microsoft.playwright.Page#evalOnSelector
+ * Page.evalOnSelector()} and {@link com.microsoft.playwright.Page#evaluate Page.evaluate()} methods.
  *
  * <p> The difference between the {@code Locator} and ElementHandle is that the ElementHandle points to a particular element,
  * while {@code Locator} captures the logic of how to retrieve an element.
@@ -76,8 +77,9 @@ public interface ElementHandle extends JSHandle {
     public Position position;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
     /**
@@ -121,8 +123,9 @@ public interface ElementHandle extends JSHandle {
     }
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public CheckOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -174,8 +177,9 @@ public interface ElementHandle extends JSHandle {
     public Position position;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
     /**
@@ -248,8 +252,9 @@ public interface ElementHandle extends JSHandle {
     }
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public ClickOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -297,8 +302,9 @@ public interface ElementHandle extends JSHandle {
     public Position position;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
     /**
@@ -364,8 +370,9 @@ public interface ElementHandle extends JSHandle {
     }
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public DblclickOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -395,8 +402,9 @@ public interface ElementHandle extends JSHandle {
     public Boolean noWaitAfter;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
 
@@ -419,8 +427,9 @@ public interface ElementHandle extends JSHandle {
     }
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public FillOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -451,8 +460,9 @@ public interface ElementHandle extends JSHandle {
     public Position position;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
     /**
@@ -504,8 +514,9 @@ public interface ElementHandle extends JSHandle {
     }
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public HoverOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -524,15 +535,17 @@ public interface ElementHandle extends JSHandle {
   class InputValueOptions {
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
 
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public InputValueOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -552,8 +565,9 @@ public interface ElementHandle extends JSHandle {
     public Boolean noWaitAfter;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
 
@@ -575,8 +589,9 @@ public interface ElementHandle extends JSHandle {
     }
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public PressOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -642,8 +657,9 @@ public interface ElementHandle extends JSHandle {
     public String style;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
     /**
@@ -736,8 +752,9 @@ public interface ElementHandle extends JSHandle {
     }
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public ScreenshotOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -754,15 +771,17 @@ public interface ElementHandle extends JSHandle {
   class ScrollIntoViewIfNeededOptions {
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
 
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public ScrollIntoViewIfNeededOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -783,8 +802,9 @@ public interface ElementHandle extends JSHandle {
     public Boolean noWaitAfter;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
 
@@ -807,8 +827,9 @@ public interface ElementHandle extends JSHandle {
     }
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public SelectOptionOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -823,8 +844,9 @@ public interface ElementHandle extends JSHandle {
     public Boolean force;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
 
@@ -838,8 +860,9 @@ public interface ElementHandle extends JSHandle {
     }
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public SelectTextOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -865,8 +888,9 @@ public interface ElementHandle extends JSHandle {
     public Position position;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
     /**
@@ -910,8 +934,9 @@ public interface ElementHandle extends JSHandle {
     }
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public SetCheckedOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -936,8 +961,9 @@ public interface ElementHandle extends JSHandle {
     public Boolean noWaitAfter;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
 
@@ -952,8 +978,9 @@ public interface ElementHandle extends JSHandle {
     }
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public SetInputFilesOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -984,8 +1011,9 @@ public interface ElementHandle extends JSHandle {
     public Position position;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
     /**
@@ -1037,8 +1065,9 @@ public interface ElementHandle extends JSHandle {
     }
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public TapOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -1067,8 +1096,9 @@ public interface ElementHandle extends JSHandle {
     public Boolean noWaitAfter;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
 
@@ -1090,8 +1120,9 @@ public interface ElementHandle extends JSHandle {
     }
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public TypeOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -1117,8 +1148,9 @@ public interface ElementHandle extends JSHandle {
     public Position position;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
     /**
@@ -1162,8 +1194,9 @@ public interface ElementHandle extends JSHandle {
     }
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public UncheckOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -1182,15 +1215,17 @@ public interface ElementHandle extends JSHandle {
   class WaitForElementStateOptions {
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
 
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public WaitForElementStateOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -1217,8 +1252,9 @@ public interface ElementHandle extends JSHandle {
     public Boolean strict;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
 
@@ -1247,8 +1283,9 @@ public interface ElementHandle extends JSHandle {
     }
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public WaitForSelectorOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -1269,7 +1306,7 @@ public interface ElementHandle extends JSHandle {
    * <p> Assuming the page is static, it is safe to use bounding box coordinates to perform input. For example, the following
    * snippet should click the center of the element.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * BoundingBox box = elementHandle.boundingBox();
    * page.mouse().click(box.x + box.width / 2, box.y + box.height / 2);
@@ -1286,7 +1323,7 @@ public interface ElementHandle extends JSHandle {
    * <li> Wait for <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks on the element, unless {@code
    * force} option is set.</li>
    * <li> Scroll the element into view if needed.</li>
-   * <li> Use {@link Page#mouse Page.mouse()} to click in the center of the element.</li>
+   * <li> Use {@link com.microsoft.playwright.Page#mouse Page.mouse()} to click in the center of the element.</li>
    * <li> Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.</li>
    * <li> Ensure that the element is now checked. If not, this method throws.</li>
    * </ol>
@@ -1309,7 +1346,7 @@ public interface ElementHandle extends JSHandle {
    * <li> Wait for <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks on the element, unless {@code
    * force} option is set.</li>
    * <li> Scroll the element into view if needed.</li>
-   * <li> Use {@link Page#mouse Page.mouse()} to click in the center of the element.</li>
+   * <li> Use {@link com.microsoft.playwright.Page#mouse Page.mouse()} to click in the center of the element.</li>
    * <li> Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.</li>
    * <li> Ensure that the element is now checked. If not, this method throws.</li>
    * </ol>
@@ -1328,7 +1365,8 @@ public interface ElementHandle extends JSHandle {
    * <li> Wait for <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks on the element, unless {@code
    * force} option is set.</li>
    * <li> Scroll the element into view if needed.</li>
-   * <li> Use {@link Page#mouse Page.mouse()} to click in the center of the element, or the specified {@code position}.</li>
+   * <li> Use {@link com.microsoft.playwright.Page#mouse Page.mouse()} to click in the center of the element, or the specified
+   * {@code position}.</li>
    * <li> Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.</li>
    * </ol>
    *
@@ -1348,7 +1386,8 @@ public interface ElementHandle extends JSHandle {
    * <li> Wait for <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks on the element, unless {@code
    * force} option is set.</li>
    * <li> Scroll the element into view if needed.</li>
-   * <li> Use {@link Page#mouse Page.mouse()} to click in the center of the element, or the specified {@code position}.</li>
+   * <li> Use {@link com.microsoft.playwright.Page#mouse Page.mouse()} to click in the center of the element, or the specified
+   * {@code position}.</li>
    * <li> Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.</li>
    * </ol>
    *
@@ -1372,7 +1411,8 @@ public interface ElementHandle extends JSHandle {
    * <li> Wait for <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks on the element, unless {@code
    * force} option is set.</li>
    * <li> Scroll the element into view if needed.</li>
-   * <li> Use {@link Page#mouse Page.mouse()} to double click in the center of the element, or the specified {@code position}.</li>
+   * <li> Use {@link com.microsoft.playwright.Page#mouse Page.mouse()} to double click in the center of the element, or the
+   * specified {@code position}.</li>
    * <li> Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set. Note that if the
    * first click of the {@code dblclick()} triggers a navigation event, this method will throw.</li>
    * </ol>
@@ -1395,7 +1435,8 @@ public interface ElementHandle extends JSHandle {
    * <li> Wait for <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks on the element, unless {@code
    * force} option is set.</li>
    * <li> Scroll the element into view if needed.</li>
-   * <li> Use {@link Page#mouse Page.mouse()} to double click in the center of the element, or the specified {@code position}.</li>
+   * <li> Use {@link com.microsoft.playwright.Page#mouse Page.mouse()} to double click in the center of the element, or the
+   * specified {@code position}.</li>
    * <li> Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set. Note that if the
    * first click of the {@code dblclick()} triggers a navigation event, this method will throw.</li>
    * </ol>
@@ -1415,7 +1456,7 @@ public interface ElementHandle extends JSHandle {
    * {@code click} is dispatched. This is equivalent to calling <a
    * href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/click">element.click()</a>.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * elementHandle.dispatchEvent("click");
    * }</pre>
@@ -1459,7 +1500,7 @@ public interface ElementHandle extends JSHandle {
    * {@code click} is dispatched. This is equivalent to calling <a
    * href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/click">element.click()</a>.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * elementHandle.dispatchEvent("click");
    * }</pre>
@@ -1505,9 +1546,10 @@ public interface ElementHandle extends JSHandle {
    *
    * <p> If {@code expression} returns a <a
    * href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>, then {@link
-   * ElementHandle#evalOnSelector ElementHandle.evalOnSelector()} would wait for the promise to resolve and return its value.
+   * com.microsoft.playwright.ElementHandle#evalOnSelector ElementHandle.evalOnSelector()} would wait for the promise to
+   * resolve and return its value.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * ElementHandle tweetHandle = page.querySelector(".tweet");
    * assertEquals("100", tweetHandle.evalOnSelector(".like", "node => node.innerText"));
@@ -1530,9 +1572,10 @@ public interface ElementHandle extends JSHandle {
    *
    * <p> If {@code expression} returns a <a
    * href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>, then {@link
-   * ElementHandle#evalOnSelector ElementHandle.evalOnSelector()} would wait for the promise to resolve and return its value.
+   * com.microsoft.playwright.ElementHandle#evalOnSelector ElementHandle.evalOnSelector()} would wait for the promise to
+   * resolve and return its value.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * ElementHandle tweetHandle = page.querySelector(".tweet");
    * assertEquals("100", tweetHandle.evalOnSelector(".like", "node => node.innerText"));
@@ -1554,10 +1597,10 @@ public interface ElementHandle extends JSHandle {
    *
    * <p> If {@code expression} returns a <a
    * href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>, then {@link
-   * ElementHandle#evalOnSelectorAll ElementHandle.evalOnSelectorAll()} would wait for the promise to resolve and return its
-   * value.
+   * com.microsoft.playwright.ElementHandle#evalOnSelectorAll ElementHandle.evalOnSelectorAll()} would wait for the promise
+   * to resolve and return its value.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * ElementHandle feedHandle = page.querySelector(".feed");
    * assertEquals(Arrays.asList("Hello!", "Hi!"), feedHandle.evalOnSelectorAll(".tweet", "nodes => nodes.map(n => n.innerText)"));
@@ -1579,10 +1622,10 @@ public interface ElementHandle extends JSHandle {
    *
    * <p> If {@code expression} returns a <a
    * href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>, then {@link
-   * ElementHandle#evalOnSelectorAll ElementHandle.evalOnSelectorAll()} would wait for the promise to resolve and return its
-   * value.
+   * com.microsoft.playwright.ElementHandle#evalOnSelectorAll ElementHandle.evalOnSelectorAll()} would wait for the promise
+   * to resolve and return its value.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * ElementHandle feedHandle = page.querySelector(".feed");
    * assertEquals(Arrays.asList("Hello!", "Hi!"), feedHandle.evalOnSelectorAll(".tweet", "nodes => nodes.map(n => n.innerText)"));
@@ -1605,7 +1648,8 @@ public interface ElementHandle extends JSHandle {
    * href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLLabelElement/control">control</a>, the control will be filled
    * instead.
    *
-   * <p> To send fine-grained keyboard events, use {@link Locator#pressSequentially Locator.pressSequentially()}.
+   * <p> To send fine-grained keyboard events, use {@link com.microsoft.playwright.Locator#pressSequentially
+   * Locator.pressSequentially()}.
    *
    * @param value Value to set for the {@code <input>}, {@code <textarea>} or {@code [contenteditable]} element.
    * @since v1.8
@@ -1623,7 +1667,8 @@ public interface ElementHandle extends JSHandle {
    * href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLLabelElement/control">control</a>, the control will be filled
    * instead.
    *
-   * <p> To send fine-grained keyboard events, use {@link Locator#pressSequentially Locator.pressSequentially()}.
+   * <p> To send fine-grained keyboard events, use {@link com.microsoft.playwright.Locator#pressSequentially
+   * Locator.pressSequentially()}.
    *
    * @param value Value to set for the {@code <input>}, {@code <textarea>} or {@code [contenteditable]} element.
    * @since v1.8
@@ -1648,7 +1693,8 @@ public interface ElementHandle extends JSHandle {
    * <li> Wait for <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks on the element, unless {@code
    * force} option is set.</li>
    * <li> Scroll the element into view if needed.</li>
-   * <li> Use {@link Page#mouse Page.mouse()} to hover over the center of the element, or the specified {@code position}.</li>
+   * <li> Use {@link com.microsoft.playwright.Page#mouse Page.mouse()} to hover over the center of the element, or the specified
+   * {@code position}.</li>
    * <li> Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.</li>
    * </ol>
    *
@@ -1668,7 +1714,8 @@ public interface ElementHandle extends JSHandle {
    * <li> Wait for <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks on the element, unless {@code
    * force} option is set.</li>
    * <li> Scroll the element into view if needed.</li>
-   * <li> Use {@link Page#mouse Page.mouse()} to hover over the center of the element, or the specified {@code position}.</li>
+   * <li> Use {@link com.microsoft.playwright.Page#mouse Page.mouse()} to hover over the center of the element, or the specified
+   * {@code position}.</li>
    * <li> Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.</li>
    * </ol>
    *
@@ -1759,7 +1806,8 @@ public interface ElementHandle extends JSHandle {
    */
   Frame ownerFrame();
   /**
-   * Focuses the element, and then uses {@link Keyboard#down Keyboard.down()} and {@link Keyboard#up Keyboard.up()}.
+   * Focuses the element, and then uses {@link com.microsoft.playwright.Keyboard#down Keyboard.down()} and {@link
+   * com.microsoft.playwright.Keyboard#up Keyboard.up()}.
    *
    * <p> {@code key} can specify the intended <a
    * href="https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key">keyboardEvent.key</a> value or a single
@@ -1789,7 +1837,8 @@ public interface ElementHandle extends JSHandle {
     press(key, null);
   }
   /**
-   * Focuses the element, and then uses {@link Keyboard#down Keyboard.down()} and {@link Keyboard#up Keyboard.up()}.
+   * Focuses the element, and then uses {@link com.microsoft.playwright.Keyboard#down Keyboard.down()} and {@link
+   * com.microsoft.playwright.Keyboard#up Keyboard.up()}.
    *
    * <p> {@code key} can specify the intended <a
    * href="https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key">keyboardEvent.key</a> value or a single
@@ -1899,7 +1948,7 @@ public interface ElementHandle extends JSHandle {
    *
    * <p> Triggers a {@code change} and {@code input} event once all the provided options have been selected.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * // Single selection matching the value or label
    * handle.selectOption("blue");
@@ -1930,7 +1979,7 @@ public interface ElementHandle extends JSHandle {
    *
    * <p> Triggers a {@code change} and {@code input} event once all the provided options have been selected.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * // Single selection matching the value or label
    * handle.selectOption("blue");
@@ -1959,7 +2008,7 @@ public interface ElementHandle extends JSHandle {
    *
    * <p> Triggers a {@code change} and {@code input} event once all the provided options have been selected.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * // Single selection matching the value or label
    * handle.selectOption("blue");
@@ -1990,7 +2039,7 @@ public interface ElementHandle extends JSHandle {
    *
    * <p> Triggers a {@code change} and {@code input} event once all the provided options have been selected.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * // Single selection matching the value or label
    * handle.selectOption("blue");
@@ -2019,7 +2068,7 @@ public interface ElementHandle extends JSHandle {
    *
    * <p> Triggers a {@code change} and {@code input} event once all the provided options have been selected.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * // Single selection matching the value or label
    * handle.selectOption("blue");
@@ -2050,7 +2099,7 @@ public interface ElementHandle extends JSHandle {
    *
    * <p> Triggers a {@code change} and {@code input} event once all the provided options have been selected.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * // Single selection matching the value or label
    * handle.selectOption("blue");
@@ -2079,7 +2128,7 @@ public interface ElementHandle extends JSHandle {
    *
    * <p> Triggers a {@code change} and {@code input} event once all the provided options have been selected.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * // Single selection matching the value or label
    * handle.selectOption("blue");
@@ -2110,7 +2159,7 @@ public interface ElementHandle extends JSHandle {
    *
    * <p> Triggers a {@code change} and {@code input} event once all the provided options have been selected.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * // Single selection matching the value or label
    * handle.selectOption("blue");
@@ -2139,7 +2188,7 @@ public interface ElementHandle extends JSHandle {
    *
    * <p> Triggers a {@code change} and {@code input} event once all the provided options have been selected.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * // Single selection matching the value or label
    * handle.selectOption("blue");
@@ -2170,7 +2219,7 @@ public interface ElementHandle extends JSHandle {
    *
    * <p> Triggers a {@code change} and {@code input} event once all the provided options have been selected.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * // Single selection matching the value or label
    * handle.selectOption("blue");
@@ -2199,7 +2248,7 @@ public interface ElementHandle extends JSHandle {
    *
    * <p> Triggers a {@code change} and {@code input} event once all the provided options have been selected.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * // Single selection matching the value or label
    * handle.selectOption("blue");
@@ -2230,7 +2279,7 @@ public interface ElementHandle extends JSHandle {
    *
    * <p> Triggers a {@code change} and {@code input} event once all the provided options have been selected.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * // Single selection matching the value or label
    * handle.selectOption("blue");
@@ -2278,7 +2327,7 @@ public interface ElementHandle extends JSHandle {
    * <li> Wait for <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks on the matched element,
    * unless {@code force} option is set. If the element is detached during the checks, the whole action is retried.</li>
    * <li> Scroll the element into view if needed.</li>
-   * <li> Use {@link Page#mouse Page.mouse()} to click in the center of the element.</li>
+   * <li> Use {@link com.microsoft.playwright.Page#mouse Page.mouse()} to click in the center of the element.</li>
    * <li> Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.</li>
    * <li> Ensure that the element is now checked or unchecked. If not, this method throws.</li>
    * </ol>
@@ -2300,7 +2349,7 @@ public interface ElementHandle extends JSHandle {
    * <li> Wait for <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks on the matched element,
    * unless {@code force} option is set. If the element is detached during the checks, the whole action is retried.</li>
    * <li> Scroll the element into view if needed.</li>
-   * <li> Use {@link Page#mouse Page.mouse()} to click in the center of the element.</li>
+   * <li> Use {@link com.microsoft.playwright.Page#mouse Page.mouse()} to click in the center of the element.</li>
    * <li> Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.</li>
    * <li> Ensure that the element is now checked or unchecked. If not, this method throws.</li>
    * </ol>
@@ -2430,7 +2479,8 @@ public interface ElementHandle extends JSHandle {
    * <li> Wait for <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks on the element, unless {@code
    * force} option is set.</li>
    * <li> Scroll the element into view if needed.</li>
-   * <li> Use {@link Page#touchscreen Page.touchscreen()} to tap the center of the element, or the specified {@code position}.</li>
+   * <li> Use {@link com.microsoft.playwright.Page#touchscreen Page.touchscreen()} to tap the center of the element, or the
+   * specified {@code position}.</li>
    * <li> Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.</li>
    * </ol>
    *
@@ -2452,7 +2502,8 @@ public interface ElementHandle extends JSHandle {
    * <li> Wait for <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks on the element, unless {@code
    * force} option is set.</li>
    * <li> Scroll the element into view if needed.</li>
-   * <li> Use {@link Page#touchscreen Page.touchscreen()} to tap the center of the element, or the specified {@code position}.</li>
+   * <li> Use {@link com.microsoft.playwright.Page#touchscreen Page.touchscreen()} to tap the center of the element, or the
+   * specified {@code position}.</li>
    * <li> Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.</li>
    * </ol>
    *
@@ -2473,9 +2524,9 @@ public interface ElementHandle extends JSHandle {
    */
   String textContent();
   /**
-   * @deprecated In most cases, you should use {@link Locator#fill Locator.fill()} instead. You only need to press keys one by one if
-   * there is special keyboard handling on the page - in this case use {@link Locator#pressSequentially
-   * Locator.pressSequentially()}.
+   * @deprecated In most cases, you should use {@link com.microsoft.playwright.Locator#fill Locator.fill()} instead. You only need to
+   * press keys one by one if there is special keyboard handling on the page - in this case use {@link
+   * com.microsoft.playwright.Locator#pressSequentially Locator.pressSequentially()}.
    *
    * @param text A text to type into a focused element.
    * @since v1.8
@@ -2484,9 +2535,9 @@ public interface ElementHandle extends JSHandle {
     type(text, null);
   }
   /**
-   * @deprecated In most cases, you should use {@link Locator#fill Locator.fill()} instead. You only need to press keys one by one if
-   * there is special keyboard handling on the page - in this case use {@link Locator#pressSequentially
-   * Locator.pressSequentially()}.
+   * @deprecated In most cases, you should use {@link com.microsoft.playwright.Locator#fill Locator.fill()} instead. You only need to
+   * press keys one by one if there is special keyboard handling on the page - in this case use {@link
+   * com.microsoft.playwright.Locator#pressSequentially Locator.pressSequentially()}.
    *
    * @param text A text to type into a focused element.
    * @since v1.8
@@ -2500,7 +2551,7 @@ public interface ElementHandle extends JSHandle {
    * <li> Wait for <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks on the element, unless {@code
    * force} option is set.</li>
    * <li> Scroll the element into view if needed.</li>
-   * <li> Use {@link Page#mouse Page.mouse()} to click in the center of the element.</li>
+   * <li> Use {@link com.microsoft.playwright.Page#mouse Page.mouse()} to click in the center of the element.</li>
    * <li> Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.</li>
    * <li> Ensure that the element is now unchecked. If not, this method throws.</li>
    * </ol>
@@ -2523,7 +2574,7 @@ public interface ElementHandle extends JSHandle {
    * <li> Wait for <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks on the element, unless {@code
    * force} option is set.</li>
    * <li> Scroll the element into view if needed.</li>
-   * <li> Use {@link Page#mouse Page.mouse()} to click in the center of the element.</li>
+   * <li> Use {@link com.microsoft.playwright.Page#mouse Page.mouse()} to click in the center of the element.</li>
    * <li> Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.</li>
    * <li> Ensure that the element is now unchecked. If not, this method throws.</li>
    * </ol>
@@ -2603,7 +2654,7 @@ public interface ElementHandle extends JSHandle {
    * condition, the method will return immediately. If the selector doesn't satisfy the condition for the {@code timeout}
    * milliseconds, the function will throw.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * page.setContent("<div><span></span></div>");
    * ElementHandle div = page.querySelector("div");
@@ -2612,7 +2663,8 @@ public interface ElementHandle extends JSHandle {
    *   .setState(WaitForSelectorState.ATTACHED));
    * }</pre>
    *
-   * <p> <strong>NOTE:</strong> This method does not work across navigations, use {@link Page#waitForSelector Page.waitForSelector()} instead.
+   * <p> <strong>NOTE:</strong> This method does not work across navigations, use {@link com.microsoft.playwright.Page#waitForSelector
+   * Page.waitForSelector()} instead.
    *
    * @param selector A selector to query for.
    * @since v1.8
@@ -2629,7 +2681,7 @@ public interface ElementHandle extends JSHandle {
    * condition, the method will return immediately. If the selector doesn't satisfy the condition for the {@code timeout}
    * milliseconds, the function will throw.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * page.setContent("<div><span></span></div>");
    * ElementHandle div = page.querySelector("div");
@@ -2638,7 +2690,8 @@ public interface ElementHandle extends JSHandle {
    *   .setState(WaitForSelectorState.ATTACHED));
    * }</pre>
    *
-   * <p> <strong>NOTE:</strong> This method does not work across navigations, use {@link Page#waitForSelector Page.waitForSelector()} instead.
+   * <p> <strong>NOTE:</strong> This method does not work across navigations, use {@link com.microsoft.playwright.Page#waitForSelector
+   * Page.waitForSelector()} instead.
    *
    * @param selector A selector to query for.
    * @since v1.8

--- a/playwright/src/main/java/com/microsoft/playwright/FileChooser.java
+++ b/playwright/src/main/java/com/microsoft/playwright/FileChooser.java
@@ -20,7 +20,8 @@ import com.microsoft.playwright.options.*;
 import java.nio.file.Path;
 
 /**
- * {@code FileChooser} objects are dispatched by the page in the {@link Page#onFileChooser Page.onFileChooser()} event.
+ * {@code FileChooser} objects are dispatched by the page in the {@link com.microsoft.playwright.Page#onFileChooser
+ * Page.onFileChooser()} event.
  * <pre>{@code
  * FileChooser fileChooser = page.waitForFileChooser(() -> page.getByText("Upload file").click());
  * fileChooser.setFiles(Paths.get("myfile.pdf"));
@@ -36,8 +37,9 @@ public interface FileChooser {
     public Boolean noWaitAfter;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
 
@@ -52,8 +54,9 @@ public interface FileChooser {
     }
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public SetFilesOptions setTimeout(double timeout) {
       this.timeout = timeout;

--- a/playwright/src/main/java/com/microsoft/playwright/Frame.java
+++ b/playwright/src/main/java/com/microsoft/playwright/Frame.java
@@ -23,16 +23,17 @@ import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
 /**
- * At every point of time, page exposes its current frame tree via the {@link Page#mainFrame Page.mainFrame()} and {@link
- * Frame#childFrames Frame.childFrames()} methods.
+ * At every point of time, page exposes its current frame tree via the {@link com.microsoft.playwright.Page#mainFrame
+ * Page.mainFrame()} and {@link com.microsoft.playwright.Frame#childFrames Frame.childFrames()} methods.
  *
  * <p> {@code Frame} object's lifecycle is controlled by three events, dispatched on the page object:
  * <ul>
- * <li> {@link Page#onFrameAttached Page.onFrameAttached()} - fired when the frame gets attached to the page. A Frame can be
- * attached to the page only once.</li>
- * <li> {@link Page#onFrameNavigated Page.onFrameNavigated()} - fired when the frame commits navigation to a different URL.</li>
- * <li> {@link Page#onFrameDetached Page.onFrameDetached()} - fired when the frame gets detached from the page.  A Frame can be
- * detached from the page only once.</li>
+ * <li> {@link com.microsoft.playwright.Page#onFrameAttached Page.onFrameAttached()} - fired when the frame gets attached to the
+ * page. A Frame can be attached to the page only once.</li>
+ * <li> {@link com.microsoft.playwright.Page#onFrameNavigated Page.onFrameNavigated()} - fired when the frame commits navigation
+ * to a different URL.</li>
+ * <li> {@link com.microsoft.playwright.Page#onFrameDetached Page.onFrameDetached()} - fired when the frame gets detached from
+ * the page.  A Frame can be detached from the page only once.</li>
  * </ul>
  *
  * <p> An example of dumping frame tree:
@@ -173,8 +174,9 @@ public interface Frame {
     public Boolean strict;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
     /**
@@ -226,8 +228,9 @@ public interface Frame {
     }
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public CheckOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -284,8 +287,9 @@ public interface Frame {
     public Boolean strict;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
     /**
@@ -366,8 +370,9 @@ public interface Frame {
     }
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public ClickOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -420,8 +425,9 @@ public interface Frame {
     public Boolean strict;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
     /**
@@ -495,8 +501,9 @@ public interface Frame {
     }
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public DblclickOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -520,8 +527,9 @@ public interface Frame {
     public Boolean strict;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
 
@@ -535,8 +543,9 @@ public interface Frame {
     }
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public DispatchEventOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -572,8 +581,9 @@ public interface Frame {
     public Position targetPosition;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
     /**
@@ -640,8 +650,9 @@ public interface Frame {
     }
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public DragAndDropOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -692,8 +703,9 @@ public interface Frame {
     public Boolean strict;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
 
@@ -724,8 +736,9 @@ public interface Frame {
     }
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public FillOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -740,8 +753,9 @@ public interface Frame {
     public Boolean strict;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
 
@@ -755,8 +769,9 @@ public interface Frame {
     }
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public FocusOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -771,8 +786,9 @@ public interface Frame {
     public Boolean strict;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
 
@@ -786,8 +802,9 @@ public interface Frame {
     }
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public GetAttributeOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -1031,14 +1048,16 @@ public interface Frame {
   class NavigateOptions {
     /**
      * Referer header value. If provided it will take preference over the referer header value set by {@link
-     * Page#setExtraHTTPHeaders Page.setExtraHTTPHeaders()}.
+     * com.microsoft.playwright.Page#setExtraHTTPHeaders Page.setExtraHTTPHeaders()}.
      */
     public String referer;
     /**
      * Maximum operation time in milliseconds, defaults to 30 seconds, pass {@code 0} to disable timeout. The default value can
-     * be changed by using the {@link BrowserContext#setDefaultNavigationTimeout BrowserContext.setDefaultNavigationTimeout()},
-     * {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()}, {@link Page#setDefaultNavigationTimeout
-     * Page.setDefaultNavigationTimeout()} or {@link Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultNavigationTimeout
+     * BrowserContext.setDefaultNavigationTimeout()}, {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()}, {@link com.microsoft.playwright.Page#setDefaultNavigationTimeout
+     * Page.setDefaultNavigationTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
     /**
@@ -1055,7 +1074,7 @@ public interface Frame {
 
     /**
      * Referer header value. If provided it will take preference over the referer header value set by {@link
-     * Page#setExtraHTTPHeaders Page.setExtraHTTPHeaders()}.
+     * com.microsoft.playwright.Page#setExtraHTTPHeaders Page.setExtraHTTPHeaders()}.
      */
     public NavigateOptions setReferer(String referer) {
       this.referer = referer;
@@ -1063,9 +1082,11 @@ public interface Frame {
     }
     /**
      * Maximum operation time in milliseconds, defaults to 30 seconds, pass {@code 0} to disable timeout. The default value can
-     * be changed by using the {@link BrowserContext#setDefaultNavigationTimeout BrowserContext.setDefaultNavigationTimeout()},
-     * {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()}, {@link Page#setDefaultNavigationTimeout
-     * Page.setDefaultNavigationTimeout()} or {@link Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultNavigationTimeout
+     * BrowserContext.setDefaultNavigationTimeout()}, {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()}, {@link com.microsoft.playwright.Page#setDefaultNavigationTimeout
+     * Page.setDefaultNavigationTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public NavigateOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -1115,8 +1136,9 @@ public interface Frame {
     public Boolean strict;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
     /**
@@ -1176,8 +1198,9 @@ public interface Frame {
     }
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public HoverOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -1201,8 +1224,9 @@ public interface Frame {
     public Boolean strict;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
 
@@ -1216,8 +1240,9 @@ public interface Frame {
     }
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public InnerHTMLOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -1232,8 +1257,9 @@ public interface Frame {
     public Boolean strict;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
 
@@ -1247,8 +1273,9 @@ public interface Frame {
     }
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public InnerTextOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -1263,8 +1290,9 @@ public interface Frame {
     public Boolean strict;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
 
@@ -1278,8 +1306,9 @@ public interface Frame {
     }
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public InputValueOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -1294,8 +1323,9 @@ public interface Frame {
     public Boolean strict;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
 
@@ -1309,8 +1339,9 @@ public interface Frame {
     }
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public IsCheckedOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -1325,8 +1356,9 @@ public interface Frame {
     public Boolean strict;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
 
@@ -1340,8 +1372,9 @@ public interface Frame {
     }
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public IsDisabledOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -1356,8 +1389,9 @@ public interface Frame {
     public Boolean strict;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
 
@@ -1371,8 +1405,9 @@ public interface Frame {
     }
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public IsEditableOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -1387,8 +1422,9 @@ public interface Frame {
     public Boolean strict;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
 
@@ -1402,8 +1438,9 @@ public interface Frame {
     }
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public IsEnabledOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -1417,8 +1454,8 @@ public interface Frame {
      */
     public Boolean strict;
     /**
-     * @deprecated This option is ignored. {@link Frame#isHidden Frame.isHidden()} does not wait for the element to become hidden and
-     * returns immediately.
+     * @deprecated This option is ignored. {@link com.microsoft.playwright.Frame#isHidden Frame.isHidden()} does not wait for the element
+     * to become hidden and returns immediately.
      */
     public Double timeout;
 
@@ -1431,8 +1468,8 @@ public interface Frame {
       return this;
     }
     /**
-     * @deprecated This option is ignored. {@link Frame#isHidden Frame.isHidden()} does not wait for the element to become hidden and
-     * returns immediately.
+     * @deprecated This option is ignored. {@link com.microsoft.playwright.Frame#isHidden Frame.isHidden()} does not wait for the element
+     * to become hidden and returns immediately.
      */
     public IsHiddenOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -1446,8 +1483,8 @@ public interface Frame {
      */
     public Boolean strict;
     /**
-     * @deprecated This option is ignored. {@link Frame#isVisible Frame.isVisible()} does not wait for the element to become visible and
-     * returns immediately.
+     * @deprecated This option is ignored. {@link com.microsoft.playwright.Frame#isVisible Frame.isVisible()} does not wait for the element
+     * to become visible and returns immediately.
      */
     public Double timeout;
 
@@ -1460,8 +1497,8 @@ public interface Frame {
       return this;
     }
     /**
-     * @deprecated This option is ignored. {@link Frame#isVisible Frame.isVisible()} does not wait for the element to become visible and
-     * returns immediately.
+     * @deprecated This option is ignored. {@link com.microsoft.playwright.Frame#isVisible Frame.isVisible()} does not wait for the element
+     * to become visible and returns immediately.
      */
     public IsVisibleOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -1582,8 +1619,9 @@ public interface Frame {
     public Boolean strict;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
 
@@ -1613,8 +1651,9 @@ public interface Frame {
     }
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public PressOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -1656,8 +1695,9 @@ public interface Frame {
     public Boolean strict;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
 
@@ -1688,8 +1728,9 @@ public interface Frame {
     }
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public SelectOptionOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -1720,8 +1761,9 @@ public interface Frame {
     public Boolean strict;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
     /**
@@ -1773,8 +1815,9 @@ public interface Frame {
     }
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public SetCheckedOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -1793,9 +1836,11 @@ public interface Frame {
   class SetContentOptions {
     /**
      * Maximum operation time in milliseconds, defaults to 30 seconds, pass {@code 0} to disable timeout. The default value can
-     * be changed by using the {@link BrowserContext#setDefaultNavigationTimeout BrowserContext.setDefaultNavigationTimeout()},
-     * {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()}, {@link Page#setDefaultNavigationTimeout
-     * Page.setDefaultNavigationTimeout()} or {@link Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultNavigationTimeout
+     * BrowserContext.setDefaultNavigationTimeout()}, {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()}, {@link com.microsoft.playwright.Page#setDefaultNavigationTimeout
+     * Page.setDefaultNavigationTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
     /**
@@ -1812,9 +1857,11 @@ public interface Frame {
 
     /**
      * Maximum operation time in milliseconds, defaults to 30 seconds, pass {@code 0} to disable timeout. The default value can
-     * be changed by using the {@link BrowserContext#setDefaultNavigationTimeout BrowserContext.setDefaultNavigationTimeout()},
-     * {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()}, {@link Page#setDefaultNavigationTimeout
-     * Page.setDefaultNavigationTimeout()} or {@link Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultNavigationTimeout
+     * BrowserContext.setDefaultNavigationTimeout()}, {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()}, {@link com.microsoft.playwright.Page#setDefaultNavigationTimeout
+     * Page.setDefaultNavigationTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public SetContentOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -1849,8 +1896,9 @@ public interface Frame {
     public Boolean strict;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
 
@@ -1873,8 +1921,9 @@ public interface Frame {
     }
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public SetInputFilesOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -1910,8 +1959,9 @@ public interface Frame {
     public Boolean strict;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
     /**
@@ -1971,8 +2021,9 @@ public interface Frame {
     }
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public TapOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -1996,8 +2047,9 @@ public interface Frame {
     public Boolean strict;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
 
@@ -2011,8 +2063,9 @@ public interface Frame {
     }
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public TextContentOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -2037,8 +2090,9 @@ public interface Frame {
     public Boolean strict;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
 
@@ -2068,8 +2122,9 @@ public interface Frame {
     }
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public TypeOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -2100,8 +2155,9 @@ public interface Frame {
     public Boolean strict;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
     /**
@@ -2153,8 +2209,9 @@ public interface Frame {
     }
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public UncheckOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -2178,8 +2235,9 @@ public interface Frame {
     public Double pollingInterval;
     /**
      * Maximum time to wait for in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The
-     * default value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or
-     * {@link Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * default value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
 
@@ -2193,8 +2251,9 @@ public interface Frame {
     }
     /**
      * Maximum time to wait for in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The
-     * default value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or
-     * {@link Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * default value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public WaitForFunctionOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -2204,17 +2263,21 @@ public interface Frame {
   class WaitForLoadStateOptions {
     /**
      * Maximum operation time in milliseconds, defaults to 30 seconds, pass {@code 0} to disable timeout. The default value can
-     * be changed by using the {@link BrowserContext#setDefaultNavigationTimeout BrowserContext.setDefaultNavigationTimeout()},
-     * {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()}, {@link Page#setDefaultNavigationTimeout
-     * Page.setDefaultNavigationTimeout()} or {@link Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultNavigationTimeout
+     * BrowserContext.setDefaultNavigationTimeout()}, {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()}, {@link com.microsoft.playwright.Page#setDefaultNavigationTimeout
+     * Page.setDefaultNavigationTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
 
     /**
      * Maximum operation time in milliseconds, defaults to 30 seconds, pass {@code 0} to disable timeout. The default value can
-     * be changed by using the {@link BrowserContext#setDefaultNavigationTimeout BrowserContext.setDefaultNavigationTimeout()},
-     * {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()}, {@link Page#setDefaultNavigationTimeout
-     * Page.setDefaultNavigationTimeout()} or {@link Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultNavigationTimeout
+     * BrowserContext.setDefaultNavigationTimeout()}, {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()}, {@link com.microsoft.playwright.Page#setDefaultNavigationTimeout
+     * Page.setDefaultNavigationTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public WaitForLoadStateOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -2224,9 +2287,11 @@ public interface Frame {
   class WaitForNavigationOptions {
     /**
      * Maximum operation time in milliseconds, defaults to 30 seconds, pass {@code 0} to disable timeout. The default value can
-     * be changed by using the {@link BrowserContext#setDefaultNavigationTimeout BrowserContext.setDefaultNavigationTimeout()},
-     * {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()}, {@link Page#setDefaultNavigationTimeout
-     * Page.setDefaultNavigationTimeout()} or {@link Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultNavigationTimeout
+     * BrowserContext.setDefaultNavigationTimeout()}, {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()}, {@link com.microsoft.playwright.Page#setDefaultNavigationTimeout
+     * Page.setDefaultNavigationTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
     /**
@@ -2249,9 +2314,11 @@ public interface Frame {
 
     /**
      * Maximum operation time in milliseconds, defaults to 30 seconds, pass {@code 0} to disable timeout. The default value can
-     * be changed by using the {@link BrowserContext#setDefaultNavigationTimeout BrowserContext.setDefaultNavigationTimeout()},
-     * {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()}, {@link Page#setDefaultNavigationTimeout
-     * Page.setDefaultNavigationTimeout()} or {@link Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultNavigationTimeout
+     * BrowserContext.setDefaultNavigationTimeout()}, {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()}, {@link com.microsoft.playwright.Page#setDefaultNavigationTimeout
+     * Page.setDefaultNavigationTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public WaitForNavigationOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -2319,8 +2386,9 @@ public interface Frame {
     public Boolean strict;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
 
@@ -2349,8 +2417,9 @@ public interface Frame {
     }
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public WaitForSelectorOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -2360,9 +2429,11 @@ public interface Frame {
   class WaitForURLOptions {
     /**
      * Maximum operation time in milliseconds, defaults to 30 seconds, pass {@code 0} to disable timeout. The default value can
-     * be changed by using the {@link BrowserContext#setDefaultNavigationTimeout BrowserContext.setDefaultNavigationTimeout()},
-     * {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()}, {@link Page#setDefaultNavigationTimeout
-     * Page.setDefaultNavigationTimeout()} or {@link Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultNavigationTimeout
+     * BrowserContext.setDefaultNavigationTimeout()}, {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()}, {@link com.microsoft.playwright.Page#setDefaultNavigationTimeout
+     * Page.setDefaultNavigationTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
     /**
@@ -2379,9 +2450,11 @@ public interface Frame {
 
     /**
      * Maximum operation time in milliseconds, defaults to 30 seconds, pass {@code 0} to disable timeout. The default value can
-     * be changed by using the {@link BrowserContext#setDefaultNavigationTimeout BrowserContext.setDefaultNavigationTimeout()},
-     * {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()}, {@link Page#setDefaultNavigationTimeout
-     * Page.setDefaultNavigationTimeout()} or {@link Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultNavigationTimeout
+     * BrowserContext.setDefaultNavigationTimeout()}, {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()}, {@link com.microsoft.playwright.Page#setDefaultNavigationTimeout
+     * Page.setDefaultNavigationTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public WaitForURLOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -2449,7 +2522,7 @@ public interface Frame {
    * <li> Wait for <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks on the matched element,
    * unless {@code force} option is set. If the element is detached during the checks, the whole action is retried.</li>
    * <li> Scroll the element into view if needed.</li>
-   * <li> Use {@link Page#mouse Page.mouse()} to click in the center of the element.</li>
+   * <li> Use {@link com.microsoft.playwright.Page#mouse Page.mouse()} to click in the center of the element.</li>
    * <li> Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.</li>
    * <li> Ensure that the element is now checked. If not, this method throws.</li>
    * </ol>
@@ -2472,7 +2545,7 @@ public interface Frame {
    * <li> Wait for <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks on the matched element,
    * unless {@code force} option is set. If the element is detached during the checks, the whole action is retried.</li>
    * <li> Scroll the element into view if needed.</li>
-   * <li> Use {@link Page#mouse Page.mouse()} to click in the center of the element.</li>
+   * <li> Use {@link com.microsoft.playwright.Page#mouse Page.mouse()} to click in the center of the element.</li>
    * <li> Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.</li>
    * <li> Ensure that the element is now checked. If not, this method throws.</li>
    * </ol>
@@ -2497,7 +2570,8 @@ public interface Frame {
    * <li> Wait for <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks on the matched element,
    * unless {@code force} option is set. If the element is detached during the checks, the whole action is retried.</li>
    * <li> Scroll the element into view if needed.</li>
-   * <li> Use {@link Page#mouse Page.mouse()} to click in the center of the element, or the specified {@code position}.</li>
+   * <li> Use {@link com.microsoft.playwright.Page#mouse Page.mouse()} to click in the center of the element, or the specified
+   * {@code position}.</li>
    * <li> Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.</li>
    * </ol>
    *
@@ -2517,7 +2591,8 @@ public interface Frame {
    * <li> Wait for <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks on the matched element,
    * unless {@code force} option is set. If the element is detached during the checks, the whole action is retried.</li>
    * <li> Scroll the element into view if needed.</li>
-   * <li> Use {@link Page#mouse Page.mouse()} to click in the center of the element, or the specified {@code position}.</li>
+   * <li> Use {@link com.microsoft.playwright.Page#mouse Page.mouse()} to click in the center of the element, or the specified
+   * {@code position}.</li>
    * <li> Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.</li>
    * </ol>
    *
@@ -2541,7 +2616,8 @@ public interface Frame {
    * <li> Wait for <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks on the matched element,
    * unless {@code force} option is set. If the element is detached during the checks, the whole action is retried.</li>
    * <li> Scroll the element into view if needed.</li>
-   * <li> Use {@link Page#mouse Page.mouse()} to double click in the center of the element, or the specified {@code position}.</li>
+   * <li> Use {@link com.microsoft.playwright.Page#mouse Page.mouse()} to double click in the center of the element, or the
+   * specified {@code position}.</li>
    * <li> Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set. Note that if the
    * first click of the {@code dblclick()} triggers a navigation event, this method will throw.</li>
    * </ol>
@@ -2564,7 +2640,8 @@ public interface Frame {
    * <li> Wait for <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks on the matched element,
    * unless {@code force} option is set. If the element is detached during the checks, the whole action is retried.</li>
    * <li> Scroll the element into view if needed.</li>
-   * <li> Use {@link Page#mouse Page.mouse()} to double click in the center of the element, or the specified {@code position}.</li>
+   * <li> Use {@link com.microsoft.playwright.Page#mouse Page.mouse()} to double click in the center of the element, or the
+   * specified {@code position}.</li>
    * <li> Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set. Note that if the
    * first click of the {@code dblclick()} triggers a navigation event, this method will throw.</li>
    * </ol>
@@ -2583,7 +2660,7 @@ public interface Frame {
    * {@code click} is dispatched. This is equivalent to calling <a
    * href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/click">element.click()</a>.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * frame.dispatchEvent("button#submit", "click");
    * }</pre>
@@ -2629,7 +2706,7 @@ public interface Frame {
    * {@code click} is dispatched. This is equivalent to calling <a
    * href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/click">element.click()</a>.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * frame.dispatchEvent("button#submit", "click");
    * }</pre>
@@ -2674,7 +2751,7 @@ public interface Frame {
    * {@code click} is dispatched. This is equivalent to calling <a
    * href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/click">element.click()</a>.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * frame.dispatchEvent("button#submit", "click");
    * }</pre>
@@ -2743,9 +2820,10 @@ public interface Frame {
    *
    * <p> If {@code expression} returns a <a
    * href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>, then {@link
-   * Frame#evalOnSelector Frame.evalOnSelector()} would wait for the promise to resolve and return its value.
+   * com.microsoft.playwright.Frame#evalOnSelector Frame.evalOnSelector()} would wait for the promise to resolve and return
+   * its value.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * String searchValue = (String) frame.evalOnSelector("#search", "el => el.value");
    * String preloadHref = (String) frame.evalOnSelector("link[rel=preload]", "el => el.href");
@@ -2769,9 +2847,10 @@ public interface Frame {
    *
    * <p> If {@code expression} returns a <a
    * href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>, then {@link
-   * Frame#evalOnSelector Frame.evalOnSelector()} would wait for the promise to resolve and return its value.
+   * com.microsoft.playwright.Frame#evalOnSelector Frame.evalOnSelector()} would wait for the promise to resolve and return
+   * its value.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * String searchValue = (String) frame.evalOnSelector("#search", "el => el.value");
    * String preloadHref = (String) frame.evalOnSelector("link[rel=preload]", "el => el.href");
@@ -2794,9 +2873,10 @@ public interface Frame {
    *
    * <p> If {@code expression} returns a <a
    * href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>, then {@link
-   * Frame#evalOnSelector Frame.evalOnSelector()} would wait for the promise to resolve and return its value.
+   * com.microsoft.playwright.Frame#evalOnSelector Frame.evalOnSelector()} would wait for the promise to resolve and return
+   * its value.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * String searchValue = (String) frame.evalOnSelector("#search", "el => el.value");
    * String preloadHref = (String) frame.evalOnSelector("link[rel=preload]", "el => el.href");
@@ -2818,9 +2898,10 @@ public interface Frame {
    *
    * <p> If {@code expression} returns a <a
    * href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>, then {@link
-   * Frame#evalOnSelectorAll Frame.evalOnSelectorAll()} would wait for the promise to resolve and return its value.
+   * com.microsoft.playwright.Frame#evalOnSelectorAll Frame.evalOnSelectorAll()} would wait for the promise to resolve and
+   * return its value.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * boolean divsCounts = (boolean) page.evalOnSelectorAll("div", "(divs, min) => divs.length >= min", 10);
    * }</pre>
@@ -2841,9 +2922,10 @@ public interface Frame {
    *
    * <p> If {@code expression} returns a <a
    * href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>, then {@link
-   * Frame#evalOnSelectorAll Frame.evalOnSelectorAll()} would wait for the promise to resolve and return its value.
+   * com.microsoft.playwright.Frame#evalOnSelectorAll Frame.evalOnSelectorAll()} would wait for the promise to resolve and
+   * return its value.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * boolean divsCounts = (boolean) page.evalOnSelectorAll("div", "(divs, min) => divs.length >= min", 10);
    * }</pre>
@@ -2858,15 +2940,16 @@ public interface Frame {
   /**
    * Returns the return value of {@code expression}.
    *
-   * <p> If the function passed to the {@link Frame#evaluate Frame.evaluate()} returns a <a
+   * <p> If the function passed to the {@link com.microsoft.playwright.Frame#evaluate Frame.evaluate()} returns a <a
    * href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>, then {@link
-   * Frame#evaluate Frame.evaluate()} would wait for the promise to resolve and return its value.
+   * com.microsoft.playwright.Frame#evaluate Frame.evaluate()} would wait for the promise to resolve and return its value.
    *
-   * <p> If the function passed to the {@link Frame#evaluate Frame.evaluate()} returns a non-[Serializable] value, then {@link
-   * Frame#evaluate Frame.evaluate()} returns {@code undefined}. Playwright also supports transferring some additional values
-   * that are not serializable by {@code JSON}: {@code -0}, {@code NaN}, {@code Infinity}, {@code -Infinity}.
+   * <p> If the function passed to the {@link com.microsoft.playwright.Frame#evaluate Frame.evaluate()} returns a
+   * non-[Serializable] value, then {@link com.microsoft.playwright.Frame#evaluate Frame.evaluate()} returns {@code
+   * undefined}. Playwright also supports transferring some additional values that are not serializable by {@code JSON}:
+   * {@code -0}, {@code NaN}, {@code Infinity}, {@code -Infinity}.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * Object result = frame.evaluate("([x, y]) => {\n" +
    *   "  return Promise.resolve(x * y);\n" +
@@ -2879,7 +2962,8 @@ public interface Frame {
    * System.out.println(frame.evaluate("1 + 2")); // prints "3"
    * }</pre>
    *
-   * <p> {@code ElementHandle} instances can be passed as an argument to the {@link Frame#evaluate Frame.evaluate()}:
+   * <p> {@code ElementHandle} instances can be passed as an argument to the {@link com.microsoft.playwright.Frame#evaluate
+   * Frame.evaluate()}:
    * <pre>{@code
    * ElementHandle bodyHandle = frame.evaluate("document.body");
    * String html = (String) frame.evaluate("([body, suffix]) => body.innerHTML + suffix", Arrays.asList(bodyHandle, "hello"));
@@ -2896,15 +2980,16 @@ public interface Frame {
   /**
    * Returns the return value of {@code expression}.
    *
-   * <p> If the function passed to the {@link Frame#evaluate Frame.evaluate()} returns a <a
+   * <p> If the function passed to the {@link com.microsoft.playwright.Frame#evaluate Frame.evaluate()} returns a <a
    * href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>, then {@link
-   * Frame#evaluate Frame.evaluate()} would wait for the promise to resolve and return its value.
+   * com.microsoft.playwright.Frame#evaluate Frame.evaluate()} would wait for the promise to resolve and return its value.
    *
-   * <p> If the function passed to the {@link Frame#evaluate Frame.evaluate()} returns a non-[Serializable] value, then {@link
-   * Frame#evaluate Frame.evaluate()} returns {@code undefined}. Playwright also supports transferring some additional values
-   * that are not serializable by {@code JSON}: {@code -0}, {@code NaN}, {@code Infinity}, {@code -Infinity}.
+   * <p> If the function passed to the {@link com.microsoft.playwright.Frame#evaluate Frame.evaluate()} returns a
+   * non-[Serializable] value, then {@link com.microsoft.playwright.Frame#evaluate Frame.evaluate()} returns {@code
+   * undefined}. Playwright also supports transferring some additional values that are not serializable by {@code JSON}:
+   * {@code -0}, {@code NaN}, {@code Infinity}, {@code -Infinity}.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * Object result = frame.evaluate("([x, y]) => {\n" +
    *   "  return Promise.resolve(x * y);\n" +
@@ -2917,7 +3002,8 @@ public interface Frame {
    * System.out.println(frame.evaluate("1 + 2")); // prints "3"
    * }</pre>
    *
-   * <p> {@code ElementHandle} instances can be passed as an argument to the {@link Frame#evaluate Frame.evaluate()}:
+   * <p> {@code ElementHandle} instances can be passed as an argument to the {@link com.microsoft.playwright.Frame#evaluate
+   * Frame.evaluate()}:
    * <pre>{@code
    * ElementHandle bodyHandle = frame.evaluate("document.body");
    * String html = (String) frame.evaluate("([body, suffix]) => body.innerHTML + suffix", Arrays.asList(bodyHandle, "hello"));
@@ -2933,14 +3019,16 @@ public interface Frame {
   /**
    * Returns the return value of {@code expression} as a {@code JSHandle}.
    *
-   * <p> The only difference between {@link Frame#evaluate Frame.evaluate()} and {@link Frame#evaluateHandle
-   * Frame.evaluateHandle()} is that {@link Frame#evaluateHandle Frame.evaluateHandle()} returns {@code JSHandle}.
+   * <p> The only difference between {@link com.microsoft.playwright.Frame#evaluate Frame.evaluate()} and {@link
+   * com.microsoft.playwright.Frame#evaluateHandle Frame.evaluateHandle()} is that {@link
+   * com.microsoft.playwright.Frame#evaluateHandle Frame.evaluateHandle()} returns {@code JSHandle}.
    *
-   * <p> If the function, passed to the {@link Frame#evaluateHandle Frame.evaluateHandle()}, returns a <a
-   * href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>, then {@link
-   * Frame#evaluateHandle Frame.evaluateHandle()} would wait for the promise to resolve and return its value.
+   * <p> If the function, passed to the {@link com.microsoft.playwright.Frame#evaluateHandle Frame.evaluateHandle()}, returns a
+   * <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>, then
+   * {@link com.microsoft.playwright.Frame#evaluateHandle Frame.evaluateHandle()} would wait for the promise to resolve and
+   * return its value.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * // Handle for the window object.
    * JSHandle aWindowHandle = frame.evaluateHandle("() => Promise.resolve(window)");
@@ -2951,7 +3039,8 @@ public interface Frame {
    * JSHandle aHandle = frame.evaluateHandle("document"); // Handle for the "document".
    * }</pre>
    *
-   * <p> {@code JSHandle} instances can be passed as an argument to the {@link Frame#evaluateHandle Frame.evaluateHandle()}:
+   * <p> {@code JSHandle} instances can be passed as an argument to the {@link com.microsoft.playwright.Frame#evaluateHandle
+   * Frame.evaluateHandle()}:
    * <pre>{@code
    * JSHandle aHandle = frame.evaluateHandle("() => document.body");
    * JSHandle resultHandle = frame.evaluateHandle("([body, suffix]) => body.innerHTML + suffix", Arrays.asList(aHandle, "hello"));
@@ -2969,14 +3058,16 @@ public interface Frame {
   /**
    * Returns the return value of {@code expression} as a {@code JSHandle}.
    *
-   * <p> The only difference between {@link Frame#evaluate Frame.evaluate()} and {@link Frame#evaluateHandle
-   * Frame.evaluateHandle()} is that {@link Frame#evaluateHandle Frame.evaluateHandle()} returns {@code JSHandle}.
+   * <p> The only difference between {@link com.microsoft.playwright.Frame#evaluate Frame.evaluate()} and {@link
+   * com.microsoft.playwright.Frame#evaluateHandle Frame.evaluateHandle()} is that {@link
+   * com.microsoft.playwright.Frame#evaluateHandle Frame.evaluateHandle()} returns {@code JSHandle}.
    *
-   * <p> If the function, passed to the {@link Frame#evaluateHandle Frame.evaluateHandle()}, returns a <a
-   * href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>, then {@link
-   * Frame#evaluateHandle Frame.evaluateHandle()} would wait for the promise to resolve and return its value.
+   * <p> If the function, passed to the {@link com.microsoft.playwright.Frame#evaluateHandle Frame.evaluateHandle()}, returns a
+   * <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>, then
+   * {@link com.microsoft.playwright.Frame#evaluateHandle Frame.evaluateHandle()} would wait for the promise to resolve and
+   * return its value.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * // Handle for the window object.
    * JSHandle aWindowHandle = frame.evaluateHandle("() => Promise.resolve(window)");
@@ -2987,7 +3078,8 @@ public interface Frame {
    * JSHandle aHandle = frame.evaluateHandle("document"); // Handle for the "document".
    * }</pre>
    *
-   * <p> {@code JSHandle} instances can be passed as an argument to the {@link Frame#evaluateHandle Frame.evaluateHandle()}:
+   * <p> {@code JSHandle} instances can be passed as an argument to the {@link com.microsoft.playwright.Frame#evaluateHandle
+   * Frame.evaluateHandle()}:
    * <pre>{@code
    * JSHandle aHandle = frame.evaluateHandle("() => document.body");
    * JSHandle resultHandle = frame.evaluateHandle("([body, suffix]) => body.innerHTML + suffix", Arrays.asList(aHandle, "hello"));
@@ -3011,7 +3103,8 @@ public interface Frame {
    * href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLLabelElement/control">control</a>, the control will be filled
    * instead.
    *
-   * <p> To send fine-grained keyboard events, use {@link Locator#pressSequentially Locator.pressSequentially()}.
+   * <p> To send fine-grained keyboard events, use {@link com.microsoft.playwright.Locator#pressSequentially
+   * Locator.pressSequentially()}.
    *
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used.
    * @param value Value to fill for the {@code <input>}, {@code <textarea>} or {@code [contenteditable]} element.
@@ -3030,7 +3123,8 @@ public interface Frame {
    * href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLLabelElement/control">control</a>, the control will be filled
    * instead.
    *
-   * <p> To send fine-grained keyboard events, use {@link Locator#pressSequentially Locator.pressSequentially()}.
+   * <p> To send fine-grained keyboard events, use {@link com.microsoft.playwright.Locator#pressSequentially
+   * Locator.pressSequentially()}.
    *
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used.
    * @param value Value to fill for the {@code <input>}, {@code <textarea>} or {@code [contenteditable]} element.
@@ -3058,12 +3152,12 @@ public interface Frame {
   /**
    * Returns the {@code frame} or {@code iframe} element handle which corresponds to this frame.
    *
-   * <p> This is an inverse of {@link ElementHandle#contentFrame ElementHandle.contentFrame()}. Note that returned handle
-   * actually belongs to the parent frame.
+   * <p> This is an inverse of {@link com.microsoft.playwright.ElementHandle#contentFrame ElementHandle.contentFrame()}. Note
+   * that returned handle actually belongs to the parent frame.
    *
    * <p> This method throws an error if the frame has been detached before {@code frameElement()} returns.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * ElementHandle frameElement = frame.frameElement();
    * Frame contentFrame = frameElement.contentFrame();
@@ -3077,7 +3171,7 @@ public interface Frame {
    * When working with iframes, you can create a frame locator that will enter the iframe and allow selecting elements in
    * that iframe.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> Following snippet locates element with text "Submit" in the iframe with id {@code my-frame}, like {@code <iframe
    * id="my-frame">}:
@@ -3111,7 +3205,7 @@ public interface Frame {
   /**
    * Allows locating elements by their alt text.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> For example, this method will find the image by alt text "Playwright logo":
    * <pre>{@code
@@ -3127,7 +3221,7 @@ public interface Frame {
   /**
    * Allows locating elements by their alt text.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> For example, this method will find the image by alt text "Playwright logo":
    * <pre>{@code
@@ -3141,7 +3235,7 @@ public interface Frame {
   /**
    * Allows locating elements by their alt text.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> For example, this method will find the image by alt text "Playwright logo":
    * <pre>{@code
@@ -3157,7 +3251,7 @@ public interface Frame {
   /**
    * Allows locating elements by their alt text.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> For example, this method will find the image by alt text "Playwright logo":
    * <pre>{@code
@@ -3172,7 +3266,7 @@ public interface Frame {
    * Allows locating input elements by the text of the associated {@code <label>} or {@code aria-labelledby} element, or by
    * the {@code aria-label} attribute.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> For example, this method will find inputs by label "Username" and "Password" in the following DOM:
    * <pre>{@code
@@ -3190,7 +3284,7 @@ public interface Frame {
    * Allows locating input elements by the text of the associated {@code <label>} or {@code aria-labelledby} element, or by
    * the {@code aria-label} attribute.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> For example, this method will find inputs by label "Username" and "Password" in the following DOM:
    * <pre>{@code
@@ -3206,7 +3300,7 @@ public interface Frame {
    * Allows locating input elements by the text of the associated {@code <label>} or {@code aria-labelledby} element, or by
    * the {@code aria-label} attribute.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> For example, this method will find inputs by label "Username" and "Password" in the following DOM:
    * <pre>{@code
@@ -3224,7 +3318,7 @@ public interface Frame {
    * Allows locating input elements by the text of the associated {@code <label>} or {@code aria-labelledby} element, or by
    * the {@code aria-label} attribute.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> For example, this method will find inputs by label "Username" and "Password" in the following DOM:
    * <pre>{@code
@@ -3239,7 +3333,7 @@ public interface Frame {
   /**
    * Allows locating input elements by the placeholder text.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> For example, consider the following DOM structure.
    *
@@ -3257,7 +3351,7 @@ public interface Frame {
   /**
    * Allows locating input elements by the placeholder text.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> For example, consider the following DOM structure.
    *
@@ -3273,7 +3367,7 @@ public interface Frame {
   /**
    * Allows locating input elements by the placeholder text.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> For example, consider the following DOM structure.
    *
@@ -3291,7 +3385,7 @@ public interface Frame {
   /**
    * Allows locating input elements by the placeholder text.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> For example, consider the following DOM structure.
    *
@@ -3309,7 +3403,7 @@ public interface Frame {
    * href="https://www.w3.org/TR/wai-aria-1.2/#aria-attributes">ARIA attributes</a> and <a
    * href="https://w3c.github.io/accname/#dfn-accessible-name">accessible name</a>.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> Consider the following DOM structure.
    *
@@ -3330,7 +3424,7 @@ public interface Frame {
    *     .click();
    * }</pre>
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
    * <p> Role selector **does not replace** accessibility audits and conformance tests, but rather gives early feedback about the
    * ARIA guidelines.
@@ -3352,7 +3446,7 @@ public interface Frame {
    * href="https://www.w3.org/TR/wai-aria-1.2/#aria-attributes">ARIA attributes</a> and <a
    * href="https://w3c.github.io/accname/#dfn-accessible-name">accessible name</a>.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> Consider the following DOM structure.
    *
@@ -3373,7 +3467,7 @@ public interface Frame {
    *     .click();
    * }</pre>
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
    * <p> Role selector **does not replace** accessibility audits and conformance tests, but rather gives early feedback about the
    * ARIA guidelines.
@@ -3391,7 +3485,7 @@ public interface Frame {
   /**
    * Locate element by the test id.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> Consider the following DOM structure.
    *
@@ -3400,10 +3494,11 @@ public interface Frame {
    * page.getByTestId("directions").click();
    * }</pre>
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
-   * <p> By default, the {@code data-testid} attribute is used as a test id. Use {@link Selectors#setTestIdAttribute
-   * Selectors.setTestIdAttribute()} to configure a different test id attribute if necessary.
+   * <p> By default, the {@code data-testid} attribute is used as a test id. Use {@link
+   * com.microsoft.playwright.Selectors#setTestIdAttribute Selectors.setTestIdAttribute()} to configure a different test id
+   * attribute if necessary.
    *
    * @param testId Id to locate the element by.
    * @since v1.27
@@ -3412,7 +3507,7 @@ public interface Frame {
   /**
    * Locate element by the test id.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> Consider the following DOM structure.
    *
@@ -3421,10 +3516,11 @@ public interface Frame {
    * page.getByTestId("directions").click();
    * }</pre>
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
-   * <p> By default, the {@code data-testid} attribute is used as a test id. Use {@link Selectors#setTestIdAttribute
-   * Selectors.setTestIdAttribute()} to configure a different test id attribute if necessary.
+   * <p> By default, the {@code data-testid} attribute is used as a test id. Use {@link
+   * com.microsoft.playwright.Selectors#setTestIdAttribute Selectors.setTestIdAttribute()} to configure a different test id
+   * attribute if necessary.
    *
    * @param testId Id to locate the element by.
    * @since v1.27
@@ -3433,10 +3529,10 @@ public interface Frame {
   /**
    * Allows locating elements that contain given text.
    *
-   * <p> See also {@link Locator#filter Locator.filter()} that allows to match by another criteria, like an accessible role, and
-   * then filter by the text content.
+   * <p> See also {@link com.microsoft.playwright.Locator#filter Locator.filter()} that allows to match by another criteria, like
+   * an accessible role, and then filter by the text content.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> Consider the following DOM structure:
    *
@@ -3458,7 +3554,7 @@ public interface Frame {
    * page.getByText(Pattern.compile("^hello$", Pattern.CASE_INSENSITIVE))
    * }</pre>
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
    * <p> Matching by text always normalizes whitespace, even with exact match. For example, it turns multiple spaces into one,
    * turns line breaks into spaces and ignores leading and trailing whitespace.
@@ -3475,10 +3571,10 @@ public interface Frame {
   /**
    * Allows locating elements that contain given text.
    *
-   * <p> See also {@link Locator#filter Locator.filter()} that allows to match by another criteria, like an accessible role, and
-   * then filter by the text content.
+   * <p> See also {@link com.microsoft.playwright.Locator#filter Locator.filter()} that allows to match by another criteria, like
+   * an accessible role, and then filter by the text content.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> Consider the following DOM structure:
    *
@@ -3500,7 +3596,7 @@ public interface Frame {
    * page.getByText(Pattern.compile("^hello$", Pattern.CASE_INSENSITIVE))
    * }</pre>
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
    * <p> Matching by text always normalizes whitespace, even with exact match. For example, it turns multiple spaces into one,
    * turns line breaks into spaces and ignores leading and trailing whitespace.
@@ -3515,10 +3611,10 @@ public interface Frame {
   /**
    * Allows locating elements that contain given text.
    *
-   * <p> See also {@link Locator#filter Locator.filter()} that allows to match by another criteria, like an accessible role, and
-   * then filter by the text content.
+   * <p> See also {@link com.microsoft.playwright.Locator#filter Locator.filter()} that allows to match by another criteria, like
+   * an accessible role, and then filter by the text content.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> Consider the following DOM structure:
    *
@@ -3540,7 +3636,7 @@ public interface Frame {
    * page.getByText(Pattern.compile("^hello$", Pattern.CASE_INSENSITIVE))
    * }</pre>
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
    * <p> Matching by text always normalizes whitespace, even with exact match. For example, it turns multiple spaces into one,
    * turns line breaks into spaces and ignores leading and trailing whitespace.
@@ -3557,10 +3653,10 @@ public interface Frame {
   /**
    * Allows locating elements that contain given text.
    *
-   * <p> See also {@link Locator#filter Locator.filter()} that allows to match by another criteria, like an accessible role, and
-   * then filter by the text content.
+   * <p> See also {@link com.microsoft.playwright.Locator#filter Locator.filter()} that allows to match by another criteria, like
+   * an accessible role, and then filter by the text content.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> Consider the following DOM structure:
    *
@@ -3582,7 +3678,7 @@ public interface Frame {
    * page.getByText(Pattern.compile("^hello$", Pattern.CASE_INSENSITIVE))
    * }</pre>
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
    * <p> Matching by text always normalizes whitespace, even with exact match. For example, it turns multiple spaces into one,
    * turns line breaks into spaces and ignores leading and trailing whitespace.
@@ -3597,7 +3693,7 @@ public interface Frame {
   /**
    * Allows locating elements by their title attribute.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> Consider the following DOM structure.
    *
@@ -3615,7 +3711,7 @@ public interface Frame {
   /**
    * Allows locating elements by their title attribute.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> Consider the following DOM structure.
    *
@@ -3631,7 +3727,7 @@ public interface Frame {
   /**
    * Allows locating elements by their title attribute.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> Consider the following DOM structure.
    *
@@ -3649,7 +3745,7 @@ public interface Frame {
   /**
    * Allows locating elements by their title attribute.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> Consider the following DOM structure.
    *
@@ -3677,7 +3773,7 @@ public interface Frame {
    *
    * <p> The method will not throw an error when any valid HTTP status code is returned by the remote server, including 404 "Not
    * Found" and 500 "Internal Server Error".  The status code for such responses can be retrieved by calling {@link
-   * Response#status Response.status()}.
+   * com.microsoft.playwright.Response#status Response.status()}.
    *
    * <p> <strong>NOTE:</strong> The method either throws an error or returns a main resource response. The only exceptions are navigation to {@code
    * about:blank} or navigation to the same URL with a different hash, which would succeed and return {@code null}.
@@ -3706,7 +3802,7 @@ public interface Frame {
    *
    * <p> The method will not throw an error when any valid HTTP status code is returned by the remote server, including 404 "Not
    * Found" and 500 "Internal Server Error".  The status code for such responses can be retrieved by calling {@link
-   * Response#status Response.status()}.
+   * com.microsoft.playwright.Response#status Response.status()}.
    *
    * <p> <strong>NOTE:</strong> The method either throws an error or returns a main resource response. The only exceptions are navigation to {@code
    * about:blank} or navigation to the same URL with a different hash, which would succeed and return {@code null}.
@@ -3725,7 +3821,8 @@ public interface Frame {
    * <li> Wait for <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks on the matched element,
    * unless {@code force} option is set. If the element is detached during the checks, the whole action is retried.</li>
    * <li> Scroll the element into view if needed.</li>
-   * <li> Use {@link Page#mouse Page.mouse()} to hover over the center of the element, or the specified {@code position}.</li>
+   * <li> Use {@link com.microsoft.playwright.Page#mouse Page.mouse()} to hover over the center of the element, or the specified
+   * {@code position}.</li>
    * <li> Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.</li>
    * </ol>
    *
@@ -3745,7 +3842,8 @@ public interface Frame {
    * <li> Wait for <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks on the matched element,
    * unless {@code force} option is set. If the element is detached during the checks, the whole action is retried.</li>
    * <li> Scroll the element into view if needed.</li>
-   * <li> Use {@link Page#mouse Page.mouse()} to hover over the center of the element, or the specified {@code position}.</li>
+   * <li> Use {@link com.microsoft.playwright.Page#mouse Page.mouse()} to hover over the center of the element, or the specified
+   * {@code position}.</li>
    * <li> Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.</li>
    * </ol>
    *
@@ -4080,7 +4178,7 @@ public interface Frame {
    *
    * <p> Triggers a {@code change} and {@code input} event once all the provided options have been selected.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * // Single selection matching the value or label
    * frame.selectOption("select#colors", "blue");
@@ -4113,7 +4211,7 @@ public interface Frame {
    *
    * <p> Triggers a {@code change} and {@code input} event once all the provided options have been selected.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * // Single selection matching the value or label
    * frame.selectOption("select#colors", "blue");
@@ -4144,7 +4242,7 @@ public interface Frame {
    *
    * <p> Triggers a {@code change} and {@code input} event once all the provided options have been selected.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * // Single selection matching the value or label
    * frame.selectOption("select#colors", "blue");
@@ -4177,7 +4275,7 @@ public interface Frame {
    *
    * <p> Triggers a {@code change} and {@code input} event once all the provided options have been selected.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * // Single selection matching the value or label
    * frame.selectOption("select#colors", "blue");
@@ -4208,7 +4306,7 @@ public interface Frame {
    *
    * <p> Triggers a {@code change} and {@code input} event once all the provided options have been selected.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * // Single selection matching the value or label
    * frame.selectOption("select#colors", "blue");
@@ -4241,7 +4339,7 @@ public interface Frame {
    *
    * <p> Triggers a {@code change} and {@code input} event once all the provided options have been selected.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * // Single selection matching the value or label
    * frame.selectOption("select#colors", "blue");
@@ -4272,7 +4370,7 @@ public interface Frame {
    *
    * <p> Triggers a {@code change} and {@code input} event once all the provided options have been selected.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * // Single selection matching the value or label
    * frame.selectOption("select#colors", "blue");
@@ -4305,7 +4403,7 @@ public interface Frame {
    *
    * <p> Triggers a {@code change} and {@code input} event once all the provided options have been selected.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * // Single selection matching the value or label
    * frame.selectOption("select#colors", "blue");
@@ -4336,7 +4434,7 @@ public interface Frame {
    *
    * <p> Triggers a {@code change} and {@code input} event once all the provided options have been selected.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * // Single selection matching the value or label
    * frame.selectOption("select#colors", "blue");
@@ -4369,7 +4467,7 @@ public interface Frame {
    *
    * <p> Triggers a {@code change} and {@code input} event once all the provided options have been selected.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * // Single selection matching the value or label
    * frame.selectOption("select#colors", "blue");
@@ -4400,7 +4498,7 @@ public interface Frame {
    *
    * <p> Triggers a {@code change} and {@code input} event once all the provided options have been selected.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * // Single selection matching the value or label
    * frame.selectOption("select#colors", "blue");
@@ -4433,7 +4531,7 @@ public interface Frame {
    *
    * <p> Triggers a {@code change} and {@code input} event once all the provided options have been selected.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * // Single selection matching the value or label
    * frame.selectOption("select#colors", "blue");
@@ -4459,7 +4557,7 @@ public interface Frame {
    * <li> Wait for <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks on the matched element,
    * unless {@code force} option is set. If the element is detached during the checks, the whole action is retried.</li>
    * <li> Scroll the element into view if needed.</li>
-   * <li> Use {@link Page#mouse Page.mouse()} to click in the center of the element.</li>
+   * <li> Use {@link com.microsoft.playwright.Page#mouse Page.mouse()} to click in the center of the element.</li>
    * <li> Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.</li>
    * <li> Ensure that the element is now checked or unchecked. If not, this method throws.</li>
    * </ol>
@@ -4483,7 +4581,7 @@ public interface Frame {
    * <li> Wait for <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks on the matched element,
    * unless {@code force} option is set. If the element is detached during the checks, the whole action is retried.</li>
    * <li> Scroll the element into view if needed.</li>
-   * <li> Use {@link Page#mouse Page.mouse()} to click in the center of the element.</li>
+   * <li> Use {@link com.microsoft.playwright.Page#mouse Page.mouse()} to click in the center of the element.</li>
    * <li> Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.</li>
    * <li> Ensure that the element is now checked or unchecked. If not, this method throws.</li>
    * </ol>
@@ -4643,7 +4741,8 @@ public interface Frame {
    * <li> Wait for <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks on the matched element,
    * unless {@code force} option is set. If the element is detached during the checks, the whole action is retried.</li>
    * <li> Scroll the element into view if needed.</li>
-   * <li> Use {@link Page#touchscreen Page.touchscreen()} to tap the center of the element, or the specified {@code position}.</li>
+   * <li> Use {@link com.microsoft.playwright.Page#touchscreen Page.touchscreen()} to tap the center of the element, or the
+   * specified {@code position}.</li>
    * <li> Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.</li>
    * </ol>
    *
@@ -4665,7 +4764,8 @@ public interface Frame {
    * <li> Wait for <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks on the matched element,
    * unless {@code force} option is set. If the element is detached during the checks, the whole action is retried.</li>
    * <li> Scroll the element into view if needed.</li>
-   * <li> Use {@link Page#touchscreen Page.touchscreen()} to tap the center of the element, or the specified {@code position}.</li>
+   * <li> Use {@link com.microsoft.playwright.Page#touchscreen Page.touchscreen()} to tap the center of the element, or the
+   * specified {@code position}.</li>
    * <li> Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.</li>
    * </ol>
    *
@@ -4701,9 +4801,9 @@ public interface Frame {
    */
   String title();
   /**
-   * @deprecated In most cases, you should use {@link Locator#fill Locator.fill()} instead. You only need to press keys one by one if
-   * there is special keyboard handling on the page - in this case use {@link Locator#pressSequentially
-   * Locator.pressSequentially()}.
+   * @deprecated In most cases, you should use {@link com.microsoft.playwright.Locator#fill Locator.fill()} instead. You only need to
+   * press keys one by one if there is special keyboard handling on the page - in this case use {@link
+   * com.microsoft.playwright.Locator#pressSequentially Locator.pressSequentially()}.
    *
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used.
    * @param text A text to type into a focused element.
@@ -4713,9 +4813,9 @@ public interface Frame {
     type(selector, text, null);
   }
   /**
-   * @deprecated In most cases, you should use {@link Locator#fill Locator.fill()} instead. You only need to press keys one by one if
-   * there is special keyboard handling on the page - in this case use {@link Locator#pressSequentially
-   * Locator.pressSequentially()}.
+   * @deprecated In most cases, you should use {@link com.microsoft.playwright.Locator#fill Locator.fill()} instead. You only need to
+   * press keys one by one if there is special keyboard handling on the page - in this case use {@link
+   * com.microsoft.playwright.Locator#pressSequentially Locator.pressSequentially()}.
    *
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used.
    * @param text A text to type into a focused element.
@@ -4731,7 +4831,7 @@ public interface Frame {
    * <li> Wait for <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks on the matched element,
    * unless {@code force} option is set. If the element is detached during the checks, the whole action is retried.</li>
    * <li> Scroll the element into view if needed.</li>
-   * <li> Use {@link Page#mouse Page.mouse()} to click in the center of the element.</li>
+   * <li> Use {@link com.microsoft.playwright.Page#mouse Page.mouse()} to click in the center of the element.</li>
    * <li> Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.</li>
    * <li> Ensure that the element is now unchecked. If not, this method throws.</li>
    * </ol>
@@ -4754,7 +4854,7 @@ public interface Frame {
    * <li> Wait for <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks on the matched element,
    * unless {@code force} option is set. If the element is detached during the checks, the whole action is retried.</li>
    * <li> Scroll the element into view if needed.</li>
-   * <li> Use {@link Page#mouse Page.mouse()} to click in the center of the element.</li>
+   * <li> Use {@link com.microsoft.playwright.Page#mouse Page.mouse()} to click in the center of the element.</li>
    * <li> Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.</li>
    * <li> Ensure that the element is now unchecked. If not, this method throws.</li>
    * </ol>
@@ -4775,9 +4875,10 @@ public interface Frame {
   /**
    * Returns when the {@code expression} returns a truthy value, returns that value.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
-   * <p> The {@link Frame#waitForFunction Frame.waitForFunction()} can be used to observe viewport size change:
+   * <p> The {@link com.microsoft.playwright.Frame#waitForFunction Frame.waitForFunction()} can be used to observe viewport size
+   * change:
    * <pre>{@code
    * import com.microsoft.playwright.*;
    *
@@ -4812,9 +4913,10 @@ public interface Frame {
   /**
    * Returns when the {@code expression} returns a truthy value, returns that value.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
-   * <p> The {@link Frame#waitForFunction Frame.waitForFunction()} can be used to observe viewport size change:
+   * <p> The {@link com.microsoft.playwright.Frame#waitForFunction Frame.waitForFunction()} can be used to observe viewport size
+   * change:
    * <pre>{@code
    * import com.microsoft.playwright.*;
    *
@@ -4848,9 +4950,10 @@ public interface Frame {
   /**
    * Returns when the {@code expression} returns a truthy value, returns that value.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
-   * <p> The {@link Frame#waitForFunction Frame.waitForFunction()} can be used to observe viewport size change:
+   * <p> The {@link com.microsoft.playwright.Frame#waitForFunction Frame.waitForFunction()} can be used to observe viewport size
+   * change:
    * <pre>{@code
    * import com.microsoft.playwright.*;
    *
@@ -4886,7 +4989,7 @@ public interface Frame {
    * <p> This returns when the frame reaches a required load state, {@code load} by default. The navigation must have been
    * committed when this method is called. If current document has already reached the required state, resolves immediately.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * frame.click("button"); // Click triggers navigation.
    * frame.waitForLoadState(); // Waits for "load" state by default.
@@ -4911,7 +5014,7 @@ public interface Frame {
    * <p> This returns when the frame reaches a required load state, {@code load} by default. The navigation must have been
    * committed when this method is called. If current document has already reached the required state, resolves immediately.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * frame.click("button"); // Click triggers navigation.
    * frame.waitForLoadState(); // Waits for "load" state by default.
@@ -4928,7 +5031,7 @@ public interface Frame {
    * <p> This returns when the frame reaches a required load state, {@code load} by default. The navigation must have been
    * committed when this method is called. If current document has already reached the required state, resolves immediately.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * frame.click("button"); // Click triggers navigation.
    * frame.waitForLoadState(); // Waits for "load" state by default.
@@ -4946,7 +5049,7 @@ public interface Frame {
    */
   void waitForLoadState(LoadState state, WaitForLoadStateOptions options);
   /**
-   * @deprecated This method is inherently racy, please use {@link Frame#waitForURL Frame.waitForURL()} instead.
+   * @deprecated This method is inherently racy, please use {@link com.microsoft.playwright.Frame#waitForURL Frame.waitForURL()} instead.
    *
    * @param callback Callback that performs the action triggering the event.
    * @since v1.8
@@ -4955,7 +5058,7 @@ public interface Frame {
     return waitForNavigation(null, callback);
   }
   /**
-   * @deprecated This method is inherently racy, please use {@link Frame#waitForURL Frame.waitForURL()} instead.
+   * @deprecated This method is inherently racy, please use {@link com.microsoft.playwright.Frame#waitForURL Frame.waitForURL()} instead.
    *
    * @param callback Callback that performs the action triggering the event.
    * @since v1.8
@@ -4973,7 +5076,7 @@ public interface Frame {
    * will return immediately. If the selector doesn't satisfy the condition for the {@code timeout} milliseconds, the
    * function will throw.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> This method works across navigations:
    * <pre>{@code
@@ -5014,7 +5117,7 @@ public interface Frame {
    * will return immediately. If the selector doesn't satisfy the condition for the {@code timeout} milliseconds, the
    * function will throw.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> This method works across navigations:
    * <pre>{@code
@@ -5054,7 +5157,7 @@ public interface Frame {
   /**
    * Waits for the frame to navigate to the given URL.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * frame.click("a.delayed-navigation"); // Clicking the link will indirectly cause a navigation
    * frame.waitForURL("**\/target.html");
@@ -5071,7 +5174,7 @@ public interface Frame {
   /**
    * Waits for the frame to navigate to the given URL.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * frame.click("a.delayed-navigation"); // Clicking the link will indirectly cause a navigation
    * frame.waitForURL("**\/target.html");
@@ -5086,7 +5189,7 @@ public interface Frame {
   /**
    * Waits for the frame to navigate to the given URL.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * frame.click("a.delayed-navigation"); // Clicking the link will indirectly cause a navigation
    * frame.waitForURL("**\/target.html");
@@ -5103,7 +5206,7 @@ public interface Frame {
   /**
    * Waits for the frame to navigate to the given URL.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * frame.click("a.delayed-navigation"); // Clicking the link will indirectly cause a navigation
    * frame.waitForURL("**\/target.html");
@@ -5118,7 +5221,7 @@ public interface Frame {
   /**
    * Waits for the frame to navigate to the given URL.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * frame.click("a.delayed-navigation"); // Clicking the link will indirectly cause a navigation
    * frame.waitForURL("**\/target.html");
@@ -5135,7 +5238,7 @@ public interface Frame {
   /**
    * Waits for the frame to navigate to the given URL.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * frame.click("a.delayed-navigation"); // Clicking the link will indirectly cause a navigation
    * frame.waitForURL("**\/target.html");

--- a/playwright/src/main/java/com/microsoft/playwright/FrameLocator.java
+++ b/playwright/src/main/java/com/microsoft/playwright/FrameLocator.java
@@ -21,14 +21,15 @@ import java.util.regex.Pattern;
 
 /**
  * FrameLocator represents a view to the {@code iframe} on the page. It captures the logic sufficient to retrieve the
- * {@code iframe} and locate elements in that iframe. FrameLocator can be created with either {@link Page#frameLocator
- * Page.frameLocator()} or {@link Locator#frameLocator Locator.frameLocator()} method.
+ * {@code iframe} and locate elements in that iframe. FrameLocator can be created with either {@link
+ * com.microsoft.playwright.Page#frameLocator Page.frameLocator()} or {@link com.microsoft.playwright.Locator#frameLocator
+ * Locator.frameLocator()} method.
  * <pre>{@code
  * Locator locator = page.frameLocator("#my-frame").getByText("Submit");
  * locator.click();
  * }</pre>
  *
- * <p> **Strictness**
+ * <p> <strong>Strictness</strong>
  *
  * <p> Frame locators are strict. This means that all operations on frame locators will throw if more than one element matches
  * a given selector.
@@ -40,15 +41,15 @@ import java.util.regex.Pattern;
  * page.frame_locator(".result-frame").first().getByRole(AriaRole.BUTTON).click();
  * }</pre>
  *
- * <p> **Converting Locator to FrameLocator**
+ * <p> <strong>Converting Locator to FrameLocator</strong>
  *
  * <p> If you have a {@code Locator} object pointing to an {@code iframe} it can be converted to {@code FrameLocator} using
- * {@link Locator#contentFrame Locator.contentFrame()}.
+ * {@link com.microsoft.playwright.Locator#contentFrame Locator.contentFrame()}.
  *
- * <p> **Converting FrameLocator to Locator**
+ * <p> <strong>Converting FrameLocator to Locator</strong>
  *
  * <p> If you have a {@code FrameLocator} object it can be converted to {@code Locator} pointing to the same {@code iframe}
- * using {@link FrameLocator#owner FrameLocator.owner()}.
+ * using {@link com.microsoft.playwright.FrameLocator#owner FrameLocator.owner()}.
  */
 public interface FrameLocator {
   class GetByAltTextOptions {
@@ -398,7 +399,7 @@ public interface FrameLocator {
   /**
    * Allows locating elements by their alt text.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> For example, this method will find the image by alt text "Playwright logo":
    * <pre>{@code
@@ -414,7 +415,7 @@ public interface FrameLocator {
   /**
    * Allows locating elements by their alt text.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> For example, this method will find the image by alt text "Playwright logo":
    * <pre>{@code
@@ -428,7 +429,7 @@ public interface FrameLocator {
   /**
    * Allows locating elements by their alt text.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> For example, this method will find the image by alt text "Playwright logo":
    * <pre>{@code
@@ -444,7 +445,7 @@ public interface FrameLocator {
   /**
    * Allows locating elements by their alt text.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> For example, this method will find the image by alt text "Playwright logo":
    * <pre>{@code
@@ -459,7 +460,7 @@ public interface FrameLocator {
    * Allows locating input elements by the text of the associated {@code <label>} or {@code aria-labelledby} element, or by
    * the {@code aria-label} attribute.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> For example, this method will find inputs by label "Username" and "Password" in the following DOM:
    * <pre>{@code
@@ -477,7 +478,7 @@ public interface FrameLocator {
    * Allows locating input elements by the text of the associated {@code <label>} or {@code aria-labelledby} element, or by
    * the {@code aria-label} attribute.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> For example, this method will find inputs by label "Username" and "Password" in the following DOM:
    * <pre>{@code
@@ -493,7 +494,7 @@ public interface FrameLocator {
    * Allows locating input elements by the text of the associated {@code <label>} or {@code aria-labelledby} element, or by
    * the {@code aria-label} attribute.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> For example, this method will find inputs by label "Username" and "Password" in the following DOM:
    * <pre>{@code
@@ -511,7 +512,7 @@ public interface FrameLocator {
    * Allows locating input elements by the text of the associated {@code <label>} or {@code aria-labelledby} element, or by
    * the {@code aria-label} attribute.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> For example, this method will find inputs by label "Username" and "Password" in the following DOM:
    * <pre>{@code
@@ -526,7 +527,7 @@ public interface FrameLocator {
   /**
    * Allows locating input elements by the placeholder text.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> For example, consider the following DOM structure.
    *
@@ -544,7 +545,7 @@ public interface FrameLocator {
   /**
    * Allows locating input elements by the placeholder text.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> For example, consider the following DOM structure.
    *
@@ -560,7 +561,7 @@ public interface FrameLocator {
   /**
    * Allows locating input elements by the placeholder text.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> For example, consider the following DOM structure.
    *
@@ -578,7 +579,7 @@ public interface FrameLocator {
   /**
    * Allows locating input elements by the placeholder text.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> For example, consider the following DOM structure.
    *
@@ -596,7 +597,7 @@ public interface FrameLocator {
    * href="https://www.w3.org/TR/wai-aria-1.2/#aria-attributes">ARIA attributes</a> and <a
    * href="https://w3c.github.io/accname/#dfn-accessible-name">accessible name</a>.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> Consider the following DOM structure.
    *
@@ -617,7 +618,7 @@ public interface FrameLocator {
    *     .click();
    * }</pre>
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
    * <p> Role selector **does not replace** accessibility audits and conformance tests, but rather gives early feedback about the
    * ARIA guidelines.
@@ -639,7 +640,7 @@ public interface FrameLocator {
    * href="https://www.w3.org/TR/wai-aria-1.2/#aria-attributes">ARIA attributes</a> and <a
    * href="https://w3c.github.io/accname/#dfn-accessible-name">accessible name</a>.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> Consider the following DOM structure.
    *
@@ -660,7 +661,7 @@ public interface FrameLocator {
    *     .click();
    * }</pre>
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
    * <p> Role selector **does not replace** accessibility audits and conformance tests, but rather gives early feedback about the
    * ARIA guidelines.
@@ -678,7 +679,7 @@ public interface FrameLocator {
   /**
    * Locate element by the test id.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> Consider the following DOM structure.
    *
@@ -687,10 +688,11 @@ public interface FrameLocator {
    * page.getByTestId("directions").click();
    * }</pre>
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
-   * <p> By default, the {@code data-testid} attribute is used as a test id. Use {@link Selectors#setTestIdAttribute
-   * Selectors.setTestIdAttribute()} to configure a different test id attribute if necessary.
+   * <p> By default, the {@code data-testid} attribute is used as a test id. Use {@link
+   * com.microsoft.playwright.Selectors#setTestIdAttribute Selectors.setTestIdAttribute()} to configure a different test id
+   * attribute if necessary.
    *
    * @param testId Id to locate the element by.
    * @since v1.27
@@ -699,7 +701,7 @@ public interface FrameLocator {
   /**
    * Locate element by the test id.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> Consider the following DOM structure.
    *
@@ -708,10 +710,11 @@ public interface FrameLocator {
    * page.getByTestId("directions").click();
    * }</pre>
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
-   * <p> By default, the {@code data-testid} attribute is used as a test id. Use {@link Selectors#setTestIdAttribute
-   * Selectors.setTestIdAttribute()} to configure a different test id attribute if necessary.
+   * <p> By default, the {@code data-testid} attribute is used as a test id. Use {@link
+   * com.microsoft.playwright.Selectors#setTestIdAttribute Selectors.setTestIdAttribute()} to configure a different test id
+   * attribute if necessary.
    *
    * @param testId Id to locate the element by.
    * @since v1.27
@@ -720,10 +723,10 @@ public interface FrameLocator {
   /**
    * Allows locating elements that contain given text.
    *
-   * <p> See also {@link Locator#filter Locator.filter()} that allows to match by another criteria, like an accessible role, and
-   * then filter by the text content.
+   * <p> See also {@link com.microsoft.playwright.Locator#filter Locator.filter()} that allows to match by another criteria, like
+   * an accessible role, and then filter by the text content.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> Consider the following DOM structure:
    *
@@ -745,7 +748,7 @@ public interface FrameLocator {
    * page.getByText(Pattern.compile("^hello$", Pattern.CASE_INSENSITIVE))
    * }</pre>
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
    * <p> Matching by text always normalizes whitespace, even with exact match. For example, it turns multiple spaces into one,
    * turns line breaks into spaces and ignores leading and trailing whitespace.
@@ -762,10 +765,10 @@ public interface FrameLocator {
   /**
    * Allows locating elements that contain given text.
    *
-   * <p> See also {@link Locator#filter Locator.filter()} that allows to match by another criteria, like an accessible role, and
-   * then filter by the text content.
+   * <p> See also {@link com.microsoft.playwright.Locator#filter Locator.filter()} that allows to match by another criteria, like
+   * an accessible role, and then filter by the text content.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> Consider the following DOM structure:
    *
@@ -787,7 +790,7 @@ public interface FrameLocator {
    * page.getByText(Pattern.compile("^hello$", Pattern.CASE_INSENSITIVE))
    * }</pre>
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
    * <p> Matching by text always normalizes whitespace, even with exact match. For example, it turns multiple spaces into one,
    * turns line breaks into spaces and ignores leading and trailing whitespace.
@@ -802,10 +805,10 @@ public interface FrameLocator {
   /**
    * Allows locating elements that contain given text.
    *
-   * <p> See also {@link Locator#filter Locator.filter()} that allows to match by another criteria, like an accessible role, and
-   * then filter by the text content.
+   * <p> See also {@link com.microsoft.playwright.Locator#filter Locator.filter()} that allows to match by another criteria, like
+   * an accessible role, and then filter by the text content.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> Consider the following DOM structure:
    *
@@ -827,7 +830,7 @@ public interface FrameLocator {
    * page.getByText(Pattern.compile("^hello$", Pattern.CASE_INSENSITIVE))
    * }</pre>
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
    * <p> Matching by text always normalizes whitespace, even with exact match. For example, it turns multiple spaces into one,
    * turns line breaks into spaces and ignores leading and trailing whitespace.
@@ -844,10 +847,10 @@ public interface FrameLocator {
   /**
    * Allows locating elements that contain given text.
    *
-   * <p> See also {@link Locator#filter Locator.filter()} that allows to match by another criteria, like an accessible role, and
-   * then filter by the text content.
+   * <p> See also {@link com.microsoft.playwright.Locator#filter Locator.filter()} that allows to match by another criteria, like
+   * an accessible role, and then filter by the text content.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> Consider the following DOM structure:
    *
@@ -869,7 +872,7 @@ public interface FrameLocator {
    * page.getByText(Pattern.compile("^hello$", Pattern.CASE_INSENSITIVE))
    * }</pre>
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
    * <p> Matching by text always normalizes whitespace, even with exact match. For example, it turns multiple spaces into one,
    * turns line breaks into spaces and ignores leading and trailing whitespace.
@@ -884,7 +887,7 @@ public interface FrameLocator {
   /**
    * Allows locating elements by their title attribute.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> Consider the following DOM structure.
    *
@@ -902,7 +905,7 @@ public interface FrameLocator {
   /**
    * Allows locating elements by their title attribute.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> Consider the following DOM structure.
    *
@@ -918,7 +921,7 @@ public interface FrameLocator {
   /**
    * Allows locating elements by their title attribute.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> Consider the following DOM structure.
    *
@@ -936,7 +939,7 @@ public interface FrameLocator {
   /**
    * Allows locating elements by their title attribute.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> Consider the following DOM structure.
    *
@@ -957,7 +960,7 @@ public interface FrameLocator {
   FrameLocator last();
   /**
    * The method finds an element matching the specified selector in the locator's subtree. It also accepts filter options,
-   * similar to {@link Locator#filter Locator.filter()} method.
+   * similar to {@link com.microsoft.playwright.Locator#filter Locator.filter()} method.
    *
    * <p> <a href="https://playwright.dev/java/docs/locators">Learn more about locators</a>.
    *
@@ -969,7 +972,7 @@ public interface FrameLocator {
   }
   /**
    * The method finds an element matching the specified selector in the locator's subtree. It also accepts filter options,
-   * similar to {@link Locator#filter Locator.filter()} method.
+   * similar to {@link com.microsoft.playwright.Locator#filter Locator.filter()} method.
    *
    * <p> <a href="https://playwright.dev/java/docs/locators">Learn more about locators</a>.
    *
@@ -979,7 +982,7 @@ public interface FrameLocator {
   Locator locator(String selectorOrLocator, LocatorOptions options);
   /**
    * The method finds an element matching the specified selector in the locator's subtree. It also accepts filter options,
-   * similar to {@link Locator#filter Locator.filter()} method.
+   * similar to {@link com.microsoft.playwright.Locator#filter Locator.filter()} method.
    *
    * <p> <a href="https://playwright.dev/java/docs/locators">Learn more about locators</a>.
    *
@@ -991,7 +994,7 @@ public interface FrameLocator {
   }
   /**
    * The method finds an element matching the specified selector in the locator's subtree. It also accepts filter options,
-   * similar to {@link Locator#filter Locator.filter()} method.
+   * similar to {@link com.microsoft.playwright.Locator#filter Locator.filter()} method.
    *
    * <p> <a href="https://playwright.dev/java/docs/locators">Learn more about locators</a>.
    *
@@ -1011,9 +1014,9 @@ public interface FrameLocator {
    * <p> Useful when you have a {@code FrameLocator} object obtained somewhere, and later on would like to interact with the
    * {@code iframe} element.
    *
-   * <p> For a reverse operation, use {@link Locator#contentFrame Locator.contentFrame()}.
+   * <p> For a reverse operation, use {@link com.microsoft.playwright.Locator#contentFrame Locator.contentFrame()}.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * FrameLocator frameLocator = page.frameLocator("iframe[name=\"embedded\"]");
    * // ...

--- a/playwright/src/main/java/com/microsoft/playwright/JSHandle.java
+++ b/playwright/src/main/java/com/microsoft/playwright/JSHandle.java
@@ -19,19 +19,20 @@ package com.microsoft.playwright;
 import java.util.*;
 
 /**
- * JSHandle represents an in-page JavaScript object. JSHandles can be created with the {@link Page#evaluateHandle
- * Page.evaluateHandle()} method.
+ * JSHandle represents an in-page JavaScript object. JSHandles can be created with the {@link
+ * com.microsoft.playwright.Page#evaluateHandle Page.evaluateHandle()} method.
  * <pre>{@code
  * JSHandle windowHandle = page.evaluateHandle("() => window");
  * // ...
  * }</pre>
  *
  * <p> JSHandle prevents the referenced JavaScript object being garbage collected unless the handle is exposed with {@link
- * JSHandle#dispose JSHandle.dispose()}. JSHandles are auto-disposed when their origin frame gets navigated or the parent
- * context gets destroyed.
+ * com.microsoft.playwright.JSHandle#dispose JSHandle.dispose()}. JSHandles are auto-disposed when their origin frame gets
+ * navigated or the parent context gets destroyed.
  *
- * <p> JSHandle instances can be used as an argument in {@link Page#evalOnSelector Page.evalOnSelector()}, {@link Page#evaluate
- * Page.evaluate()} and {@link Page#evaluateHandle Page.evaluateHandle()} methods.
+ * <p> JSHandle instances can be used as an argument in {@link com.microsoft.playwright.Page#evalOnSelector
+ * Page.evalOnSelector()}, {@link com.microsoft.playwright.Page#evaluate Page.evaluate()} and {@link
+ * com.microsoft.playwright.Page#evaluateHandle Page.evaluateHandle()} methods.
  */
 public interface JSHandle {
   /**
@@ -55,7 +56,7 @@ public interface JSHandle {
    * href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>, then {@code
    * handle.evaluate} would wait for the promise to resolve and return its value.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * ElementHandle tweetHandle = page.querySelector(".tweet .retweets");
    * assertEquals("10 retweets", tweetHandle.evaluate("node => node.innerText"));
@@ -77,7 +78,7 @@ public interface JSHandle {
    * href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>, then {@code
    * handle.evaluate} would wait for the promise to resolve and return its value.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * ElementHandle tweetHandle = page.querySelector(".tweet .retweets");
    * assertEquals("10 retweets", tweetHandle.evaluate("node => node.innerText"));
@@ -101,7 +102,7 @@ public interface JSHandle {
    * href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>, then {@code
    * jsHandle.evaluateHandle} would wait for the promise to resolve and return its value.
    *
-   * <p> See {@link Page#evaluateHandle Page.evaluateHandle()} for more details.
+   * <p> See {@link com.microsoft.playwright.Page#evaluateHandle Page.evaluateHandle()} for more details.
    *
    * @param expression JavaScript expression to be evaluated in the browser context. If the expression evaluates to a function, the function is
    * automatically invoked.
@@ -122,7 +123,7 @@ public interface JSHandle {
    * href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>, then {@code
    * jsHandle.evaluateHandle} would wait for the promise to resolve and return its value.
    *
-   * <p> See {@link Page#evaluateHandle Page.evaluateHandle()} for more details.
+   * <p> See {@link com.microsoft.playwright.Page#evaluateHandle Page.evaluateHandle()} for more details.
    *
    * @param expression JavaScript expression to be evaluated in the browser context. If the expression evaluates to a function, the function is
    * automatically invoked.
@@ -133,7 +134,7 @@ public interface JSHandle {
   /**
    * The method returns a map with **own property names** as keys and JSHandle instances for the property values.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * JSHandle handle = page.evaluateHandle("() => ({ window, document })");
    * Map<String, JSHandle> properties = handle.getProperties();

--- a/playwright/src/main/java/com/microsoft/playwright/Keyboard.java
+++ b/playwright/src/main/java/com/microsoft/playwright/Keyboard.java
@@ -19,12 +19,13 @@ package com.microsoft.playwright;
 import com.microsoft.playwright.options.*;
 
 /**
- * Keyboard provides an api for managing a virtual keyboard. The high level api is {@link Keyboard#type Keyboard.type()},
- * which takes raw characters and generates proper {@code keydown}, {@code keypress}/{@code input}, and {@code keyup}
- * events on your page.
+ * Keyboard provides an api for managing a virtual keyboard. The high level api is {@link
+ * com.microsoft.playwright.Keyboard#type Keyboard.type()}, which takes raw characters and generates proper {@code
+ * keydown}, {@code keypress}/{@code input}, and {@code keyup} events on your page.
  *
- * <p> For finer control, you can use {@link Keyboard#down Keyboard.down()}, {@link Keyboard#up Keyboard.up()}, and {@link
- * Keyboard#insertText Keyboard.insertText()} to manually fire events as if they were generated from a real keyboard.
+ * <p> For finer control, you can use {@link com.microsoft.playwright.Keyboard#down Keyboard.down()}, {@link
+ * com.microsoft.playwright.Keyboard#up Keyboard.up()}, and {@link com.microsoft.playwright.Keyboard#insertText
+ * Keyboard.insertText()} to manually fire events as if they were generated from a real keyboard.
  *
  * <p> An example of holding down {@code Shift} in order to select and delete some text:
  * <pre>{@code
@@ -104,11 +105,12 @@ public interface Keyboard {
    * different respective texts.
    *
    * <p> If {@code key} is a modifier key, {@code Shift}, {@code Meta}, {@code Control}, or {@code Alt}, subsequent key presses
-   * will be sent with that modifier active. To release the modifier key, use {@link Keyboard#up Keyboard.up()}.
+   * will be sent with that modifier active. To release the modifier key, use {@link com.microsoft.playwright.Keyboard#up
+   * Keyboard.up()}.
    *
-   * <p> After the key is pressed once, subsequent calls to {@link Keyboard#down Keyboard.down()} will have <a
-   * href="https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/repeat">repeat</a> set to true. To release the key,
-   * use {@link Keyboard#up Keyboard.up()}.
+   * <p> After the key is pressed once, subsequent calls to {@link com.microsoft.playwright.Keyboard#down Keyboard.down()} will
+   * have <a href="https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/repeat">repeat</a> set to true. To release
+   * the key, use {@link com.microsoft.playwright.Keyboard#up Keyboard.up()}.
    *
    * <p> <strong>NOTE:</strong> Modifier keys DO influence {@code keyboard.down}. Holding down {@code Shift} will type the text in upper case.
    *
@@ -119,7 +121,7 @@ public interface Keyboard {
   /**
    * Dispatches only {@code input} event, does not emit the {@code keydown}, {@code keyup} or {@code keypress} events.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * page.keyboard().insertText("嗨");
    * }</pre>
@@ -132,7 +134,7 @@ public interface Keyboard {
    */
   void insertText(String text);
   /**
-   * <strong>NOTE:</strong> In most cases, you should use {@link Locator#press Locator.press()} instead.
+   * <strong>NOTE:</strong> In most cases, you should use {@link com.microsoft.playwright.Locator#press Locator.press()} instead.
    *
    * <p> {@code key} can specify the intended <a
    * href="https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key">keyboardEvent.key</a> value or a single
@@ -155,7 +157,7 @@ public interface Keyboard {
    * <p> Shortcuts such as {@code key: "Control+o"}, {@code key: "Control++} or {@code key: "Control+Shift+T"} are supported as
    * well. When specified with the modifier, modifier is pressed and being held while the subsequent key is being pressed.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * Page page = browser.newPage();
    * page.navigate("https://keycode.info");
@@ -168,7 +170,8 @@ public interface Keyboard {
    * browser.close();
    * }</pre>
    *
-   * <p> Shortcut for {@link Keyboard#down Keyboard.down()} and {@link Keyboard#up Keyboard.up()}.
+   * <p> Shortcut for {@link com.microsoft.playwright.Keyboard#down Keyboard.down()} and {@link
+   * com.microsoft.playwright.Keyboard#up Keyboard.up()}.
    *
    * @param key Name of the key to press or a character to generate, such as {@code ArrowLeft} or {@code a}.
    * @since v1.8
@@ -177,7 +180,7 @@ public interface Keyboard {
     press(key, null);
   }
   /**
-   * <strong>NOTE:</strong> In most cases, you should use {@link Locator#press Locator.press()} instead.
+   * <strong>NOTE:</strong> In most cases, you should use {@link com.microsoft.playwright.Locator#press Locator.press()} instead.
    *
    * <p> {@code key} can specify the intended <a
    * href="https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key">keyboardEvent.key</a> value or a single
@@ -200,7 +203,7 @@ public interface Keyboard {
    * <p> Shortcuts such as {@code key: "Control+o"}, {@code key: "Control++} or {@code key: "Control+Shift+T"} are supported as
    * well. When specified with the modifier, modifier is pressed and being held while the subsequent key is being pressed.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * Page page = browser.newPage();
    * page.navigate("https://keycode.info");
@@ -213,22 +216,24 @@ public interface Keyboard {
    * browser.close();
    * }</pre>
    *
-   * <p> Shortcut for {@link Keyboard#down Keyboard.down()} and {@link Keyboard#up Keyboard.up()}.
+   * <p> Shortcut for {@link com.microsoft.playwright.Keyboard#down Keyboard.down()} and {@link
+   * com.microsoft.playwright.Keyboard#up Keyboard.up()}.
    *
    * @param key Name of the key to press or a character to generate, such as {@code ArrowLeft} or {@code a}.
    * @since v1.8
    */
   void press(String key, PressOptions options);
   /**
-   * <strong>NOTE:</strong> In most cases, you should use {@link Locator#fill Locator.fill()} instead. You only need to press keys one by one if
-   * there is special keyboard handling on the page - in this case use {@link Locator#pressSequentially
-   * Locator.pressSequentially()}.
+   * <strong>NOTE:</strong> In most cases, you should use {@link com.microsoft.playwright.Locator#fill Locator.fill()} instead. You only need to
+   * press keys one by one if there is special keyboard handling on the page - in this case use {@link
+   * com.microsoft.playwright.Locator#pressSequentially Locator.pressSequentially()}.
    *
    * <p> Sends a {@code keydown}, {@code keypress}/{@code input}, and {@code keyup} event for each character in the text.
    *
-   * <p> To press a special key, like {@code Control} or {@code ArrowDown}, use {@link Keyboard#press Keyboard.press()}.
+   * <p> To press a special key, like {@code Control} or {@code ArrowDown}, use {@link com.microsoft.playwright.Keyboard#press
+   * Keyboard.press()}.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * // Types instantly
    * page.keyboard().type("Hello");
@@ -247,15 +252,16 @@ public interface Keyboard {
     type(text, null);
   }
   /**
-   * <strong>NOTE:</strong> In most cases, you should use {@link Locator#fill Locator.fill()} instead. You only need to press keys one by one if
-   * there is special keyboard handling on the page - in this case use {@link Locator#pressSequentially
-   * Locator.pressSequentially()}.
+   * <strong>NOTE:</strong> In most cases, you should use {@link com.microsoft.playwright.Locator#fill Locator.fill()} instead. You only need to
+   * press keys one by one if there is special keyboard handling on the page - in this case use {@link
+   * com.microsoft.playwright.Locator#pressSequentially Locator.pressSequentially()}.
    *
    * <p> Sends a {@code keydown}, {@code keypress}/{@code input}, and {@code keyup} event for each character in the text.
    *
-   * <p> To press a special key, like {@code Control} or {@code ArrowDown}, use {@link Keyboard#press Keyboard.press()}.
+   * <p> To press a special key, like {@code Control} or {@code ArrowDown}, use {@link com.microsoft.playwright.Keyboard#press
+   * Keyboard.press()}.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * // Types instantly
    * page.keyboard().type("Hello");

--- a/playwright/src/main/java/com/microsoft/playwright/Locator.java
+++ b/playwright/src/main/java/com/microsoft/playwright/Locator.java
@@ -23,8 +23,8 @@ import java.util.regex.Pattern;
 
 /**
  * Locators are the central piece of Playwright's auto-waiting and retry-ability. In a nutshell, locators represent a way
- * to find element(s) on the page at any moment. A locator can be created with the {@link Page#locator Page.locator()}
- * method.
+ * to find element(s) on the page at any moment. A locator can be created with the {@link
+ * com.microsoft.playwright.Page#locator Page.locator()} method.
  *
  * <p> <a href="https://playwright.dev/java/docs/locators">Learn more about locators</a>.
  */
@@ -32,15 +32,17 @@ public interface Locator {
   class BlurOptions {
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
 
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public BlurOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -50,15 +52,17 @@ public interface Locator {
   class BoundingBoxOptions {
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
 
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public BoundingBoxOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -84,8 +88,9 @@ public interface Locator {
     public Position position;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
     /**
@@ -129,8 +134,9 @@ public interface Locator {
     }
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public CheckOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -160,8 +166,9 @@ public interface Locator {
     public Boolean noWaitAfter;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
 
@@ -184,8 +191,9 @@ public interface Locator {
     }
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public ClearOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -228,8 +236,9 @@ public interface Locator {
     public Position position;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
     /**
@@ -302,8 +311,9 @@ public interface Locator {
     }
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public ClickOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -351,8 +361,9 @@ public interface Locator {
     public Position position;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
     /**
@@ -418,8 +429,9 @@ public interface Locator {
     }
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public DblclickOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -438,15 +450,17 @@ public interface Locator {
   class DispatchEventOptions {
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
 
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public DispatchEventOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -477,8 +491,9 @@ public interface Locator {
     public Position targetPosition;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
     /**
@@ -537,8 +552,9 @@ public interface Locator {
     }
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public DragToOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -557,15 +573,17 @@ public interface Locator {
   class ElementHandleOptions {
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
 
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public ElementHandleOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -575,15 +593,17 @@ public interface Locator {
   class EvaluateOptions {
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
 
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public EvaluateOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -593,15 +613,17 @@ public interface Locator {
   class EvaluateHandleOptions {
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
 
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public EvaluateHandleOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -622,8 +644,9 @@ public interface Locator {
     public Boolean noWaitAfter;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
 
@@ -646,8 +669,9 @@ public interface Locator {
     }
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public FillOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -753,15 +777,17 @@ public interface Locator {
   class FocusOptions {
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
 
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public FocusOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -771,15 +797,17 @@ public interface Locator {
   class GetAttributeOptions {
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
 
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public GetAttributeOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -1044,8 +1072,9 @@ public interface Locator {
     public Position position;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
     /**
@@ -1097,8 +1126,9 @@ public interface Locator {
     }
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public HoverOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -1117,15 +1147,17 @@ public interface Locator {
   class InnerHTMLOptions {
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
 
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public InnerHTMLOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -1135,15 +1167,17 @@ public interface Locator {
   class InnerTextOptions {
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
 
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public InnerTextOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -1153,15 +1187,17 @@ public interface Locator {
   class InputValueOptions {
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
 
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public InputValueOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -1171,15 +1207,17 @@ public interface Locator {
   class IsCheckedOptions {
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
 
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public IsCheckedOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -1189,15 +1227,17 @@ public interface Locator {
   class IsDisabledOptions {
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
 
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public IsDisabledOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -1207,15 +1247,17 @@ public interface Locator {
   class IsEditableOptions {
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
 
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public IsEditableOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -1225,15 +1267,17 @@ public interface Locator {
   class IsEnabledOptions {
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
 
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public IsEnabledOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -1242,14 +1286,14 @@ public interface Locator {
   }
   class IsHiddenOptions {
     /**
-     * @deprecated This option is ignored. {@link Locator#isHidden Locator.isHidden()} does not wait for the element to become hidden and
-     * returns immediately.
+     * @deprecated This option is ignored. {@link com.microsoft.playwright.Locator#isHidden Locator.isHidden()} does not wait for the
+     * element to become hidden and returns immediately.
      */
     public Double timeout;
 
     /**
-     * @deprecated This option is ignored. {@link Locator#isHidden Locator.isHidden()} does not wait for the element to become hidden and
-     * returns immediately.
+     * @deprecated This option is ignored. {@link com.microsoft.playwright.Locator#isHidden Locator.isHidden()} does not wait for the
+     * element to become hidden and returns immediately.
      */
     public IsHiddenOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -1258,14 +1302,14 @@ public interface Locator {
   }
   class IsVisibleOptions {
     /**
-     * @deprecated This option is ignored. {@link Locator#isVisible Locator.isVisible()} does not wait for the element to become visible
-     * and returns immediately.
+     * @deprecated This option is ignored. {@link com.microsoft.playwright.Locator#isVisible Locator.isVisible()} does not wait for the
+     * element to become visible and returns immediately.
      */
     public Double timeout;
 
     /**
-     * @deprecated This option is ignored. {@link Locator#isVisible Locator.isVisible()} does not wait for the element to become visible
-     * and returns immediately.
+     * @deprecated This option is ignored. {@link com.microsoft.playwright.Locator#isVisible Locator.isVisible()} does not wait for the
+     * element to become visible and returns immediately.
      */
     public IsVisibleOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -1381,8 +1425,9 @@ public interface Locator {
     public Boolean noWaitAfter;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
 
@@ -1404,8 +1449,9 @@ public interface Locator {
     }
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public PressOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -1425,8 +1471,9 @@ public interface Locator {
     public Boolean noWaitAfter;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
 
@@ -1448,8 +1495,9 @@ public interface Locator {
     }
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public PressSequentiallyOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -1515,8 +1563,9 @@ public interface Locator {
     public String style;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
     /**
@@ -1609,8 +1658,9 @@ public interface Locator {
     }
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public ScreenshotOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -1627,15 +1677,17 @@ public interface Locator {
   class ScrollIntoViewIfNeededOptions {
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
 
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public ScrollIntoViewIfNeededOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -1656,8 +1708,9 @@ public interface Locator {
     public Boolean noWaitAfter;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
 
@@ -1680,8 +1733,9 @@ public interface Locator {
     }
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public SelectOptionOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -1696,8 +1750,9 @@ public interface Locator {
     public Boolean force;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
 
@@ -1711,8 +1766,9 @@ public interface Locator {
     }
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public SelectTextOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -1738,8 +1794,9 @@ public interface Locator {
     public Position position;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
     /**
@@ -1783,8 +1840,9 @@ public interface Locator {
     }
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public SetCheckedOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -1809,8 +1867,9 @@ public interface Locator {
     public Boolean noWaitAfter;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
 
@@ -1825,8 +1884,9 @@ public interface Locator {
     }
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public SetInputFilesOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -1857,8 +1917,9 @@ public interface Locator {
     public Position position;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
     /**
@@ -1910,8 +1971,9 @@ public interface Locator {
     }
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public TapOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -1930,15 +1992,17 @@ public interface Locator {
   class TextContentOptions {
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
 
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public TextContentOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -1958,8 +2022,9 @@ public interface Locator {
     public Boolean noWaitAfter;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
 
@@ -1981,8 +2046,9 @@ public interface Locator {
     }
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public TypeOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -2008,8 +2074,9 @@ public interface Locator {
     public Position position;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
     /**
@@ -2053,8 +2120,9 @@ public interface Locator {
     }
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public UncheckOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -2085,8 +2153,9 @@ public interface Locator {
     public WaitForSelectorState state;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
 
@@ -2107,8 +2176,9 @@ public interface Locator {
     }
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public WaitForOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -2118,12 +2188,13 @@ public interface Locator {
   /**
    * When the locator points to a list of elements, this returns an array of locators, pointing to their respective elements.
    *
-   * <p> <strong>NOTE:</strong> {@link Locator#all Locator.all()} does not wait for elements to match the locator, and instead immediately returns
-   * whatever is present in the page.  When the list of elements changes dynamically, {@link Locator#all Locator.all()} will
-   * produce unpredictable and flaky results.  When the list of elements is stable, but loaded dynamically, wait for the full
-   * list to finish loading before calling {@link Locator#all Locator.all()}.
+   * <p> <strong>NOTE:</strong> {@link com.microsoft.playwright.Locator#all Locator.all()} does not wait for elements to match the locator, and instead
+   * immediately returns whatever is present in the page.  When the list of elements changes dynamically, {@link
+   * com.microsoft.playwright.Locator#all Locator.all()} will produce unpredictable and flaky results.  When the list of
+   * elements is stable, but loaded dynamically, wait for the full list to finish loading before calling {@link
+   * com.microsoft.playwright.Locator#all Locator.all()}.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * for (Locator li : page.getByRole('listitem').all())
    *   li.click();
@@ -2135,11 +2206,11 @@ public interface Locator {
   /**
    * Returns an array of {@code node.innerText} values for all matching nodes.
    *
-   * <p> <strong>NOTE:</strong> If you need to assert text on the page, prefer {@link LocatorAssertions#hasText LocatorAssertions.hasText()} with {@code
-   * useInnerText} option to avoid flakiness. See <a href="https://playwright.dev/java/docs/test-assertions">assertions
-   * guide</a> for more details.
+   * <p> <strong>NOTE:</strong> If you need to assert text on the page, prefer {@link com.microsoft.playwright.assertions.LocatorAssertions#hasText
+   * LocatorAssertions.hasText()} with {@code useInnerText} option to avoid flakiness. See <a
+   * href="https://playwright.dev/java/docs/test-assertions">assertions guide</a> for more details.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * String[] texts = page.getByRole(AriaRole.LINK).allInnerTexts();
    * }</pre>
@@ -2150,10 +2221,11 @@ public interface Locator {
   /**
    * Returns an array of {@code node.textContent} values for all matching nodes.
    *
-   * <p> <strong>NOTE:</strong> If you need to assert text on the page, prefer {@link LocatorAssertions#hasText LocatorAssertions.hasText()} to avoid
-   * flakiness. See <a href="https://playwright.dev/java/docs/test-assertions">assertions guide</a> for more details.
+   * <p> <strong>NOTE:</strong> If you need to assert text on the page, prefer {@link com.microsoft.playwright.assertions.LocatorAssertions#hasText
+   * LocatorAssertions.hasText()} to avoid flakiness. See <a
+   * href="https://playwright.dev/java/docs/test-assertions">assertions guide</a> for more details.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * String[] texts = page.getByRole(AriaRole.LINK).allTextContents();
    * }</pre>
@@ -2164,7 +2236,7 @@ public interface Locator {
   /**
    * Creates a locator that matches both this locator and the argument locator.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> The following example finds a button with a specific title.
    * <pre>{@code
@@ -2193,7 +2265,7 @@ public interface Locator {
    * This method returns the bounding box of the element matching the locator, or {@code null} if the element is not visible.
    * The bounding box is calculated relative to the main frame viewport - which is usually the same as the browser window.
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
    * <p> Scrolling affects the returned bounding box, similarly to <a
    * href="https://developer.mozilla.org/en-US/docs/Web/API/Element/getBoundingClientRect">Element.getBoundingClientRect</a>.
@@ -2205,7 +2277,7 @@ public interface Locator {
    * <p> Assuming the page is static, it is safe to use bounding box coordinates to perform input. For example, the following
    * snippet should click the center of the element.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * BoundingBox box = page.getByRole(AriaRole.BUTTON).boundingBox();
    * page.mouse().click(box.x + box.width / 2, box.y + box.height / 2);
@@ -2220,7 +2292,7 @@ public interface Locator {
    * This method returns the bounding box of the element matching the locator, or {@code null} if the element is not visible.
    * The bounding box is calculated relative to the main frame viewport - which is usually the same as the browser window.
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
    * <p> Scrolling affects the returned bounding box, similarly to <a
    * href="https://developer.mozilla.org/en-US/docs/Web/API/Element/getBoundingClientRect">Element.getBoundingClientRect</a>.
@@ -2232,7 +2304,7 @@ public interface Locator {
    * <p> Assuming the page is static, it is safe to use bounding box coordinates to perform input. For example, the following
    * snippet should click the center of the element.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * BoundingBox box = page.getByRole(AriaRole.BUTTON).boundingBox();
    * page.mouse().click(box.x + box.width / 2, box.y + box.height / 2);
@@ -2244,7 +2316,7 @@ public interface Locator {
   /**
    * Ensure that checkbox or radio element is checked.
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
    * <p> Performs the following steps:
    * <ol>
@@ -2253,7 +2325,7 @@ public interface Locator {
    * <li> Wait for <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks on the element, unless {@code
    * force} option is set.</li>
    * <li> Scroll the element into view if needed.</li>
-   * <li> Use {@link Page#mouse Page.mouse()} to click in the center of the element.</li>
+   * <li> Use {@link com.microsoft.playwright.Page#mouse Page.mouse()} to click in the center of the element.</li>
    * <li> Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.</li>
    * <li> Ensure that the element is now checked. If not, this method throws.</li>
    * </ol>
@@ -2263,7 +2335,7 @@ public interface Locator {
    * <p> When all steps combined have not finished during the specified {@code timeout}, this method throws a {@code
    * TimeoutError}. Passing zero timeout disables this.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * page.getByRole(AriaRole.CHECKBOX).check();
    * }</pre>
@@ -2276,7 +2348,7 @@ public interface Locator {
   /**
    * Ensure that checkbox or radio element is checked.
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
    * <p> Performs the following steps:
    * <ol>
@@ -2285,7 +2357,7 @@ public interface Locator {
    * <li> Wait for <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks on the element, unless {@code
    * force} option is set.</li>
    * <li> Scroll the element into view if needed.</li>
-   * <li> Use {@link Page#mouse Page.mouse()} to click in the center of the element.</li>
+   * <li> Use {@link com.microsoft.playwright.Page#mouse Page.mouse()} to click in the center of the element.</li>
    * <li> Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.</li>
    * <li> Ensure that the element is now checked. If not, this method throws.</li>
    * </ol>
@@ -2295,7 +2367,7 @@ public interface Locator {
    * <p> When all steps combined have not finished during the specified {@code timeout}, this method throws a {@code
    * TimeoutError}. Passing zero timeout disables this.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * page.getByRole(AriaRole.CHECKBOX).check();
    * }</pre>
@@ -2306,7 +2378,7 @@ public interface Locator {
   /**
    * Clear the input field.
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
    * <p> This method waits for <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks, focuses the
    * element, clears it and triggers an {@code input} event after clearing.
@@ -2316,7 +2388,7 @@ public interface Locator {
    * href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLLabelElement/control">control</a>, the control will be
    * cleared instead.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * page.getByRole(AriaRole.TEXTBOX).clear();
    * }</pre>
@@ -2329,7 +2401,7 @@ public interface Locator {
   /**
    * Clear the input field.
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
    * <p> This method waits for <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks, focuses the
    * element, clears it and triggers an {@code input} event after clearing.
@@ -2339,7 +2411,7 @@ public interface Locator {
    * href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLLabelElement/control">control</a>, the control will be
    * cleared instead.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * page.getByRole(AriaRole.TEXTBOX).clear();
    * }</pre>
@@ -2350,14 +2422,15 @@ public interface Locator {
   /**
    * Click an element.
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
    * <p> This method clicks the element by performing the following steps:
    * <ol>
    * <li> Wait for <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks on the element, unless {@code
    * force} option is set.</li>
    * <li> Scroll the element into view if needed.</li>
-   * <li> Use {@link Page#mouse Page.mouse()} to click in the center of the element, or the specified {@code position}.</li>
+   * <li> Use {@link com.microsoft.playwright.Page#mouse Page.mouse()} to click in the center of the element, or the specified
+   * {@code position}.</li>
    * <li> Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.</li>
    * </ol>
    *
@@ -2366,7 +2439,7 @@ public interface Locator {
    * <p> When all steps combined have not finished during the specified {@code timeout}, this method throws a {@code
    * TimeoutError}. Passing zero timeout disables this.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> Click a button:
    * <pre>{@code
@@ -2389,14 +2462,15 @@ public interface Locator {
   /**
    * Click an element.
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
    * <p> This method clicks the element by performing the following steps:
    * <ol>
    * <li> Wait for <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks on the element, unless {@code
    * force} option is set.</li>
    * <li> Scroll the element into view if needed.</li>
-   * <li> Use {@link Page#mouse Page.mouse()} to click in the center of the element, or the specified {@code position}.</li>
+   * <li> Use {@link com.microsoft.playwright.Page#mouse Page.mouse()} to click in the center of the element, or the specified
+   * {@code position}.</li>
    * <li> Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.</li>
    * </ol>
    *
@@ -2405,7 +2479,7 @@ public interface Locator {
    * <p> When all steps combined have not finished during the specified {@code timeout}, this method throws a {@code
    * TimeoutError}. Passing zero timeout disables this.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> Click a button:
    * <pre>{@code
@@ -2426,11 +2500,11 @@ public interface Locator {
   /**
    * Returns the number of elements matching the locator.
    *
-   * <p> <strong>NOTE:</strong> If you need to assert the number of elements on the page, prefer {@link LocatorAssertions#hasCount
-   * LocatorAssertions.hasCount()} to avoid flakiness. See <a
+   * <p> <strong>NOTE:</strong> If you need to assert the number of elements on the page, prefer {@link
+   * com.microsoft.playwright.assertions.LocatorAssertions#hasCount LocatorAssertions.hasCount()} to avoid flakiness. See <a
    * href="https://playwright.dev/java/docs/test-assertions">assertions guide</a> for more details.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * int count = page.getByRole(AriaRole.LISTITEM).count();
    * }</pre>
@@ -2441,14 +2515,15 @@ public interface Locator {
   /**
    * Double-click an element.
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
    * <p> This method double clicks the element by performing the following steps:
    * <ol>
    * <li> Wait for <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks on the element, unless {@code
    * force} option is set.</li>
    * <li> Scroll the element into view if needed.</li>
-   * <li> Use {@link Page#mouse Page.mouse()} to double click in the center of the element, or the specified {@code position}.</li>
+   * <li> Use {@link com.microsoft.playwright.Page#mouse Page.mouse()} to double click in the center of the element, or the
+   * specified {@code position}.</li>
    * <li> Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set. Note that if the
    * first click of the {@code dblclick()} triggers a navigation event, this method will throw.</li>
    * </ol>
@@ -2468,14 +2543,15 @@ public interface Locator {
   /**
    * Double-click an element.
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
    * <p> This method double clicks the element by performing the following steps:
    * <ol>
    * <li> Wait for <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks on the element, unless {@code
    * force} option is set.</li>
    * <li> Scroll the element into view if needed.</li>
-   * <li> Use {@link Page#mouse Page.mouse()} to double click in the center of the element, or the specified {@code position}.</li>
+   * <li> Use {@link com.microsoft.playwright.Page#mouse Page.mouse()} to double click in the center of the element, or the
+   * specified {@code position}.</li>
    * <li> Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set. Note that if the
    * first click of the {@code dblclick()} triggers a navigation event, this method will throw.</li>
    * </ol>
@@ -2493,12 +2569,12 @@ public interface Locator {
   /**
    * Programmatically dispatch an event on the matching element.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * locator.dispatchEvent("click");
    * }</pre>
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
    * <p> The snippet above dispatches the {@code click} event on the element. Regardless of the visibility state of the element,
    * {@code click} is dispatched. This is equivalent to calling <a
@@ -2542,12 +2618,12 @@ public interface Locator {
   /**
    * Programmatically dispatch an event on the matching element.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * locator.dispatchEvent("click");
    * }</pre>
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
    * <p> The snippet above dispatches the {@code click} event on the element. Regardless of the visibility state of the element,
    * {@code click} is dispatched. This is equivalent to calling <a
@@ -2590,12 +2666,12 @@ public interface Locator {
   /**
    * Programmatically dispatch an event on the matching element.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * locator.dispatchEvent("click");
    * }</pre>
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
    * <p> The snippet above dispatches the {@code click} event on the element. Regardless of the visibility state of the element,
    * {@code click} is dispatched. This is equivalent to calling <a
@@ -2637,12 +2713,12 @@ public interface Locator {
   /**
    * Drag the source element towards the target element and drop it.
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
    * <p> This method drags the locator to another target locator or target position. It will first move to the source element,
    * perform a {@code mousedown}, then move to the target element or position and perform a {@code mouseup}.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * Locator source = page.locator("#source");
    * Locator target = page.locator("#target");
@@ -2662,12 +2738,12 @@ public interface Locator {
   /**
    * Drag the source element towards the target element and drop it.
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
    * <p> This method drags the locator to another target locator or target position. It will first move to the source element,
    * perform a {@code mousedown}, then move to the target element or position and perform a {@code mouseup}.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * Locator source = page.locator("#source");
    * Locator target = page.locator("#target");
@@ -2710,9 +2786,9 @@ public interface Locator {
    * <p> Useful when you have a {@code Locator} object obtained somewhere, and later on would like to interact with the content
    * inside the frame.
    *
-   * <p> For a reverse operation, use {@link FrameLocator#owner FrameLocator.owner()}.
+   * <p> For a reverse operation, use {@link com.microsoft.playwright.FrameLocator#owner FrameLocator.owner()}.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * Locator locator = page.locator("iframe[name=\"embedded\"]");
    * // ...
@@ -2726,7 +2802,7 @@ public interface Locator {
   /**
    * Execute JavaScript code in the page, taking the matching element as an argument.
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
    * <p> Returns the return value of {@code expression}, called with the matching element as a first argument, and {@code arg} as
    * a second argument.
@@ -2737,7 +2813,7 @@ public interface Locator {
    *
    * <p> If {@code expression} throws or rejects, this method throws.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * Locator tweets = page.locator(".tweet .retweets");
    * assertEquals("10 retweets", tweets.evaluate("node => node.innerText"));
@@ -2754,7 +2830,7 @@ public interface Locator {
   /**
    * Execute JavaScript code in the page, taking the matching element as an argument.
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
    * <p> Returns the return value of {@code expression}, called with the matching element as a first argument, and {@code arg} as
    * a second argument.
@@ -2765,7 +2841,7 @@ public interface Locator {
    *
    * <p> If {@code expression} throws or rejects, this method throws.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * Locator tweets = page.locator(".tweet .retweets");
    * assertEquals("10 retweets", tweets.evaluate("node => node.innerText"));
@@ -2781,7 +2857,7 @@ public interface Locator {
   /**
    * Execute JavaScript code in the page, taking the matching element as an argument.
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
    * <p> Returns the return value of {@code expression}, called with the matching element as a first argument, and {@code arg} as
    * a second argument.
@@ -2792,7 +2868,7 @@ public interface Locator {
    *
    * <p> If {@code expression} throws or rejects, this method throws.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * Locator tweets = page.locator(".tweet .retweets");
    * assertEquals("10 retweets", tweets.evaluate("node => node.innerText"));
@@ -2807,7 +2883,7 @@ public interface Locator {
   /**
    * Execute JavaScript code in the page, taking all matching elements as an argument.
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
    * <p> Returns the return value of {@code expression}, called with an array of all matching elements as a first argument, and
    * {@code arg} as a second argument.
@@ -2818,7 +2894,7 @@ public interface Locator {
    *
    * <p> If {@code expression} throws or rejects, this method throws.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * Locator locator = page.locator("div");
    * boolean moreThanTen = (boolean) locator.evaluateAll("(divs, min) => divs.length > min", 10);
@@ -2834,7 +2910,7 @@ public interface Locator {
   /**
    * Execute JavaScript code in the page, taking all matching elements as an argument.
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
    * <p> Returns the return value of {@code expression}, called with an array of all matching elements as a first argument, and
    * {@code arg} as a second argument.
@@ -2845,7 +2921,7 @@ public interface Locator {
    *
    * <p> If {@code expression} throws or rejects, this method throws.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * Locator locator = page.locator("div");
    * boolean moreThanTen = (boolean) locator.evaluateAll("(divs, min) => divs.length > min", 10);
@@ -2861,13 +2937,14 @@ public interface Locator {
    * Execute JavaScript code in the page, taking the matching element as an argument, and return a {@code JSHandle} with the
    * result.
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
    * <p> Returns the return value of {@code expression} as a{@code JSHandle}, called with the matching element as a first
    * argument, and {@code arg} as a second argument.
    *
-   * <p> The only difference between {@link Locator#evaluate Locator.evaluate()} and {@link Locator#evaluateHandle
-   * Locator.evaluateHandle()} is that {@link Locator#evaluateHandle Locator.evaluateHandle()} returns {@code JSHandle}.
+   * <p> The only difference between {@link com.microsoft.playwright.Locator#evaluate Locator.evaluate()} and {@link
+   * com.microsoft.playwright.Locator#evaluateHandle Locator.evaluateHandle()} is that {@link
+   * com.microsoft.playwright.Locator#evaluateHandle Locator.evaluateHandle()} returns {@code JSHandle}.
    *
    * <p> If {@code expression} returns a <a
    * href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>, this method
@@ -2875,7 +2952,7 @@ public interface Locator {
    *
    * <p> If {@code expression} throws or rejects, this method throws.
    *
-   * <p> See {@link Page#evaluateHandle Page.evaluateHandle()} for more details.
+   * <p> See {@link com.microsoft.playwright.Page#evaluateHandle Page.evaluateHandle()} for more details.
    *
    * @param expression JavaScript expression to be evaluated in the browser context. If the expression evaluates to a function, the function is
    * automatically invoked.
@@ -2889,13 +2966,14 @@ public interface Locator {
    * Execute JavaScript code in the page, taking the matching element as an argument, and return a {@code JSHandle} with the
    * result.
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
    * <p> Returns the return value of {@code expression} as a{@code JSHandle}, called with the matching element as a first
    * argument, and {@code arg} as a second argument.
    *
-   * <p> The only difference between {@link Locator#evaluate Locator.evaluate()} and {@link Locator#evaluateHandle
-   * Locator.evaluateHandle()} is that {@link Locator#evaluateHandle Locator.evaluateHandle()} returns {@code JSHandle}.
+   * <p> The only difference between {@link com.microsoft.playwright.Locator#evaluate Locator.evaluate()} and {@link
+   * com.microsoft.playwright.Locator#evaluateHandle Locator.evaluateHandle()} is that {@link
+   * com.microsoft.playwright.Locator#evaluateHandle Locator.evaluateHandle()} returns {@code JSHandle}.
    *
    * <p> If {@code expression} returns a <a
    * href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>, this method
@@ -2903,7 +2981,7 @@ public interface Locator {
    *
    * <p> If {@code expression} throws or rejects, this method throws.
    *
-   * <p> See {@link Page#evaluateHandle Page.evaluateHandle()} for more details.
+   * <p> See {@link com.microsoft.playwright.Page#evaluateHandle Page.evaluateHandle()} for more details.
    *
    * @param expression JavaScript expression to be evaluated in the browser context. If the expression evaluates to a function, the function is
    * automatically invoked.
@@ -2916,13 +2994,14 @@ public interface Locator {
    * Execute JavaScript code in the page, taking the matching element as an argument, and return a {@code JSHandle} with the
    * result.
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
    * <p> Returns the return value of {@code expression} as a{@code JSHandle}, called with the matching element as a first
    * argument, and {@code arg} as a second argument.
    *
-   * <p> The only difference between {@link Locator#evaluate Locator.evaluate()} and {@link Locator#evaluateHandle
-   * Locator.evaluateHandle()} is that {@link Locator#evaluateHandle Locator.evaluateHandle()} returns {@code JSHandle}.
+   * <p> The only difference between {@link com.microsoft.playwright.Locator#evaluate Locator.evaluate()} and {@link
+   * com.microsoft.playwright.Locator#evaluateHandle Locator.evaluateHandle()} is that {@link
+   * com.microsoft.playwright.Locator#evaluateHandle Locator.evaluateHandle()} returns {@code JSHandle}.
    *
    * <p> If {@code expression} returns a <a
    * href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>, this method
@@ -2930,7 +3009,7 @@ public interface Locator {
    *
    * <p> If {@code expression} throws or rejects, this method throws.
    *
-   * <p> See {@link Page#evaluateHandle Page.evaluateHandle()} for more details.
+   * <p> See {@link com.microsoft.playwright.Page#evaluateHandle Page.evaluateHandle()} for more details.
    *
    * @param expression JavaScript expression to be evaluated in the browser context. If the expression evaluates to a function, the function is
    * automatically invoked.
@@ -2941,12 +3020,12 @@ public interface Locator {
   /**
    * Set a value to the input field.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * page.getByRole(AriaRole.TEXTBOX).fill("example value");
    * }</pre>
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
    * <p> This method waits for <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks, focuses the
    * element, fills it and triggers an {@code input} event after filling. Note that you can pass an empty string to clear the
@@ -2957,7 +3036,8 @@ public interface Locator {
    * href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLLabelElement/control">control</a>, the control will be filled
    * instead.
    *
-   * <p> To send fine-grained keyboard events, use {@link Locator#pressSequentially Locator.pressSequentially()}.
+   * <p> To send fine-grained keyboard events, use {@link com.microsoft.playwright.Locator#pressSequentially
+   * Locator.pressSequentially()}.
    *
    * @param value Value to set for the {@code <input>}, {@code <textarea>} or {@code [contenteditable]} element.
    * @since v1.14
@@ -2968,12 +3048,12 @@ public interface Locator {
   /**
    * Set a value to the input field.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * page.getByRole(AriaRole.TEXTBOX).fill("example value");
    * }</pre>
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
    * <p> This method waits for <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks, focuses the
    * element, fills it and triggers an {@code input} event after filling. Note that you can pass an empty string to clear the
@@ -2984,7 +3064,8 @@ public interface Locator {
    * href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLLabelElement/control">control</a>, the control will be filled
    * instead.
    *
-   * <p> To send fine-grained keyboard events, use {@link Locator#pressSequentially Locator.pressSequentially()}.
+   * <p> To send fine-grained keyboard events, use {@link com.microsoft.playwright.Locator#pressSequentially
+   * Locator.pressSequentially()}.
    *
    * @param value Value to set for the {@code <input>}, {@code <textarea>} or {@code [contenteditable]} element.
    * @since v1.14
@@ -2994,7 +3075,7 @@ public interface Locator {
    * This method narrows existing locator according to the options, for example filters by text. It can be chained to filter
    * multiple times.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * Locator rowLocator = page.locator("tr");
    * // ...
@@ -3015,7 +3096,7 @@ public interface Locator {
    * This method narrows existing locator according to the options, for example filters by text. It can be chained to filter
    * multiple times.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * Locator rowLocator = page.locator("tr");
    * // ...
@@ -3054,7 +3135,7 @@ public interface Locator {
    * When working with iframes, you can create a frame locator that will enter the iframe and allow locating elements in that
    * iframe:
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * Locator locator = page.frameLocator("iframe").getByText("Submit");
    * locator.click();
@@ -3067,9 +3148,9 @@ public interface Locator {
   /**
    * Returns the matching element's attribute value.
    *
-   * <p> <strong>NOTE:</strong> If you need to assert an element's attribute, prefer {@link LocatorAssertions#hasAttribute
-   * LocatorAssertions.hasAttribute()} to avoid flakiness. See <a
-   * href="https://playwright.dev/java/docs/test-assertions">assertions guide</a> for more details.
+   * <p> <strong>NOTE:</strong> If you need to assert an element's attribute, prefer {@link
+   * com.microsoft.playwright.assertions.LocatorAssertions#hasAttribute LocatorAssertions.hasAttribute()} to avoid flakiness.
+   * See <a href="https://playwright.dev/java/docs/test-assertions">assertions guide</a> for more details.
    *
    * @param name Attribute name to get the value for.
    * @since v1.14
@@ -3080,9 +3161,9 @@ public interface Locator {
   /**
    * Returns the matching element's attribute value.
    *
-   * <p> <strong>NOTE:</strong> If you need to assert an element's attribute, prefer {@link LocatorAssertions#hasAttribute
-   * LocatorAssertions.hasAttribute()} to avoid flakiness. See <a
-   * href="https://playwright.dev/java/docs/test-assertions">assertions guide</a> for more details.
+   * <p> <strong>NOTE:</strong> If you need to assert an element's attribute, prefer {@link
+   * com.microsoft.playwright.assertions.LocatorAssertions#hasAttribute LocatorAssertions.hasAttribute()} to avoid flakiness.
+   * See <a href="https://playwright.dev/java/docs/test-assertions">assertions guide</a> for more details.
    *
    * @param name Attribute name to get the value for.
    * @since v1.14
@@ -3091,7 +3172,7 @@ public interface Locator {
   /**
    * Allows locating elements by their alt text.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> For example, this method will find the image by alt text "Playwright logo":
    * <pre>{@code
@@ -3107,7 +3188,7 @@ public interface Locator {
   /**
    * Allows locating elements by their alt text.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> For example, this method will find the image by alt text "Playwright logo":
    * <pre>{@code
@@ -3121,7 +3202,7 @@ public interface Locator {
   /**
    * Allows locating elements by their alt text.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> For example, this method will find the image by alt text "Playwright logo":
    * <pre>{@code
@@ -3137,7 +3218,7 @@ public interface Locator {
   /**
    * Allows locating elements by their alt text.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> For example, this method will find the image by alt text "Playwright logo":
    * <pre>{@code
@@ -3152,7 +3233,7 @@ public interface Locator {
    * Allows locating input elements by the text of the associated {@code <label>} or {@code aria-labelledby} element, or by
    * the {@code aria-label} attribute.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> For example, this method will find inputs by label "Username" and "Password" in the following DOM:
    * <pre>{@code
@@ -3170,7 +3251,7 @@ public interface Locator {
    * Allows locating input elements by the text of the associated {@code <label>} or {@code aria-labelledby} element, or by
    * the {@code aria-label} attribute.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> For example, this method will find inputs by label "Username" and "Password" in the following DOM:
    * <pre>{@code
@@ -3186,7 +3267,7 @@ public interface Locator {
    * Allows locating input elements by the text of the associated {@code <label>} or {@code aria-labelledby} element, or by
    * the {@code aria-label} attribute.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> For example, this method will find inputs by label "Username" and "Password" in the following DOM:
    * <pre>{@code
@@ -3204,7 +3285,7 @@ public interface Locator {
    * Allows locating input elements by the text of the associated {@code <label>} or {@code aria-labelledby} element, or by
    * the {@code aria-label} attribute.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> For example, this method will find inputs by label "Username" and "Password" in the following DOM:
    * <pre>{@code
@@ -3219,7 +3300,7 @@ public interface Locator {
   /**
    * Allows locating input elements by the placeholder text.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> For example, consider the following DOM structure.
    *
@@ -3237,7 +3318,7 @@ public interface Locator {
   /**
    * Allows locating input elements by the placeholder text.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> For example, consider the following DOM structure.
    *
@@ -3253,7 +3334,7 @@ public interface Locator {
   /**
    * Allows locating input elements by the placeholder text.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> For example, consider the following DOM structure.
    *
@@ -3271,7 +3352,7 @@ public interface Locator {
   /**
    * Allows locating input elements by the placeholder text.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> For example, consider the following DOM structure.
    *
@@ -3289,7 +3370,7 @@ public interface Locator {
    * href="https://www.w3.org/TR/wai-aria-1.2/#aria-attributes">ARIA attributes</a> and <a
    * href="https://w3c.github.io/accname/#dfn-accessible-name">accessible name</a>.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> Consider the following DOM structure.
    *
@@ -3310,7 +3391,7 @@ public interface Locator {
    *     .click();
    * }</pre>
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
    * <p> Role selector **does not replace** accessibility audits and conformance tests, but rather gives early feedback about the
    * ARIA guidelines.
@@ -3332,7 +3413,7 @@ public interface Locator {
    * href="https://www.w3.org/TR/wai-aria-1.2/#aria-attributes">ARIA attributes</a> and <a
    * href="https://w3c.github.io/accname/#dfn-accessible-name">accessible name</a>.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> Consider the following DOM structure.
    *
@@ -3353,7 +3434,7 @@ public interface Locator {
    *     .click();
    * }</pre>
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
    * <p> Role selector **does not replace** accessibility audits and conformance tests, but rather gives early feedback about the
    * ARIA guidelines.
@@ -3371,7 +3452,7 @@ public interface Locator {
   /**
    * Locate element by the test id.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> Consider the following DOM structure.
    *
@@ -3380,10 +3461,11 @@ public interface Locator {
    * page.getByTestId("directions").click();
    * }</pre>
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
-   * <p> By default, the {@code data-testid} attribute is used as a test id. Use {@link Selectors#setTestIdAttribute
-   * Selectors.setTestIdAttribute()} to configure a different test id attribute if necessary.
+   * <p> By default, the {@code data-testid} attribute is used as a test id. Use {@link
+   * com.microsoft.playwright.Selectors#setTestIdAttribute Selectors.setTestIdAttribute()} to configure a different test id
+   * attribute if necessary.
    *
    * @param testId Id to locate the element by.
    * @since v1.27
@@ -3392,7 +3474,7 @@ public interface Locator {
   /**
    * Locate element by the test id.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> Consider the following DOM structure.
    *
@@ -3401,10 +3483,11 @@ public interface Locator {
    * page.getByTestId("directions").click();
    * }</pre>
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
-   * <p> By default, the {@code data-testid} attribute is used as a test id. Use {@link Selectors#setTestIdAttribute
-   * Selectors.setTestIdAttribute()} to configure a different test id attribute if necessary.
+   * <p> By default, the {@code data-testid} attribute is used as a test id. Use {@link
+   * com.microsoft.playwright.Selectors#setTestIdAttribute Selectors.setTestIdAttribute()} to configure a different test id
+   * attribute if necessary.
    *
    * @param testId Id to locate the element by.
    * @since v1.27
@@ -3413,10 +3496,10 @@ public interface Locator {
   /**
    * Allows locating elements that contain given text.
    *
-   * <p> See also {@link Locator#filter Locator.filter()} that allows to match by another criteria, like an accessible role, and
-   * then filter by the text content.
+   * <p> See also {@link com.microsoft.playwright.Locator#filter Locator.filter()} that allows to match by another criteria, like
+   * an accessible role, and then filter by the text content.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> Consider the following DOM structure:
    *
@@ -3438,7 +3521,7 @@ public interface Locator {
    * page.getByText(Pattern.compile("^hello$", Pattern.CASE_INSENSITIVE))
    * }</pre>
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
    * <p> Matching by text always normalizes whitespace, even with exact match. For example, it turns multiple spaces into one,
    * turns line breaks into spaces and ignores leading and trailing whitespace.
@@ -3455,10 +3538,10 @@ public interface Locator {
   /**
    * Allows locating elements that contain given text.
    *
-   * <p> See also {@link Locator#filter Locator.filter()} that allows to match by another criteria, like an accessible role, and
-   * then filter by the text content.
+   * <p> See also {@link com.microsoft.playwright.Locator#filter Locator.filter()} that allows to match by another criteria, like
+   * an accessible role, and then filter by the text content.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> Consider the following DOM structure:
    *
@@ -3480,7 +3563,7 @@ public interface Locator {
    * page.getByText(Pattern.compile("^hello$", Pattern.CASE_INSENSITIVE))
    * }</pre>
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
    * <p> Matching by text always normalizes whitespace, even with exact match. For example, it turns multiple spaces into one,
    * turns line breaks into spaces and ignores leading and trailing whitespace.
@@ -3495,10 +3578,10 @@ public interface Locator {
   /**
    * Allows locating elements that contain given text.
    *
-   * <p> See also {@link Locator#filter Locator.filter()} that allows to match by another criteria, like an accessible role, and
-   * then filter by the text content.
+   * <p> See also {@link com.microsoft.playwright.Locator#filter Locator.filter()} that allows to match by another criteria, like
+   * an accessible role, and then filter by the text content.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> Consider the following DOM structure:
    *
@@ -3520,7 +3603,7 @@ public interface Locator {
    * page.getByText(Pattern.compile("^hello$", Pattern.CASE_INSENSITIVE))
    * }</pre>
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
    * <p> Matching by text always normalizes whitespace, even with exact match. For example, it turns multiple spaces into one,
    * turns line breaks into spaces and ignores leading and trailing whitespace.
@@ -3537,10 +3620,10 @@ public interface Locator {
   /**
    * Allows locating elements that contain given text.
    *
-   * <p> See also {@link Locator#filter Locator.filter()} that allows to match by another criteria, like an accessible role, and
-   * then filter by the text content.
+   * <p> See also {@link com.microsoft.playwright.Locator#filter Locator.filter()} that allows to match by another criteria, like
+   * an accessible role, and then filter by the text content.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> Consider the following DOM structure:
    *
@@ -3562,7 +3645,7 @@ public interface Locator {
    * page.getByText(Pattern.compile("^hello$", Pattern.CASE_INSENSITIVE))
    * }</pre>
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
    * <p> Matching by text always normalizes whitespace, even with exact match. For example, it turns multiple spaces into one,
    * turns line breaks into spaces and ignores leading and trailing whitespace.
@@ -3577,7 +3660,7 @@ public interface Locator {
   /**
    * Allows locating elements by their title attribute.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> Consider the following DOM structure.
    *
@@ -3595,7 +3678,7 @@ public interface Locator {
   /**
    * Allows locating elements by their title attribute.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> Consider the following DOM structure.
    *
@@ -3611,7 +3694,7 @@ public interface Locator {
   /**
    * Allows locating elements by their title attribute.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> Consider the following DOM structure.
    *
@@ -3629,7 +3712,7 @@ public interface Locator {
   /**
    * Allows locating elements by their title attribute.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> Consider the following DOM structure.
    *
@@ -3644,7 +3727,7 @@ public interface Locator {
   Locator getByTitle(Pattern text, GetByTitleOptions options);
   /**
    * Highlight the corresponding element(s) on the screen. Useful for debugging, don't commit the code that uses {@link
-   * Locator#highlight Locator.highlight()}.
+   * com.microsoft.playwright.Locator#highlight Locator.highlight()}.
    *
    * @since v1.20
    */
@@ -3652,19 +3735,20 @@ public interface Locator {
   /**
    * Hover over the matching element.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * page.getByRole(AriaRole.LINK).hover();
    * }</pre>
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
    * <p> This method hovers over the element by performing the following steps:
    * <ol>
    * <li> Wait for <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks on the element, unless {@code
    * force} option is set.</li>
    * <li> Scroll the element into view if needed.</li>
-   * <li> Use {@link Page#mouse Page.mouse()} to hover over the center of the element, or the specified {@code position}.</li>
+   * <li> Use {@link com.microsoft.playwright.Page#mouse Page.mouse()} to hover over the center of the element, or the specified
+   * {@code position}.</li>
    * <li> Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.</li>
    * </ol>
    *
@@ -3681,19 +3765,20 @@ public interface Locator {
   /**
    * Hover over the matching element.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * page.getByRole(AriaRole.LINK).hover();
    * }</pre>
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
    * <p> This method hovers over the element by performing the following steps:
    * <ol>
    * <li> Wait for <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks on the element, unless {@code
    * force} option is set.</li>
    * <li> Scroll the element into view if needed.</li>
-   * <li> Use {@link Page#mouse Page.mouse()} to hover over the center of the element, or the specified {@code position}.</li>
+   * <li> Use {@link com.microsoft.playwright.Page#mouse Page.mouse()} to hover over the center of the element, or the specified
+   * {@code position}.</li>
    * <li> Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.</li>
    * </ol>
    *
@@ -3723,9 +3808,9 @@ public interface Locator {
    * Returns the <a href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/innerText">{@code
    * element.innerText}</a>.
    *
-   * <p> <strong>NOTE:</strong> If you need to assert text on the page, prefer {@link LocatorAssertions#hasText LocatorAssertions.hasText()} with {@code
-   * useInnerText} option to avoid flakiness. See <a href="https://playwright.dev/java/docs/test-assertions">assertions
-   * guide</a> for more details.
+   * <p> <strong>NOTE:</strong> If you need to assert text on the page, prefer {@link com.microsoft.playwright.assertions.LocatorAssertions#hasText
+   * LocatorAssertions.hasText()} with {@code useInnerText} option to avoid flakiness. See <a
+   * href="https://playwright.dev/java/docs/test-assertions">assertions guide</a> for more details.
    *
    * @since v1.14
    */
@@ -3736,9 +3821,9 @@ public interface Locator {
    * Returns the <a href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/innerText">{@code
    * element.innerText}</a>.
    *
-   * <p> <strong>NOTE:</strong> If you need to assert text on the page, prefer {@link LocatorAssertions#hasText LocatorAssertions.hasText()} with {@code
-   * useInnerText} option to avoid flakiness. See <a href="https://playwright.dev/java/docs/test-assertions">assertions
-   * guide</a> for more details.
+   * <p> <strong>NOTE:</strong> If you need to assert text on the page, prefer {@link com.microsoft.playwright.assertions.LocatorAssertions#hasText
+   * LocatorAssertions.hasText()} with {@code useInnerText} option to avoid flakiness. See <a
+   * href="https://playwright.dev/java/docs/test-assertions">assertions guide</a> for more details.
    *
    * @since v1.14
    */
@@ -3746,15 +3831,16 @@ public interface Locator {
   /**
    * Returns the value for the matching {@code <input>} or {@code <textarea>} or {@code <select>} element.
    *
-   * <p> <strong>NOTE:</strong> If you need to assert input value, prefer {@link LocatorAssertions#hasValue LocatorAssertions.hasValue()} to avoid
-   * flakiness. See <a href="https://playwright.dev/java/docs/test-assertions">assertions guide</a> for more details.
+   * <p> <strong>NOTE:</strong> If you need to assert input value, prefer {@link com.microsoft.playwright.assertions.LocatorAssertions#hasValue
+   * LocatorAssertions.hasValue()} to avoid flakiness. See <a
+   * href="https://playwright.dev/java/docs/test-assertions">assertions guide</a> for more details.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * String value = page.getByRole(AriaRole.TEXTBOX).inputValue();
    * }</pre>
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
    * <p> Throws elements that are not an input, textarea or a select. However, if the element is inside the {@code <label>}
    * element that has an associated <a
@@ -3769,15 +3855,16 @@ public interface Locator {
   /**
    * Returns the value for the matching {@code <input>} or {@code <textarea>} or {@code <select>} element.
    *
-   * <p> <strong>NOTE:</strong> If you need to assert input value, prefer {@link LocatorAssertions#hasValue LocatorAssertions.hasValue()} to avoid
-   * flakiness. See <a href="https://playwright.dev/java/docs/test-assertions">assertions guide</a> for more details.
+   * <p> <strong>NOTE:</strong> If you need to assert input value, prefer {@link com.microsoft.playwright.assertions.LocatorAssertions#hasValue
+   * LocatorAssertions.hasValue()} to avoid flakiness. See <a
+   * href="https://playwright.dev/java/docs/test-assertions">assertions guide</a> for more details.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * String value = page.getByRole(AriaRole.TEXTBOX).inputValue();
    * }</pre>
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
    * <p> Throws elements that are not an input, textarea or a select. However, if the element is inside the {@code <label>}
    * element that has an associated <a
@@ -3790,11 +3877,11 @@ public interface Locator {
   /**
    * Returns whether the element is checked. Throws if the element is not a checkbox or radio input.
    *
-   * <p> <strong>NOTE:</strong> If you need to assert that checkbox is checked, prefer {@link LocatorAssertions#isChecked LocatorAssertions.isChecked()}
-   * to avoid flakiness. See <a href="https://playwright.dev/java/docs/test-assertions">assertions guide</a> for more
-   * details.
+   * <p> <strong>NOTE:</strong> If you need to assert that checkbox is checked, prefer {@link
+   * com.microsoft.playwright.assertions.LocatorAssertions#isChecked LocatorAssertions.isChecked()} to avoid flakiness. See
+   * <a href="https://playwright.dev/java/docs/test-assertions">assertions guide</a> for more details.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * boolean checked = page.getByRole(AriaRole.CHECKBOX).isChecked();
    * }</pre>
@@ -3807,11 +3894,11 @@ public interface Locator {
   /**
    * Returns whether the element is checked. Throws if the element is not a checkbox or radio input.
    *
-   * <p> <strong>NOTE:</strong> If you need to assert that checkbox is checked, prefer {@link LocatorAssertions#isChecked LocatorAssertions.isChecked()}
-   * to avoid flakiness. See <a href="https://playwright.dev/java/docs/test-assertions">assertions guide</a> for more
-   * details.
+   * <p> <strong>NOTE:</strong> If you need to assert that checkbox is checked, prefer {@link
+   * com.microsoft.playwright.assertions.LocatorAssertions#isChecked LocatorAssertions.isChecked()} to avoid flakiness. See
+   * <a href="https://playwright.dev/java/docs/test-assertions">assertions guide</a> for more details.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * boolean checked = page.getByRole(AriaRole.CHECKBOX).isChecked();
    * }</pre>
@@ -3823,11 +3910,11 @@ public interface Locator {
    * Returns whether the element is disabled, the opposite of <a
    * href="https://playwright.dev/java/docs/actionability#enabled">enabled</a>.
    *
-   * <p> <strong>NOTE:</strong> If you need to assert that an element is disabled, prefer {@link LocatorAssertions#isDisabled
-   * LocatorAssertions.isDisabled()} to avoid flakiness. See <a
-   * href="https://playwright.dev/java/docs/test-assertions">assertions guide</a> for more details.
+   * <p> <strong>NOTE:</strong> If you need to assert that an element is disabled, prefer {@link
+   * com.microsoft.playwright.assertions.LocatorAssertions#isDisabled LocatorAssertions.isDisabled()} to avoid flakiness. See
+   * <a href="https://playwright.dev/java/docs/test-assertions">assertions guide</a> for more details.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * boolean disabled = page.getByRole(AriaRole.BUTTON).isDisabled();
    * }</pre>
@@ -3841,11 +3928,11 @@ public interface Locator {
    * Returns whether the element is disabled, the opposite of <a
    * href="https://playwright.dev/java/docs/actionability#enabled">enabled</a>.
    *
-   * <p> <strong>NOTE:</strong> If you need to assert that an element is disabled, prefer {@link LocatorAssertions#isDisabled
-   * LocatorAssertions.isDisabled()} to avoid flakiness. See <a
-   * href="https://playwright.dev/java/docs/test-assertions">assertions guide</a> for more details.
+   * <p> <strong>NOTE:</strong> If you need to assert that an element is disabled, prefer {@link
+   * com.microsoft.playwright.assertions.LocatorAssertions#isDisabled LocatorAssertions.isDisabled()} to avoid flakiness. See
+   * <a href="https://playwright.dev/java/docs/test-assertions">assertions guide</a> for more details.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * boolean disabled = page.getByRole(AriaRole.BUTTON).isDisabled();
    * }</pre>
@@ -3856,11 +3943,11 @@ public interface Locator {
   /**
    * Returns whether the element is <a href="https://playwright.dev/java/docs/actionability#editable">editable</a>.
    *
-   * <p> <strong>NOTE:</strong> If you need to assert that an element is editable, prefer {@link LocatorAssertions#isEditable
-   * LocatorAssertions.isEditable()} to avoid flakiness. See <a
-   * href="https://playwright.dev/java/docs/test-assertions">assertions guide</a> for more details.
+   * <p> <strong>NOTE:</strong> If you need to assert that an element is editable, prefer {@link
+   * com.microsoft.playwright.assertions.LocatorAssertions#isEditable LocatorAssertions.isEditable()} to avoid flakiness. See
+   * <a href="https://playwright.dev/java/docs/test-assertions">assertions guide</a> for more details.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * boolean editable = page.getByRole(AriaRole.TEXTBOX).isEditable();
    * }</pre>
@@ -3873,11 +3960,11 @@ public interface Locator {
   /**
    * Returns whether the element is <a href="https://playwright.dev/java/docs/actionability#editable">editable</a>.
    *
-   * <p> <strong>NOTE:</strong> If you need to assert that an element is editable, prefer {@link LocatorAssertions#isEditable
-   * LocatorAssertions.isEditable()} to avoid flakiness. See <a
-   * href="https://playwright.dev/java/docs/test-assertions">assertions guide</a> for more details.
+   * <p> <strong>NOTE:</strong> If you need to assert that an element is editable, prefer {@link
+   * com.microsoft.playwright.assertions.LocatorAssertions#isEditable LocatorAssertions.isEditable()} to avoid flakiness. See
+   * <a href="https://playwright.dev/java/docs/test-assertions">assertions guide</a> for more details.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * boolean editable = page.getByRole(AriaRole.TEXTBOX).isEditable();
    * }</pre>
@@ -3888,11 +3975,11 @@ public interface Locator {
   /**
    * Returns whether the element is <a href="https://playwright.dev/java/docs/actionability#enabled">enabled</a>.
    *
-   * <p> <strong>NOTE:</strong> If you need to assert that an element is enabled, prefer {@link LocatorAssertions#isEnabled
-   * LocatorAssertions.isEnabled()} to avoid flakiness. See <a
-   * href="https://playwright.dev/java/docs/test-assertions">assertions guide</a> for more details.
+   * <p> <strong>NOTE:</strong> If you need to assert that an element is enabled, prefer {@link
+   * com.microsoft.playwright.assertions.LocatorAssertions#isEnabled LocatorAssertions.isEnabled()} to avoid flakiness. See
+   * <a href="https://playwright.dev/java/docs/test-assertions">assertions guide</a> for more details.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * boolean enabled = page.getByRole(AriaRole.BUTTON).isEnabled();
    * }</pre>
@@ -3905,11 +3992,11 @@ public interface Locator {
   /**
    * Returns whether the element is <a href="https://playwright.dev/java/docs/actionability#enabled">enabled</a>.
    *
-   * <p> <strong>NOTE:</strong> If you need to assert that an element is enabled, prefer {@link LocatorAssertions#isEnabled
-   * LocatorAssertions.isEnabled()} to avoid flakiness. See <a
-   * href="https://playwright.dev/java/docs/test-assertions">assertions guide</a> for more details.
+   * <p> <strong>NOTE:</strong> If you need to assert that an element is enabled, prefer {@link
+   * com.microsoft.playwright.assertions.LocatorAssertions#isEnabled LocatorAssertions.isEnabled()} to avoid flakiness. See
+   * <a href="https://playwright.dev/java/docs/test-assertions">assertions guide</a> for more details.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * boolean enabled = page.getByRole(AriaRole.BUTTON).isEnabled();
    * }</pre>
@@ -3921,10 +4008,11 @@ public interface Locator {
    * Returns whether the element is hidden, the opposite of <a
    * href="https://playwright.dev/java/docs/actionability#visible">visible</a>.
    *
-   * <p> <strong>NOTE:</strong> If you need to assert that element is hidden, prefer {@link LocatorAssertions#isHidden LocatorAssertions.isHidden()} to
-   * avoid flakiness. See <a href="https://playwright.dev/java/docs/test-assertions">assertions guide</a> for more details.
+   * <p> <strong>NOTE:</strong> If you need to assert that element is hidden, prefer {@link
+   * com.microsoft.playwright.assertions.LocatorAssertions#isHidden LocatorAssertions.isHidden()} to avoid flakiness. See <a
+   * href="https://playwright.dev/java/docs/test-assertions">assertions guide</a> for more details.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * boolean hidden = page.getByRole(AriaRole.BUTTON).isHidden();
    * }</pre>
@@ -3938,10 +4026,11 @@ public interface Locator {
    * Returns whether the element is hidden, the opposite of <a
    * href="https://playwright.dev/java/docs/actionability#visible">visible</a>.
    *
-   * <p> <strong>NOTE:</strong> If you need to assert that element is hidden, prefer {@link LocatorAssertions#isHidden LocatorAssertions.isHidden()} to
-   * avoid flakiness. See <a href="https://playwright.dev/java/docs/test-assertions">assertions guide</a> for more details.
+   * <p> <strong>NOTE:</strong> If you need to assert that element is hidden, prefer {@link
+   * com.microsoft.playwright.assertions.LocatorAssertions#isHidden LocatorAssertions.isHidden()} to avoid flakiness. See <a
+   * href="https://playwright.dev/java/docs/test-assertions">assertions guide</a> for more details.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * boolean hidden = page.getByRole(AriaRole.BUTTON).isHidden();
    * }</pre>
@@ -3952,11 +4041,11 @@ public interface Locator {
   /**
    * Returns whether the element is <a href="https://playwright.dev/java/docs/actionability#visible">visible</a>.
    *
-   * <p> <strong>NOTE:</strong> If you need to assert that element is visible, prefer {@link LocatorAssertions#isVisible LocatorAssertions.isVisible()}
-   * to avoid flakiness. See <a href="https://playwright.dev/java/docs/test-assertions">assertions guide</a> for more
-   * details.
+   * <p> <strong>NOTE:</strong> If you need to assert that element is visible, prefer {@link
+   * com.microsoft.playwright.assertions.LocatorAssertions#isVisible LocatorAssertions.isVisible()} to avoid flakiness. See
+   * <a href="https://playwright.dev/java/docs/test-assertions">assertions guide</a> for more details.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * boolean visible = page.getByRole(AriaRole.BUTTON).isVisible();
    * }</pre>
@@ -3969,11 +4058,11 @@ public interface Locator {
   /**
    * Returns whether the element is <a href="https://playwright.dev/java/docs/actionability#visible">visible</a>.
    *
-   * <p> <strong>NOTE:</strong> If you need to assert that element is visible, prefer {@link LocatorAssertions#isVisible LocatorAssertions.isVisible()}
-   * to avoid flakiness. See <a href="https://playwright.dev/java/docs/test-assertions">assertions guide</a> for more
-   * details.
+   * <p> <strong>NOTE:</strong> If you need to assert that element is visible, prefer {@link
+   * com.microsoft.playwright.assertions.LocatorAssertions#isVisible LocatorAssertions.isVisible()} to avoid flakiness. See
+   * <a href="https://playwright.dev/java/docs/test-assertions">assertions guide</a> for more details.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * boolean visible = page.getByRole(AriaRole.BUTTON).isVisible();
    * }</pre>
@@ -3984,7 +4073,7 @@ public interface Locator {
   /**
    * Returns locator to the last matching element.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * Locator banana = page.getByRole(AriaRole.LISTITEM).last();
    * }</pre>
@@ -3994,7 +4083,7 @@ public interface Locator {
   Locator last();
   /**
    * The method finds an element matching the specified selector in the locator's subtree. It also accepts filter options,
-   * similar to {@link Locator#filter Locator.filter()} method.
+   * similar to {@link com.microsoft.playwright.Locator#filter Locator.filter()} method.
    *
    * <p> <a href="https://playwright.dev/java/docs/locators">Learn more about locators</a>.
    *
@@ -4006,7 +4095,7 @@ public interface Locator {
   }
   /**
    * The method finds an element matching the specified selector in the locator's subtree. It also accepts filter options,
-   * similar to {@link Locator#filter Locator.filter()} method.
+   * similar to {@link com.microsoft.playwright.Locator#filter Locator.filter()} method.
    *
    * <p> <a href="https://playwright.dev/java/docs/locators">Learn more about locators</a>.
    *
@@ -4016,7 +4105,7 @@ public interface Locator {
   Locator locator(String selectorOrLocator, LocatorOptions options);
   /**
    * The method finds an element matching the specified selector in the locator's subtree. It also accepts filter options,
-   * similar to {@link Locator#filter Locator.filter()} method.
+   * similar to {@link com.microsoft.playwright.Locator#filter Locator.filter()} method.
    *
    * <p> <a href="https://playwright.dev/java/docs/locators">Learn more about locators</a>.
    *
@@ -4028,7 +4117,7 @@ public interface Locator {
   }
   /**
    * The method finds an element matching the specified selector in the locator's subtree. It also accepts filter options,
-   * similar to {@link Locator#filter Locator.filter()} method.
+   * similar to {@link com.microsoft.playwright.Locator#filter Locator.filter()} method.
    *
    * <p> <a href="https://playwright.dev/java/docs/locators">Learn more about locators</a>.
    *
@@ -4039,7 +4128,7 @@ public interface Locator {
   /**
    * Returns locator to the n-th matching element. It's zero based, {@code nth(0)} selects the first element.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * Locator banana = page.getByRole(AriaRole.LISTITEM).nth(2);
    * }</pre>
@@ -4050,7 +4139,7 @@ public interface Locator {
   /**
    * Creates a locator that matches either of the two locators.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> Consider a scenario where you'd like to click on a "New email" button, but sometimes a security settings dialog shows up
    * instead. In this case, you can wait for either a "New email" button, or a dialog and act accordingly.
@@ -4076,14 +4165,15 @@ public interface Locator {
   /**
    * Focuses the matching element and presses a combination of the keys.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * page.getByRole(AriaRole.TEXTBOX).press("Backspace");
    * }</pre>
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
-   * <p> Focuses the element, and then uses {@link Keyboard#down Keyboard.down()} and {@link Keyboard#up Keyboard.up()}.
+   * <p> Focuses the element, and then uses {@link com.microsoft.playwright.Keyboard#down Keyboard.down()} and {@link
+   * com.microsoft.playwright.Keyboard#up Keyboard.up()}.
    *
    * <p> {@code key} can specify the intended <a
    * href="https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key">keyboardEvent.key</a> value or a single
@@ -4115,14 +4205,15 @@ public interface Locator {
   /**
    * Focuses the matching element and presses a combination of the keys.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * page.getByRole(AriaRole.TEXTBOX).press("Backspace");
    * }</pre>
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
-   * <p> Focuses the element, and then uses {@link Keyboard#down Keyboard.down()} and {@link Keyboard#up Keyboard.up()}.
+   * <p> Focuses the element, and then uses {@link com.microsoft.playwright.Keyboard#down Keyboard.down()} and {@link
+   * com.microsoft.playwright.Keyboard#up Keyboard.up()}.
    *
    * <p> {@code key} can specify the intended <a
    * href="https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key">keyboardEvent.key</a> value or a single
@@ -4150,15 +4241,16 @@ public interface Locator {
    */
   void press(String key, PressOptions options);
   /**
-   * <strong>NOTE:</strong> In most cases, you should use {@link Locator#fill Locator.fill()} instead. You only need to press keys one by one if
-   * there is special keyboard handling on the page.
+   * <strong>NOTE:</strong> In most cases, you should use {@link com.microsoft.playwright.Locator#fill Locator.fill()} instead. You only need to
+   * press keys one by one if there is special keyboard handling on the page.
    *
    * <p> Focuses the element, and then sends a {@code keydown}, {@code keypress}/{@code input}, and {@code keyup} event for each
    * character in the text.
    *
-   * <p> To press a special key, like {@code Control} or {@code ArrowDown}, use {@link Locator#press Locator.press()}.
+   * <p> To press a special key, like {@code Control} or {@code ArrowDown}, use {@link com.microsoft.playwright.Locator#press
+   * Locator.press()}.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * locator.pressSequentially("Hello"); // Types instantly
    * locator.pressSequentially("World", new Locator.pressSequentiallyOptions().setDelay(100)); // Types slower, like a user
@@ -4178,15 +4270,16 @@ public interface Locator {
     pressSequentially(text, null);
   }
   /**
-   * <strong>NOTE:</strong> In most cases, you should use {@link Locator#fill Locator.fill()} instead. You only need to press keys one by one if
-   * there is special keyboard handling on the page.
+   * <strong>NOTE:</strong> In most cases, you should use {@link com.microsoft.playwright.Locator#fill Locator.fill()} instead. You only need to
+   * press keys one by one if there is special keyboard handling on the page.
    *
    * <p> Focuses the element, and then sends a {@code keydown}, {@code keypress}/{@code input}, and {@code keyup} event for each
    * character in the text.
    *
-   * <p> To press a special key, like {@code Control} or {@code ArrowDown}, use {@link Locator#press Locator.press()}.
+   * <p> To press a special key, like {@code Control} or {@code ArrowDown}, use {@link com.microsoft.playwright.Locator#press
+   * Locator.press()}.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * locator.pressSequentially("Hello"); // Types instantly
    * locator.pressSequentially("World", new Locator.pressSequentiallyOptions().setDelay(100)); // Types slower, like a user
@@ -4206,7 +4299,7 @@ public interface Locator {
   /**
    * Take a screenshot of the element matching the locator.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * page.getByRole(AriaRole.LINK).screenshot();
    * }</pre>
@@ -4218,7 +4311,7 @@ public interface Locator {
    *     .setPath(Paths.get("example.png")));
    * }</pre>
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
    * <p> This method captures a screenshot of the page, clipped to the size and position of a particular element matching the
    * locator. If the element is covered by other elements, it will not be actually visible on the screenshot. If the element
@@ -4237,7 +4330,7 @@ public interface Locator {
   /**
    * Take a screenshot of the element matching the locator.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * page.getByRole(AriaRole.LINK).screenshot();
    * }</pre>
@@ -4249,7 +4342,7 @@ public interface Locator {
    *     .setPath(Paths.get("example.png")));
    * }</pre>
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
    * <p> This method captures a screenshot of the page, clipped to the size and position of a particular element matching the
    * locator. If the element is covered by other elements, it will not be actually visible on the screenshot. If the element
@@ -4286,7 +4379,7 @@ public interface Locator {
   /**
    * Selects option or options in {@code <select>}.
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
    * <p> This method waits for <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks, waits until all
    * specified options are present in the {@code <select>} element and selects these options.
@@ -4300,7 +4393,7 @@ public interface Locator {
    *
    * <p> Triggers a {@code change} and {@code input} event once all the provided options have been selected.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * // single selection matching the value or label
    * element.selectOption("blue");
@@ -4321,7 +4414,7 @@ public interface Locator {
   /**
    * Selects option or options in {@code <select>}.
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
    * <p> This method waits for <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks, waits until all
    * specified options are present in the {@code <select>} element and selects these options.
@@ -4335,7 +4428,7 @@ public interface Locator {
    *
    * <p> Triggers a {@code change} and {@code input} event once all the provided options have been selected.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * // single selection matching the value or label
    * element.selectOption("blue");
@@ -4354,7 +4447,7 @@ public interface Locator {
   /**
    * Selects option or options in {@code <select>}.
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
    * <p> This method waits for <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks, waits until all
    * specified options are present in the {@code <select>} element and selects these options.
@@ -4368,7 +4461,7 @@ public interface Locator {
    *
    * <p> Triggers a {@code change} and {@code input} event once all the provided options have been selected.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * // single selection matching the value or label
    * element.selectOption("blue");
@@ -4389,7 +4482,7 @@ public interface Locator {
   /**
    * Selects option or options in {@code <select>}.
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
    * <p> This method waits for <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks, waits until all
    * specified options are present in the {@code <select>} element and selects these options.
@@ -4403,7 +4496,7 @@ public interface Locator {
    *
    * <p> Triggers a {@code change} and {@code input} event once all the provided options have been selected.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * // single selection matching the value or label
    * element.selectOption("blue");
@@ -4422,7 +4515,7 @@ public interface Locator {
   /**
    * Selects option or options in {@code <select>}.
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
    * <p> This method waits for <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks, waits until all
    * specified options are present in the {@code <select>} element and selects these options.
@@ -4436,7 +4529,7 @@ public interface Locator {
    *
    * <p> Triggers a {@code change} and {@code input} event once all the provided options have been selected.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * // single selection matching the value or label
    * element.selectOption("blue");
@@ -4457,7 +4550,7 @@ public interface Locator {
   /**
    * Selects option or options in {@code <select>}.
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
    * <p> This method waits for <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks, waits until all
    * specified options are present in the {@code <select>} element and selects these options.
@@ -4471,7 +4564,7 @@ public interface Locator {
    *
    * <p> Triggers a {@code change} and {@code input} event once all the provided options have been selected.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * // single selection matching the value or label
    * element.selectOption("blue");
@@ -4490,7 +4583,7 @@ public interface Locator {
   /**
    * Selects option or options in {@code <select>}.
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
    * <p> This method waits for <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks, waits until all
    * specified options are present in the {@code <select>} element and selects these options.
@@ -4504,7 +4597,7 @@ public interface Locator {
    *
    * <p> Triggers a {@code change} and {@code input} event once all the provided options have been selected.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * // single selection matching the value or label
    * element.selectOption("blue");
@@ -4525,7 +4618,7 @@ public interface Locator {
   /**
    * Selects option or options in {@code <select>}.
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
    * <p> This method waits for <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks, waits until all
    * specified options are present in the {@code <select>} element and selects these options.
@@ -4539,7 +4632,7 @@ public interface Locator {
    *
    * <p> Triggers a {@code change} and {@code input} event once all the provided options have been selected.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * // single selection matching the value or label
    * element.selectOption("blue");
@@ -4558,7 +4651,7 @@ public interface Locator {
   /**
    * Selects option or options in {@code <select>}.
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
    * <p> This method waits for <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks, waits until all
    * specified options are present in the {@code <select>} element and selects these options.
@@ -4572,7 +4665,7 @@ public interface Locator {
    *
    * <p> Triggers a {@code change} and {@code input} event once all the provided options have been selected.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * // single selection matching the value or label
    * element.selectOption("blue");
@@ -4593,7 +4686,7 @@ public interface Locator {
   /**
    * Selects option or options in {@code <select>}.
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
    * <p> This method waits for <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks, waits until all
    * specified options are present in the {@code <select>} element and selects these options.
@@ -4607,7 +4700,7 @@ public interface Locator {
    *
    * <p> Triggers a {@code change} and {@code input} event once all the provided options have been selected.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * // single selection matching the value or label
    * element.selectOption("blue");
@@ -4626,7 +4719,7 @@ public interface Locator {
   /**
    * Selects option or options in {@code <select>}.
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
    * <p> This method waits for <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks, waits until all
    * specified options are present in the {@code <select>} element and selects these options.
@@ -4640,7 +4733,7 @@ public interface Locator {
    *
    * <p> Triggers a {@code change} and {@code input} event once all the provided options have been selected.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * // single selection matching the value or label
    * element.selectOption("blue");
@@ -4661,7 +4754,7 @@ public interface Locator {
   /**
    * Selects option or options in {@code <select>}.
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
    * <p> This method waits for <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks, waits until all
    * specified options are present in the {@code <select>} element and selects these options.
@@ -4675,7 +4768,7 @@ public interface Locator {
    *
    * <p> Triggers a {@code change} and {@code input} event once all the provided options have been selected.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * // single selection matching the value or label
    * element.selectOption("blue");
@@ -4718,12 +4811,12 @@ public interface Locator {
   /**
    * Set the state of a checkbox or a radio element.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * page.getByRole(AriaRole.CHECKBOX).setChecked(true);
    * }</pre>
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
    * <p> This method checks or unchecks an element by performing the following steps:
    * <ol>
@@ -4732,7 +4825,7 @@ public interface Locator {
    * <li> Wait for <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks on the matched element,
    * unless {@code force} option is set. If the element is detached during the checks, the whole action is retried.</li>
    * <li> Scroll the element into view if needed.</li>
-   * <li> Use {@link Page#mouse Page.mouse()} to click in the center of the element.</li>
+   * <li> Use {@link com.microsoft.playwright.Page#mouse Page.mouse()} to click in the center of the element.</li>
    * <li> Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.</li>
    * <li> Ensure that the element is now checked or unchecked. If not, this method throws.</li>
    * </ol>
@@ -4749,12 +4842,12 @@ public interface Locator {
   /**
    * Set the state of a checkbox or a radio element.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * page.getByRole(AriaRole.CHECKBOX).setChecked(true);
    * }</pre>
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
    * <p> This method checks or unchecks an element by performing the following steps:
    * <ol>
@@ -4763,7 +4856,7 @@ public interface Locator {
    * <li> Wait for <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks on the matched element,
    * unless {@code force} option is set. If the element is detached during the checks, the whole action is retried.</li>
    * <li> Scroll the element into view if needed.</li>
-   * <li> Use {@link Page#mouse Page.mouse()} to click in the center of the element.</li>
+   * <li> Use {@link com.microsoft.playwright.Page#mouse Page.mouse()} to click in the center of the element.</li>
    * <li> Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.</li>
    * <li> Ensure that the element is now checked or unchecked. If not, this method throws.</li>
    * </ol>
@@ -4778,7 +4871,7 @@ public interface Locator {
   /**
    * Upload file or multiple files into {@code <input type=file>}.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * // Select one file
    * page.getByLabel("Upload file").setInputFiles(Paths.get("myfile.pdf"));
@@ -4794,7 +4887,7 @@ public interface Locator {
    *   "file.txt", "text/plain", "this is test".getBytes(StandardCharsets.UTF_8)));
    * }</pre>
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
    * <p> Sets the value of the file input to these file paths or files. If some of the {@code filePaths} are relative paths, then
    * they are resolved relative to the current working directory. For empty array, clears the selected files.
@@ -4813,7 +4906,7 @@ public interface Locator {
   /**
    * Upload file or multiple files into {@code <input type=file>}.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * // Select one file
    * page.getByLabel("Upload file").setInputFiles(Paths.get("myfile.pdf"));
@@ -4829,7 +4922,7 @@ public interface Locator {
    *   "file.txt", "text/plain", "this is test".getBytes(StandardCharsets.UTF_8)));
    * }</pre>
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
    * <p> Sets the value of the file input to these file paths or files. If some of the {@code filePaths} are relative paths, then
    * they are resolved relative to the current working directory. For empty array, clears the selected files.
@@ -4846,7 +4939,7 @@ public interface Locator {
   /**
    * Upload file or multiple files into {@code <input type=file>}.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * // Select one file
    * page.getByLabel("Upload file").setInputFiles(Paths.get("myfile.pdf"));
@@ -4862,7 +4955,7 @@ public interface Locator {
    *   "file.txt", "text/plain", "this is test".getBytes(StandardCharsets.UTF_8)));
    * }</pre>
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
    * <p> Sets the value of the file input to these file paths or files. If some of the {@code filePaths} are relative paths, then
    * they are resolved relative to the current working directory. For empty array, clears the selected files.
@@ -4881,7 +4974,7 @@ public interface Locator {
   /**
    * Upload file or multiple files into {@code <input type=file>}.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * // Select one file
    * page.getByLabel("Upload file").setInputFiles(Paths.get("myfile.pdf"));
@@ -4897,7 +4990,7 @@ public interface Locator {
    *   "file.txt", "text/plain", "this is test".getBytes(StandardCharsets.UTF_8)));
    * }</pre>
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
    * <p> Sets the value of the file input to these file paths or files. If some of the {@code filePaths} are relative paths, then
    * they are resolved relative to the current working directory. For empty array, clears the selected files.
@@ -4914,7 +5007,7 @@ public interface Locator {
   /**
    * Upload file or multiple files into {@code <input type=file>}.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * // Select one file
    * page.getByLabel("Upload file").setInputFiles(Paths.get("myfile.pdf"));
@@ -4930,7 +5023,7 @@ public interface Locator {
    *   "file.txt", "text/plain", "this is test".getBytes(StandardCharsets.UTF_8)));
    * }</pre>
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
    * <p> Sets the value of the file input to these file paths or files. If some of the {@code filePaths} are relative paths, then
    * they are resolved relative to the current working directory. For empty array, clears the selected files.
@@ -4949,7 +5042,7 @@ public interface Locator {
   /**
    * Upload file or multiple files into {@code <input type=file>}.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * // Select one file
    * page.getByLabel("Upload file").setInputFiles(Paths.get("myfile.pdf"));
@@ -4965,7 +5058,7 @@ public interface Locator {
    *   "file.txt", "text/plain", "this is test".getBytes(StandardCharsets.UTF_8)));
    * }</pre>
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
    * <p> Sets the value of the file input to these file paths or files. If some of the {@code filePaths} are relative paths, then
    * they are resolved relative to the current working directory. For empty array, clears the selected files.
@@ -4982,7 +5075,7 @@ public interface Locator {
   /**
    * Upload file or multiple files into {@code <input type=file>}.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * // Select one file
    * page.getByLabel("Upload file").setInputFiles(Paths.get("myfile.pdf"));
@@ -4998,7 +5091,7 @@ public interface Locator {
    *   "file.txt", "text/plain", "this is test".getBytes(StandardCharsets.UTF_8)));
    * }</pre>
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
    * <p> Sets the value of the file input to these file paths or files. If some of the {@code filePaths} are relative paths, then
    * they are resolved relative to the current working directory. For empty array, clears the selected files.
@@ -5017,7 +5110,7 @@ public interface Locator {
   /**
    * Upload file or multiple files into {@code <input type=file>}.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * // Select one file
    * page.getByLabel("Upload file").setInputFiles(Paths.get("myfile.pdf"));
@@ -5033,7 +5126,7 @@ public interface Locator {
    *   "file.txt", "text/plain", "this is test".getBytes(StandardCharsets.UTF_8)));
    * }</pre>
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
    * <p> Sets the value of the file input to these file paths or files. If some of the {@code filePaths} are relative paths, then
    * they are resolved relative to the current working directory. For empty array, clears the selected files.
@@ -5050,14 +5143,15 @@ public interface Locator {
   /**
    * Perform a tap gesture on the element matching the locator.
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
    * <p> This method taps the element by performing the following steps:
    * <ol>
    * <li> Wait for <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks on the element, unless {@code
    * force} option is set.</li>
    * <li> Scroll the element into view if needed.</li>
-   * <li> Use {@link Page#touchscreen Page.touchscreen()} to tap the center of the element, or the specified {@code position}.</li>
+   * <li> Use {@link com.microsoft.playwright.Page#touchscreen Page.touchscreen()} to tap the center of the element, or the
+   * specified {@code position}.</li>
    * <li> Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.</li>
    * </ol>
    *
@@ -5076,14 +5170,15 @@ public interface Locator {
   /**
    * Perform a tap gesture on the element matching the locator.
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
    * <p> This method taps the element by performing the following steps:
    * <ol>
    * <li> Wait for <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks on the element, unless {@code
    * force} option is set.</li>
    * <li> Scroll the element into view if needed.</li>
-   * <li> Use {@link Page#touchscreen Page.touchscreen()} to tap the center of the element, or the specified {@code position}.</li>
+   * <li> Use {@link com.microsoft.playwright.Page#touchscreen Page.touchscreen()} to tap the center of the element, or the
+   * specified {@code position}.</li>
    * <li> Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.</li>
    * </ol>
    *
@@ -5100,8 +5195,9 @@ public interface Locator {
   /**
    * Returns the <a href="https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent">{@code node.textContent}</a>.
    *
-   * <p> <strong>NOTE:</strong> If you need to assert text on the page, prefer {@link LocatorAssertions#hasText LocatorAssertions.hasText()} to avoid
-   * flakiness. See <a href="https://playwright.dev/java/docs/test-assertions">assertions guide</a> for more details.
+   * <p> <strong>NOTE:</strong> If you need to assert text on the page, prefer {@link com.microsoft.playwright.assertions.LocatorAssertions#hasText
+   * LocatorAssertions.hasText()} to avoid flakiness. See <a
+   * href="https://playwright.dev/java/docs/test-assertions">assertions guide</a> for more details.
    *
    * @since v1.14
    */
@@ -5111,16 +5207,17 @@ public interface Locator {
   /**
    * Returns the <a href="https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent">{@code node.textContent}</a>.
    *
-   * <p> <strong>NOTE:</strong> If you need to assert text on the page, prefer {@link LocatorAssertions#hasText LocatorAssertions.hasText()} to avoid
-   * flakiness. See <a href="https://playwright.dev/java/docs/test-assertions">assertions guide</a> for more details.
+   * <p> <strong>NOTE:</strong> If you need to assert text on the page, prefer {@link com.microsoft.playwright.assertions.LocatorAssertions#hasText
+   * LocatorAssertions.hasText()} to avoid flakiness. See <a
+   * href="https://playwright.dev/java/docs/test-assertions">assertions guide</a> for more details.
    *
    * @since v1.14
    */
   String textContent(TextContentOptions options);
   /**
-   * @deprecated In most cases, you should use {@link Locator#fill Locator.fill()} instead. You only need to press keys one by one if
-   * there is special keyboard handling on the page - in this case use {@link Locator#pressSequentially
-   * Locator.pressSequentially()}.
+   * @deprecated In most cases, you should use {@link com.microsoft.playwright.Locator#fill Locator.fill()} instead. You only need to
+   * press keys one by one if there is special keyboard handling on the page - in this case use {@link
+   * com.microsoft.playwright.Locator#pressSequentially Locator.pressSequentially()}.
    *
    * @param text A text to type into a focused element.
    * @since v1.14
@@ -5129,9 +5226,9 @@ public interface Locator {
     type(text, null);
   }
   /**
-   * @deprecated In most cases, you should use {@link Locator#fill Locator.fill()} instead. You only need to press keys one by one if
-   * there is special keyboard handling on the page - in this case use {@link Locator#pressSequentially
-   * Locator.pressSequentially()}.
+   * @deprecated In most cases, you should use {@link com.microsoft.playwright.Locator#fill Locator.fill()} instead. You only need to
+   * press keys one by one if there is special keyboard handling on the page - in this case use {@link
+   * com.microsoft.playwright.Locator#pressSequentially Locator.pressSequentially()}.
    *
    * @param text A text to type into a focused element.
    * @since v1.14
@@ -5140,12 +5237,12 @@ public interface Locator {
   /**
    * Ensure that checkbox or radio element is unchecked.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * page.getByRole(AriaRole.CHECKBOX).uncheck();
    * }</pre>
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
    * <p> This method unchecks the element by performing the following steps:
    * <ol>
@@ -5154,7 +5251,7 @@ public interface Locator {
    * <li> Wait for <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks on the element, unless {@code
    * force} option is set.</li>
    * <li> Scroll the element into view if needed.</li>
-   * <li> Use {@link Page#mouse Page.mouse()} to click in the center of the element.</li>
+   * <li> Use {@link com.microsoft.playwright.Page#mouse Page.mouse()} to click in the center of the element.</li>
    * <li> Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.</li>
    * <li> Ensure that the element is now unchecked. If not, this method throws.</li>
    * </ol>
@@ -5172,12 +5269,12 @@ public interface Locator {
   /**
    * Ensure that checkbox or radio element is unchecked.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * page.getByRole(AriaRole.CHECKBOX).uncheck();
    * }</pre>
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
    * <p> This method unchecks the element by performing the following steps:
    * <ol>
@@ -5186,7 +5283,7 @@ public interface Locator {
    * <li> Wait for <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks on the element, unless {@code
    * force} option is set.</li>
    * <li> Scroll the element into view if needed.</li>
-   * <li> Use {@link Page#mouse Page.mouse()} to click in the center of the element.</li>
+   * <li> Use {@link com.microsoft.playwright.Page#mouse Page.mouse()} to click in the center of the element.</li>
    * <li> Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.</li>
    * <li> Ensure that the element is now unchecked. If not, this method throws.</li>
    * </ol>
@@ -5205,7 +5302,7 @@ public interface Locator {
    * <p> If target element already satisfies the condition, the method returns immediately. Otherwise, waits for up to {@code
    * timeout} milliseconds until the condition is met.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * Locator orderSent = page.locator("#order-sent");
    * orderSent.waitFor();
@@ -5222,7 +5319,7 @@ public interface Locator {
    * <p> If target element already satisfies the condition, the method returns immediately. Otherwise, waits for up to {@code
    * timeout} milliseconds until the condition is met.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * Locator orderSent = page.locator("#order-sent");
    * orderSent.waitFor();

--- a/playwright/src/main/java/com/microsoft/playwright/Mouse.java
+++ b/playwright/src/main/java/com/microsoft/playwright/Mouse.java
@@ -21,7 +21,7 @@ import com.microsoft.playwright.options.*;
 /**
  * The Mouse class operates in main-frame CSS pixels relative to the top-left corner of the viewport.
  *
- * <p> Every {@code page} object has its own Mouse, accessible with {@link Page#mouse Page.mouse()}.
+ * <p> Every {@code page} object has its own Mouse, accessible with {@link com.microsoft.playwright.Page#mouse Page.mouse()}.
  * <pre>{@code
  * // Using ‘page.mouse’ to trace a 100x100 square.
  * page.mouse().move(0, 0);
@@ -160,7 +160,8 @@ public interface Mouse {
     }
   }
   /**
-   * Shortcut for {@link Mouse#move Mouse.move()}, {@link Mouse#down Mouse.down()}, {@link Mouse#up Mouse.up()}.
+   * Shortcut for {@link com.microsoft.playwright.Mouse#move Mouse.move()}, {@link com.microsoft.playwright.Mouse#down
+   * Mouse.down()}, {@link com.microsoft.playwright.Mouse#up Mouse.up()}.
    *
    * @since v1.8
    */
@@ -168,14 +169,16 @@ public interface Mouse {
     click(x, y, null);
   }
   /**
-   * Shortcut for {@link Mouse#move Mouse.move()}, {@link Mouse#down Mouse.down()}, {@link Mouse#up Mouse.up()}.
+   * Shortcut for {@link com.microsoft.playwright.Mouse#move Mouse.move()}, {@link com.microsoft.playwright.Mouse#down
+   * Mouse.down()}, {@link com.microsoft.playwright.Mouse#up Mouse.up()}.
    *
    * @since v1.8
    */
   void click(double x, double y, ClickOptions options);
   /**
-   * Shortcut for {@link Mouse#move Mouse.move()}, {@link Mouse#down Mouse.down()}, {@link Mouse#up Mouse.up()}, {@link
-   * Mouse#down Mouse.down()} and {@link Mouse#up Mouse.up()}.
+   * Shortcut for {@link com.microsoft.playwright.Mouse#move Mouse.move()}, {@link com.microsoft.playwright.Mouse#down
+   * Mouse.down()}, {@link com.microsoft.playwright.Mouse#up Mouse.up()}, {@link com.microsoft.playwright.Mouse#down
+   * Mouse.down()} and {@link com.microsoft.playwright.Mouse#up Mouse.up()}.
    *
    * @since v1.8
    */
@@ -183,8 +186,9 @@ public interface Mouse {
     dblclick(x, y, null);
   }
   /**
-   * Shortcut for {@link Mouse#move Mouse.move()}, {@link Mouse#down Mouse.down()}, {@link Mouse#up Mouse.up()}, {@link
-   * Mouse#down Mouse.down()} and {@link Mouse#up Mouse.up()}.
+   * Shortcut for {@link com.microsoft.playwright.Mouse#move Mouse.move()}, {@link com.microsoft.playwright.Mouse#down
+   * Mouse.down()}, {@link com.microsoft.playwright.Mouse#up Mouse.up()}, {@link com.microsoft.playwright.Mouse#down
+   * Mouse.down()} and {@link com.microsoft.playwright.Mouse#up Mouse.up()}.
    *
    * @since v1.8
    */

--- a/playwright/src/main/java/com/microsoft/playwright/Page.java
+++ b/playwright/src/main/java/com/microsoft/playwright/Page.java
@@ -84,7 +84,7 @@ public interface Page extends AutoCloseable {
    *
    * <p> The arguments passed into {@code console.log} are available on the {@code ConsoleMessage} event handler argument.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * page.onConsoleMessage(msg -> {
    *   for (int i = 0; i < msg.args().size(); ++i)
@@ -123,20 +123,21 @@ public interface Page extends AutoCloseable {
 
   /**
    * Emitted when a JavaScript dialog appears, such as {@code alert}, {@code prompt}, {@code confirm} or {@code
-   * beforeunload}. Listener **must** either {@link Dialog#accept Dialog.accept()} or {@link Dialog#dismiss Dialog.dismiss()}
-   * the dialog - otherwise the page will <a
+   * beforeunload}. Listener **must** either {@link com.microsoft.playwright.Dialog#accept Dialog.accept()} or {@link
+   * com.microsoft.playwright.Dialog#dismiss Dialog.dismiss()} the dialog - otherwise the page will <a
    * href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/EventLoop#never_blocking">freeze</a> waiting for the
    * dialog, and actions like click will never finish.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * page.onDialog(dialog -> {
    *   dialog.accept();
    * });
    * }</pre>
    *
-   * <p> <strong>NOTE:</strong> When no {@link Page#onDialog Page.onDialog()} or {@link BrowserContext#onDialog BrowserContext.onDialog()} listeners are
-   * present, all dialogs are automatically dismissed.
+   * <p> <strong>NOTE:</strong> When no {@link com.microsoft.playwright.Page#onDialog Page.onDialog()} or {@link
+   * com.microsoft.playwright.BrowserContext#onDialog BrowserContext.onDialog()} listeners are present, all dialogs are
+   * automatically dismissed.
    */
   void onDialog(Consumer<Dialog> handler);
   /**
@@ -166,8 +167,8 @@ public interface Page extends AutoCloseable {
 
   /**
    * Emitted when a file chooser is supposed to appear, such as after clicking the  {@code <input type=file>}. Playwright can
-   * respond to it via setting the input files using {@link FileChooser#setFiles FileChooser.setFiles()} that can be uploaded
-   * after that.
+   * respond to it via setting the input files using {@link com.microsoft.playwright.FileChooser#setFiles
+   * FileChooser.setFiles()} that can be uploaded after that.
    * <pre>{@code
    * page.onFileChooser(fileChooser -> {
    *   fileChooser.setFiles(Paths.get("/tmp/myfile.pdf"));
@@ -236,8 +237,8 @@ public interface Page extends AutoCloseable {
   void offPageError(Consumer<String> handler);
 
   /**
-   * Emitted when the page opens a new tab or window. This event is emitted in addition to the {@link BrowserContext#onPage
-   * BrowserContext.onPage()}, but only for popups relevant to this page.
+   * Emitted when the page opens a new tab or window. This event is emitted in addition to the {@link
+   * com.microsoft.playwright.BrowserContext#onPage BrowserContext.onPage()}, but only for popups relevant to this page.
    *
    * <p> The earliest moment that page is available is when it has navigated to the initial url. For example, when opening a
    * popup with {@code window.open('http://example.com')}, this event will fire when the network request to
@@ -249,8 +250,8 @@ public interface Page extends AutoCloseable {
    * System.out.println(popup.evaluate("location.href"));
    * }</pre>
    *
-   * <p> <strong>NOTE:</strong> Use {@link Page#waitForLoadState Page.waitForLoadState()} to wait until the page gets to a particular state (you should
-   * not need it in most cases).
+   * <p> <strong>NOTE:</strong> Use {@link com.microsoft.playwright.Page#waitForLoadState Page.waitForLoadState()} to wait until the page gets to a
+   * particular state (you should not need it in most cases).
    */
   void onPopup(Consumer<Page> handler);
   /**
@@ -260,7 +261,8 @@ public interface Page extends AutoCloseable {
 
   /**
    * Emitted when a page issues a request. The [request] object is read-only. In order to intercept and mutate requests, see
-   * {@link Page#route Page.route()} or {@link BrowserContext#route BrowserContext.route()}.
+   * {@link com.microsoft.playwright.Page#route Page.route()} or {@link com.microsoft.playwright.BrowserContext#route
+   * BrowserContext.route()}.
    */
   void onRequest(Consumer<Request> handler);
   /**
@@ -277,9 +279,9 @@ public interface Page extends AutoCloseable {
    * }</pre>
    *
    * <p> <strong>NOTE:</strong> HTTP Error responses, such as 404 or 503, are still successful responses from HTTP standpoint, so request will complete
-   * with {@link Page#onRequestFinished Page.onRequestFinished()} event and not with {@link Page#onRequestFailed
-   * Page.onRequestFailed()}. A request will only be considered failed when the client cannot get an HTTP response from the
-   * server, e.g. due to network error net::ERR_FAILED.
+   * with {@link com.microsoft.playwright.Page#onRequestFinished Page.onRequestFinished()} event and not with {@link
+   * com.microsoft.playwright.Page#onRequestFailed Page.onRequestFailed()}. A request will only be considered failed when the
+   * client cannot get an HTTP response from the server, e.g. due to network error net::ERR_FAILED.
    */
   void onRequestFailed(Consumer<Request> handler);
   /**
@@ -439,8 +441,9 @@ public interface Page extends AutoCloseable {
     public Boolean strict;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
     /**
@@ -492,8 +495,9 @@ public interface Page extends AutoCloseable {
     }
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public CheckOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -550,8 +554,9 @@ public interface Page extends AutoCloseable {
     public Boolean strict;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
     /**
@@ -632,8 +637,9 @@ public interface Page extends AutoCloseable {
     }
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public ClickOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -713,8 +719,9 @@ public interface Page extends AutoCloseable {
     public Boolean strict;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
     /**
@@ -788,8 +795,9 @@ public interface Page extends AutoCloseable {
     }
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public DblclickOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -813,8 +821,9 @@ public interface Page extends AutoCloseable {
     public Boolean strict;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
 
@@ -828,8 +837,9 @@ public interface Page extends AutoCloseable {
     }
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public DispatchEventOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -865,8 +875,9 @@ public interface Page extends AutoCloseable {
     public Position targetPosition;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
     /**
@@ -933,8 +944,9 @@ public interface Page extends AutoCloseable {
     }
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public DragAndDropOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -1056,8 +1068,9 @@ public interface Page extends AutoCloseable {
     public Boolean strict;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
 
@@ -1088,8 +1101,9 @@ public interface Page extends AutoCloseable {
     }
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public FillOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -1104,8 +1118,9 @@ public interface Page extends AutoCloseable {
     public Boolean strict;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
 
@@ -1119,8 +1134,9 @@ public interface Page extends AutoCloseable {
     }
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public FocusOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -1135,8 +1151,9 @@ public interface Page extends AutoCloseable {
     public Boolean strict;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
 
@@ -1150,8 +1167,9 @@ public interface Page extends AutoCloseable {
     }
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public GetAttributeOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -1395,9 +1413,11 @@ public interface Page extends AutoCloseable {
   class GoBackOptions {
     /**
      * Maximum operation time in milliseconds, defaults to 30 seconds, pass {@code 0} to disable timeout. The default value can
-     * be changed by using the {@link BrowserContext#setDefaultNavigationTimeout BrowserContext.setDefaultNavigationTimeout()},
-     * {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()}, {@link Page#setDefaultNavigationTimeout
-     * Page.setDefaultNavigationTimeout()} or {@link Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultNavigationTimeout
+     * BrowserContext.setDefaultNavigationTimeout()}, {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()}, {@link com.microsoft.playwright.Page#setDefaultNavigationTimeout
+     * Page.setDefaultNavigationTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
     /**
@@ -1414,9 +1434,11 @@ public interface Page extends AutoCloseable {
 
     /**
      * Maximum operation time in milliseconds, defaults to 30 seconds, pass {@code 0} to disable timeout. The default value can
-     * be changed by using the {@link BrowserContext#setDefaultNavigationTimeout BrowserContext.setDefaultNavigationTimeout()},
-     * {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()}, {@link Page#setDefaultNavigationTimeout
-     * Page.setDefaultNavigationTimeout()} or {@link Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultNavigationTimeout
+     * BrowserContext.setDefaultNavigationTimeout()}, {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()}, {@link com.microsoft.playwright.Page#setDefaultNavigationTimeout
+     * Page.setDefaultNavigationTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public GoBackOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -1440,9 +1462,11 @@ public interface Page extends AutoCloseable {
   class GoForwardOptions {
     /**
      * Maximum operation time in milliseconds, defaults to 30 seconds, pass {@code 0} to disable timeout. The default value can
-     * be changed by using the {@link BrowserContext#setDefaultNavigationTimeout BrowserContext.setDefaultNavigationTimeout()},
-     * {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()}, {@link Page#setDefaultNavigationTimeout
-     * Page.setDefaultNavigationTimeout()} or {@link Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultNavigationTimeout
+     * BrowserContext.setDefaultNavigationTimeout()}, {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()}, {@link com.microsoft.playwright.Page#setDefaultNavigationTimeout
+     * Page.setDefaultNavigationTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
     /**
@@ -1459,9 +1483,11 @@ public interface Page extends AutoCloseable {
 
     /**
      * Maximum operation time in milliseconds, defaults to 30 seconds, pass {@code 0} to disable timeout. The default value can
-     * be changed by using the {@link BrowserContext#setDefaultNavigationTimeout BrowserContext.setDefaultNavigationTimeout()},
-     * {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()}, {@link Page#setDefaultNavigationTimeout
-     * Page.setDefaultNavigationTimeout()} or {@link Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultNavigationTimeout
+     * BrowserContext.setDefaultNavigationTimeout()}, {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()}, {@link com.microsoft.playwright.Page#setDefaultNavigationTimeout
+     * Page.setDefaultNavigationTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public GoForwardOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -1485,14 +1511,16 @@ public interface Page extends AutoCloseable {
   class NavigateOptions {
     /**
      * Referer header value. If provided it will take preference over the referer header value set by {@link
-     * Page#setExtraHTTPHeaders Page.setExtraHTTPHeaders()}.
+     * com.microsoft.playwright.Page#setExtraHTTPHeaders Page.setExtraHTTPHeaders()}.
      */
     public String referer;
     /**
      * Maximum operation time in milliseconds, defaults to 30 seconds, pass {@code 0} to disable timeout. The default value can
-     * be changed by using the {@link BrowserContext#setDefaultNavigationTimeout BrowserContext.setDefaultNavigationTimeout()},
-     * {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()}, {@link Page#setDefaultNavigationTimeout
-     * Page.setDefaultNavigationTimeout()} or {@link Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultNavigationTimeout
+     * BrowserContext.setDefaultNavigationTimeout()}, {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()}, {@link com.microsoft.playwright.Page#setDefaultNavigationTimeout
+     * Page.setDefaultNavigationTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
     /**
@@ -1509,7 +1537,7 @@ public interface Page extends AutoCloseable {
 
     /**
      * Referer header value. If provided it will take preference over the referer header value set by {@link
-     * Page#setExtraHTTPHeaders Page.setExtraHTTPHeaders()}.
+     * com.microsoft.playwright.Page#setExtraHTTPHeaders Page.setExtraHTTPHeaders()}.
      */
     public NavigateOptions setReferer(String referer) {
       this.referer = referer;
@@ -1517,9 +1545,11 @@ public interface Page extends AutoCloseable {
     }
     /**
      * Maximum operation time in milliseconds, defaults to 30 seconds, pass {@code 0} to disable timeout. The default value can
-     * be changed by using the {@link BrowserContext#setDefaultNavigationTimeout BrowserContext.setDefaultNavigationTimeout()},
-     * {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()}, {@link Page#setDefaultNavigationTimeout
-     * Page.setDefaultNavigationTimeout()} or {@link Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultNavigationTimeout
+     * BrowserContext.setDefaultNavigationTimeout()}, {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()}, {@link com.microsoft.playwright.Page#setDefaultNavigationTimeout
+     * Page.setDefaultNavigationTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public NavigateOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -1569,8 +1599,9 @@ public interface Page extends AutoCloseable {
     public Boolean strict;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
     /**
@@ -1630,8 +1661,9 @@ public interface Page extends AutoCloseable {
     }
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public HoverOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -1655,8 +1687,9 @@ public interface Page extends AutoCloseable {
     public Boolean strict;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
 
@@ -1670,8 +1703,9 @@ public interface Page extends AutoCloseable {
     }
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public InnerHTMLOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -1686,8 +1720,9 @@ public interface Page extends AutoCloseable {
     public Boolean strict;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
 
@@ -1701,8 +1736,9 @@ public interface Page extends AutoCloseable {
     }
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public InnerTextOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -1717,8 +1753,9 @@ public interface Page extends AutoCloseable {
     public Boolean strict;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
 
@@ -1732,8 +1769,9 @@ public interface Page extends AutoCloseable {
     }
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public InputValueOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -1748,8 +1786,9 @@ public interface Page extends AutoCloseable {
     public Boolean strict;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
 
@@ -1763,8 +1802,9 @@ public interface Page extends AutoCloseable {
     }
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public IsCheckedOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -1779,8 +1819,9 @@ public interface Page extends AutoCloseable {
     public Boolean strict;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
 
@@ -1794,8 +1835,9 @@ public interface Page extends AutoCloseable {
     }
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public IsDisabledOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -1810,8 +1852,9 @@ public interface Page extends AutoCloseable {
     public Boolean strict;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
 
@@ -1825,8 +1868,9 @@ public interface Page extends AutoCloseable {
     }
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public IsEditableOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -1841,8 +1885,9 @@ public interface Page extends AutoCloseable {
     public Boolean strict;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
 
@@ -1856,8 +1901,9 @@ public interface Page extends AutoCloseable {
     }
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public IsEnabledOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -1871,8 +1917,8 @@ public interface Page extends AutoCloseable {
      */
     public Boolean strict;
     /**
-     * @deprecated This option is ignored. {@link Page#isHidden Page.isHidden()} does not wait for the element to become hidden and returns
-     * immediately.
+     * @deprecated This option is ignored. {@link com.microsoft.playwright.Page#isHidden Page.isHidden()} does not wait for the element to
+     * become hidden and returns immediately.
      */
     public Double timeout;
 
@@ -1885,8 +1931,8 @@ public interface Page extends AutoCloseable {
       return this;
     }
     /**
-     * @deprecated This option is ignored. {@link Page#isHidden Page.isHidden()} does not wait for the element to become hidden and returns
-     * immediately.
+     * @deprecated This option is ignored. {@link com.microsoft.playwright.Page#isHidden Page.isHidden()} does not wait for the element to
+     * become hidden and returns immediately.
      */
     public IsHiddenOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -1900,8 +1946,8 @@ public interface Page extends AutoCloseable {
      */
     public Boolean strict;
     /**
-     * @deprecated This option is ignored. {@link Page#isVisible Page.isVisible()} does not wait for the element to become visible and
-     * returns immediately.
+     * @deprecated This option is ignored. {@link com.microsoft.playwright.Page#isVisible Page.isVisible()} does not wait for the element
+     * to become visible and returns immediately.
      */
     public Double timeout;
 
@@ -1914,8 +1960,8 @@ public interface Page extends AutoCloseable {
       return this;
     }
     /**
-     * @deprecated This option is ignored. {@link Page#isVisible Page.isVisible()} does not wait for the element to become visible and
-     * returns immediately.
+     * @deprecated This option is ignored. {@link com.microsoft.playwright.Page#isVisible Page.isVisible()} does not wait for the element
+     * to become visible and returns immediately.
      */
     public IsVisibleOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -2224,8 +2270,9 @@ public interface Page extends AutoCloseable {
     public Boolean strict;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
 
@@ -2255,8 +2302,9 @@ public interface Page extends AutoCloseable {
     }
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public PressOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -2282,9 +2330,11 @@ public interface Page extends AutoCloseable {
   class ReloadOptions {
     /**
      * Maximum operation time in milliseconds, defaults to 30 seconds, pass {@code 0} to disable timeout. The default value can
-     * be changed by using the {@link BrowserContext#setDefaultNavigationTimeout BrowserContext.setDefaultNavigationTimeout()},
-     * {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()}, {@link Page#setDefaultNavigationTimeout
-     * Page.setDefaultNavigationTimeout()} or {@link Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultNavigationTimeout
+     * BrowserContext.setDefaultNavigationTimeout()}, {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()}, {@link com.microsoft.playwright.Page#setDefaultNavigationTimeout
+     * Page.setDefaultNavigationTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
     /**
@@ -2301,9 +2351,11 @@ public interface Page extends AutoCloseable {
 
     /**
      * Maximum operation time in milliseconds, defaults to 30 seconds, pass {@code 0} to disable timeout. The default value can
-     * be changed by using the {@link BrowserContext#setDefaultNavigationTimeout BrowserContext.setDefaultNavigationTimeout()},
-     * {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()}, {@link Page#setDefaultNavigationTimeout
-     * Page.setDefaultNavigationTimeout()} or {@link Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultNavigationTimeout
+     * BrowserContext.setDefaultNavigationTimeout()}, {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()}, {@link com.microsoft.playwright.Page#setDefaultNavigationTimeout
+     * Page.setDefaultNavigationTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public ReloadOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -2350,7 +2402,7 @@ public interface Page extends AutoCloseable {
     public HarNotFound notFound;
     /**
      * If specified, updates the given HAR with the actual network information instead of serving from file. The file is
-     * written to disk when {@link BrowserContext#close BrowserContext.close()} is called.
+     * written to disk when {@link com.microsoft.playwright.BrowserContext#close BrowserContext.close()} is called.
      */
     public Boolean update;
     /**
@@ -2384,7 +2436,7 @@ public interface Page extends AutoCloseable {
     }
     /**
      * If specified, updates the given HAR with the actual network information instead of serving from file. The file is
-     * written to disk when {@link BrowserContext#close BrowserContext.close()} is called.
+     * written to disk when {@link com.microsoft.playwright.BrowserContext#close BrowserContext.close()} is called.
      */
     public RouteFromHAROptions setUpdate(boolean update) {
       this.update = update;
@@ -2492,8 +2544,9 @@ public interface Page extends AutoCloseable {
     public String style;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
     /**
@@ -2607,8 +2660,9 @@ public interface Page extends AutoCloseable {
     }
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public ScreenshotOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -2641,8 +2695,9 @@ public interface Page extends AutoCloseable {
     public Boolean strict;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
 
@@ -2673,8 +2728,9 @@ public interface Page extends AutoCloseable {
     }
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public SelectOptionOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -2705,8 +2761,9 @@ public interface Page extends AutoCloseable {
     public Boolean strict;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
     /**
@@ -2758,8 +2815,9 @@ public interface Page extends AutoCloseable {
     }
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public SetCheckedOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -2778,9 +2836,11 @@ public interface Page extends AutoCloseable {
   class SetContentOptions {
     /**
      * Maximum operation time in milliseconds, defaults to 30 seconds, pass {@code 0} to disable timeout. The default value can
-     * be changed by using the {@link BrowserContext#setDefaultNavigationTimeout BrowserContext.setDefaultNavigationTimeout()},
-     * {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()}, {@link Page#setDefaultNavigationTimeout
-     * Page.setDefaultNavigationTimeout()} or {@link Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultNavigationTimeout
+     * BrowserContext.setDefaultNavigationTimeout()}, {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()}, {@link com.microsoft.playwright.Page#setDefaultNavigationTimeout
+     * Page.setDefaultNavigationTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
     /**
@@ -2797,9 +2857,11 @@ public interface Page extends AutoCloseable {
 
     /**
      * Maximum operation time in milliseconds, defaults to 30 seconds, pass {@code 0} to disable timeout. The default value can
-     * be changed by using the {@link BrowserContext#setDefaultNavigationTimeout BrowserContext.setDefaultNavigationTimeout()},
-     * {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()}, {@link Page#setDefaultNavigationTimeout
-     * Page.setDefaultNavigationTimeout()} or {@link Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultNavigationTimeout
+     * BrowserContext.setDefaultNavigationTimeout()}, {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()}, {@link com.microsoft.playwright.Page#setDefaultNavigationTimeout
+     * Page.setDefaultNavigationTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public SetContentOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -2834,8 +2896,9 @@ public interface Page extends AutoCloseable {
     public Boolean strict;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
 
@@ -2858,8 +2921,9 @@ public interface Page extends AutoCloseable {
     }
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public SetInputFilesOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -2895,8 +2959,9 @@ public interface Page extends AutoCloseable {
     public Boolean strict;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
     /**
@@ -2956,8 +3021,9 @@ public interface Page extends AutoCloseable {
     }
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public TapOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -2981,8 +3047,9 @@ public interface Page extends AutoCloseable {
     public Boolean strict;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
 
@@ -2996,8 +3063,9 @@ public interface Page extends AutoCloseable {
     }
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public TextContentOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -3022,8 +3090,9 @@ public interface Page extends AutoCloseable {
     public Boolean strict;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
 
@@ -3053,8 +3122,9 @@ public interface Page extends AutoCloseable {
     }
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public TypeOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -3085,8 +3155,9 @@ public interface Page extends AutoCloseable {
     public Boolean strict;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
     /**
@@ -3138,8 +3209,9 @@ public interface Page extends AutoCloseable {
     }
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public UncheckOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -3158,13 +3230,15 @@ public interface Page extends AutoCloseable {
   class WaitForCloseOptions {
     /**
      * Maximum time to wait for in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The
-     * default value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()}.
+     * default value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()}.
      */
     public Double timeout;
 
     /**
      * Maximum time to wait for in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The
-     * default value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()}.
+     * default value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()}.
      */
     public WaitForCloseOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -3178,7 +3252,8 @@ public interface Page extends AutoCloseable {
     public Predicate<ConsoleMessage> predicate;
     /**
      * Maximum time to wait for in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The
-     * default value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()}.
+     * default value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()}.
      */
     public Double timeout;
 
@@ -3191,7 +3266,8 @@ public interface Page extends AutoCloseable {
     }
     /**
      * Maximum time to wait for in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The
-     * default value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()}.
+     * default value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()}.
      */
     public WaitForConsoleMessageOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -3205,7 +3281,8 @@ public interface Page extends AutoCloseable {
     public Predicate<Download> predicate;
     /**
      * Maximum time to wait for in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The
-     * default value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()}.
+     * default value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()}.
      */
     public Double timeout;
 
@@ -3218,7 +3295,8 @@ public interface Page extends AutoCloseable {
     }
     /**
      * Maximum time to wait for in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The
-     * default value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()}.
+     * default value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()}.
      */
     public WaitForDownloadOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -3232,7 +3310,8 @@ public interface Page extends AutoCloseable {
     public Predicate<FileChooser> predicate;
     /**
      * Maximum time to wait for in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The
-     * default value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()}.
+     * default value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()}.
      */
     public Double timeout;
 
@@ -3245,7 +3324,8 @@ public interface Page extends AutoCloseable {
     }
     /**
      * Maximum time to wait for in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The
-     * default value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()}.
+     * default value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()}.
      */
     public WaitForFileChooserOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -3260,8 +3340,9 @@ public interface Page extends AutoCloseable {
     public Double pollingInterval;
     /**
      * Maximum time to wait for in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The
-     * default value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or
-     * {@link Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * default value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
 
@@ -3275,8 +3356,9 @@ public interface Page extends AutoCloseable {
     }
     /**
      * Maximum time to wait for in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The
-     * default value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or
-     * {@link Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * default value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public WaitForFunctionOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -3286,17 +3368,21 @@ public interface Page extends AutoCloseable {
   class WaitForLoadStateOptions {
     /**
      * Maximum operation time in milliseconds, defaults to 30 seconds, pass {@code 0} to disable timeout. The default value can
-     * be changed by using the {@link BrowserContext#setDefaultNavigationTimeout BrowserContext.setDefaultNavigationTimeout()},
-     * {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()}, {@link Page#setDefaultNavigationTimeout
-     * Page.setDefaultNavigationTimeout()} or {@link Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultNavigationTimeout
+     * BrowserContext.setDefaultNavigationTimeout()}, {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()}, {@link com.microsoft.playwright.Page#setDefaultNavigationTimeout
+     * Page.setDefaultNavigationTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
 
     /**
      * Maximum operation time in milliseconds, defaults to 30 seconds, pass {@code 0} to disable timeout. The default value can
-     * be changed by using the {@link BrowserContext#setDefaultNavigationTimeout BrowserContext.setDefaultNavigationTimeout()},
-     * {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()}, {@link Page#setDefaultNavigationTimeout
-     * Page.setDefaultNavigationTimeout()} or {@link Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultNavigationTimeout
+     * BrowserContext.setDefaultNavigationTimeout()}, {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()}, {@link com.microsoft.playwright.Page#setDefaultNavigationTimeout
+     * Page.setDefaultNavigationTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public WaitForLoadStateOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -3306,9 +3392,11 @@ public interface Page extends AutoCloseable {
   class WaitForNavigationOptions {
     /**
      * Maximum operation time in milliseconds, defaults to 30 seconds, pass {@code 0} to disable timeout. The default value can
-     * be changed by using the {@link BrowserContext#setDefaultNavigationTimeout BrowserContext.setDefaultNavigationTimeout()},
-     * {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()}, {@link Page#setDefaultNavigationTimeout
-     * Page.setDefaultNavigationTimeout()} or {@link Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultNavigationTimeout
+     * BrowserContext.setDefaultNavigationTimeout()}, {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()}, {@link com.microsoft.playwright.Page#setDefaultNavigationTimeout
+     * Page.setDefaultNavigationTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
     /**
@@ -3331,9 +3419,11 @@ public interface Page extends AutoCloseable {
 
     /**
      * Maximum operation time in milliseconds, defaults to 30 seconds, pass {@code 0} to disable timeout. The default value can
-     * be changed by using the {@link BrowserContext#setDefaultNavigationTimeout BrowserContext.setDefaultNavigationTimeout()},
-     * {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()}, {@link Page#setDefaultNavigationTimeout
-     * Page.setDefaultNavigationTimeout()} or {@link Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultNavigationTimeout
+     * BrowserContext.setDefaultNavigationTimeout()}, {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()}, {@link com.microsoft.playwright.Page#setDefaultNavigationTimeout
+     * Page.setDefaultNavigationTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public WaitForNavigationOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -3388,7 +3478,8 @@ public interface Page extends AutoCloseable {
     public Predicate<Page> predicate;
     /**
      * Maximum time to wait for in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The
-     * default value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()}.
+     * default value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()}.
      */
     public Double timeout;
 
@@ -3401,7 +3492,8 @@ public interface Page extends AutoCloseable {
     }
     /**
      * Maximum time to wait for in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The
-     * default value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()}.
+     * default value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()}.
      */
     public WaitForPopupOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -3411,13 +3503,13 @@ public interface Page extends AutoCloseable {
   class WaitForRequestOptions {
     /**
      * Maximum wait time in milliseconds, defaults to 30 seconds, pass {@code 0} to disable the timeout. The default value can
-     * be changed by using the {@link Page#setDefaultTimeout Page.setDefaultTimeout()} method.
+     * be changed by using the {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()} method.
      */
     public Double timeout;
 
     /**
      * Maximum wait time in milliseconds, defaults to 30 seconds, pass {@code 0} to disable the timeout. The default value can
-     * be changed by using the {@link Page#setDefaultTimeout Page.setDefaultTimeout()} method.
+     * be changed by using the {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()} method.
      */
     public WaitForRequestOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -3431,7 +3523,8 @@ public interface Page extends AutoCloseable {
     public Predicate<Request> predicate;
     /**
      * Maximum time to wait for in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The
-     * default value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()}.
+     * default value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()}.
      */
     public Double timeout;
 
@@ -3444,7 +3537,8 @@ public interface Page extends AutoCloseable {
     }
     /**
      * Maximum time to wait for in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The
-     * default value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()}.
+     * default value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()}.
      */
     public WaitForRequestFinishedOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -3454,15 +3548,17 @@ public interface Page extends AutoCloseable {
   class WaitForResponseOptions {
     /**
      * Maximum wait time in milliseconds, defaults to 30 seconds, pass {@code 0} to disable the timeout. The default value can
-     * be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
 
     /**
      * Maximum wait time in milliseconds, defaults to 30 seconds, pass {@code 0} to disable the timeout. The default value can
-     * be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public WaitForResponseOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -3489,8 +3585,9 @@ public interface Page extends AutoCloseable {
     public Boolean strict;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
 
@@ -3519,8 +3616,9 @@ public interface Page extends AutoCloseable {
     }
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
-     * value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or {@link
-     * Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public WaitForSelectorOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -3530,15 +3628,17 @@ public interface Page extends AutoCloseable {
   class WaitForConditionOptions {
     /**
      * Maximum time to wait for in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The
-     * default value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or
-     * {@link Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * default value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
 
     /**
      * Maximum time to wait for in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The
-     * default value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} or
-     * {@link Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * default value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public WaitForConditionOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -3548,9 +3648,11 @@ public interface Page extends AutoCloseable {
   class WaitForURLOptions {
     /**
      * Maximum operation time in milliseconds, defaults to 30 seconds, pass {@code 0} to disable timeout. The default value can
-     * be changed by using the {@link BrowserContext#setDefaultNavigationTimeout BrowserContext.setDefaultNavigationTimeout()},
-     * {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()}, {@link Page#setDefaultNavigationTimeout
-     * Page.setDefaultNavigationTimeout()} or {@link Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultNavigationTimeout
+     * BrowserContext.setDefaultNavigationTimeout()}, {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()}, {@link com.microsoft.playwright.Page#setDefaultNavigationTimeout
+     * Page.setDefaultNavigationTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public Double timeout;
     /**
@@ -3567,9 +3669,11 @@ public interface Page extends AutoCloseable {
 
     /**
      * Maximum operation time in milliseconds, defaults to 30 seconds, pass {@code 0} to disable timeout. The default value can
-     * be changed by using the {@link BrowserContext#setDefaultNavigationTimeout BrowserContext.setDefaultNavigationTimeout()},
-     * {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()}, {@link Page#setDefaultNavigationTimeout
-     * Page.setDefaultNavigationTimeout()} or {@link Page#setDefaultTimeout Page.setDefaultTimeout()} methods.
+     * be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultNavigationTimeout
+     * BrowserContext.setDefaultNavigationTimeout()}, {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()}, {@link com.microsoft.playwright.Page#setDefaultNavigationTimeout
+     * Page.setDefaultNavigationTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
+     * methods.
      */
     public WaitForURLOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -3597,7 +3701,8 @@ public interface Page extends AutoCloseable {
     public Predicate<WebSocket> predicate;
     /**
      * Maximum time to wait for in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The
-     * default value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()}.
+     * default value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()}.
      */
     public Double timeout;
 
@@ -3610,7 +3715,8 @@ public interface Page extends AutoCloseable {
     }
     /**
      * Maximum time to wait for in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The
-     * default value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()}.
+     * default value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()}.
      */
     public WaitForWebSocketOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -3624,7 +3730,8 @@ public interface Page extends AutoCloseable {
     public Predicate<Worker> predicate;
     /**
      * Maximum time to wait for in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The
-     * default value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()}.
+     * default value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()}.
      */
     public Double timeout;
 
@@ -3637,7 +3744,8 @@ public interface Page extends AutoCloseable {
     }
     /**
      * Maximum time to wait for in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The
-     * default value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()}.
+     * default value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()}.
      */
     public WaitForWorkerOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -3655,7 +3763,7 @@ public interface Page extends AutoCloseable {
    * <p> The script is evaluated after the document was created but before any of its scripts were run. This is useful to amend
    * the JavaScript environment, e.g. to seed {@code Math.random}.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> An example of overriding {@code Math.random} before the page loads:
    * <pre>{@code
@@ -3663,8 +3771,9 @@ public interface Page extends AutoCloseable {
    * page.addInitScript(Paths.get("./preload.js"));
    * }</pre>
    *
-   * <p> <strong>NOTE:</strong> The order of evaluation of multiple scripts installed via {@link BrowserContext#addInitScript
-   * BrowserContext.addInitScript()} and {@link Page#addInitScript Page.addInitScript()} is not defined.
+   * <p> <strong>NOTE:</strong> The order of evaluation of multiple scripts installed via {@link com.microsoft.playwright.BrowserContext#addInitScript
+   * BrowserContext.addInitScript()} and {@link com.microsoft.playwright.Page#addInitScript Page.addInitScript()} is not
+   * defined.
    *
    * @param script Script to be evaluated in all pages in the browser context.
    * @since v1.8
@@ -3681,7 +3790,7 @@ public interface Page extends AutoCloseable {
    * <p> The script is evaluated after the document was created but before any of its scripts were run. This is useful to amend
    * the JavaScript environment, e.g. to seed {@code Math.random}.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> An example of overriding {@code Math.random} before the page loads:
    * <pre>{@code
@@ -3689,8 +3798,9 @@ public interface Page extends AutoCloseable {
    * page.addInitScript(Paths.get("./preload.js"));
    * }</pre>
    *
-   * <p> <strong>NOTE:</strong> The order of evaluation of multiple scripts installed via {@link BrowserContext#addInitScript
-   * BrowserContext.addInitScript()} and {@link Page#addInitScript Page.addInitScript()} is not defined.
+   * <p> <strong>NOTE:</strong> The order of evaluation of multiple scripts installed via {@link com.microsoft.playwright.BrowserContext#addInitScript
+   * BrowserContext.addInitScript()} and {@link com.microsoft.playwright.Page#addInitScript Page.addInitScript()} is not
+   * defined.
    *
    * @param script Script to be evaluated in all pages in the browser context.
    * @since v1.8
@@ -3745,7 +3855,7 @@ public interface Page extends AutoCloseable {
    * <li> Wait for <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks on the matched element,
    * unless {@code force} option is set. If the element is detached during the checks, the whole action is retried.</li>
    * <li> Scroll the element into view if needed.</li>
-   * <li> Use {@link Page#mouse Page.mouse()} to click in the center of the element.</li>
+   * <li> Use {@link com.microsoft.playwright.Page#mouse Page.mouse()} to click in the center of the element.</li>
    * <li> Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.</li>
    * <li> Ensure that the element is now checked. If not, this method throws.</li>
    * </ol>
@@ -3768,7 +3878,7 @@ public interface Page extends AutoCloseable {
    * <li> Wait for <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks on the matched element,
    * unless {@code force} option is set. If the element is detached during the checks, the whole action is retried.</li>
    * <li> Scroll the element into view if needed.</li>
-   * <li> Use {@link Page#mouse Page.mouse()} to click in the center of the element.</li>
+   * <li> Use {@link com.microsoft.playwright.Page#mouse Page.mouse()} to click in the center of the element.</li>
    * <li> Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.</li>
    * <li> Ensure that the element is now checked. If not, this method throws.</li>
    * </ol>
@@ -3787,7 +3897,8 @@ public interface Page extends AutoCloseable {
    * <li> Wait for <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks on the matched element,
    * unless {@code force} option is set. If the element is detached during the checks, the whole action is retried.</li>
    * <li> Scroll the element into view if needed.</li>
-   * <li> Use {@link Page#mouse Page.mouse()} to click in the center of the element, or the specified {@code position}.</li>
+   * <li> Use {@link com.microsoft.playwright.Page#mouse Page.mouse()} to click in the center of the element, or the specified
+   * {@code position}.</li>
    * <li> Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.</li>
    * </ol>
    *
@@ -3807,7 +3918,8 @@ public interface Page extends AutoCloseable {
    * <li> Wait for <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks on the matched element,
    * unless {@code force} option is set. If the element is detached during the checks, the whole action is retried.</li>
    * <li> Scroll the element into view if needed.</li>
-   * <li> Use {@link Page#mouse Page.mouse()} to click in the center of the element, or the specified {@code position}.</li>
+   * <li> Use {@link com.microsoft.playwright.Page#mouse Page.mouse()} to click in the center of the element, or the specified
+   * {@code position}.</li>
    * <li> Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.</li>
    * </ol>
    *
@@ -3826,7 +3938,7 @@ public interface Page extends AutoCloseable {
    * <p> By default, {@code page.close()} **does not** run {@code beforeunload} handlers.
    *
    * <p> <strong>NOTE:</strong> if {@code runBeforeUnload} is passed as true, a {@code beforeunload} dialog might be summoned and should be handled
-   * manually via {@link Page#onDialog Page.onDialog()} event.
+   * manually via {@link com.microsoft.playwright.Page#onDialog Page.onDialog()} event.
    *
    * @since v1.8
    */
@@ -3841,7 +3953,7 @@ public interface Page extends AutoCloseable {
    * <p> By default, {@code page.close()} **does not** run {@code beforeunload} handlers.
    *
    * <p> <strong>NOTE:</strong> if {@code runBeforeUnload} is passed as true, a {@code beforeunload} dialog might be summoned and should be handled
-   * manually via {@link Page#onDialog Page.onDialog()} event.
+   * manually via {@link com.microsoft.playwright.Page#onDialog Page.onDialog()} event.
    *
    * @since v1.8
    */
@@ -3865,7 +3977,8 @@ public interface Page extends AutoCloseable {
    * <li> Wait for <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks on the matched element,
    * unless {@code force} option is set. If the element is detached during the checks, the whole action is retried.</li>
    * <li> Scroll the element into view if needed.</li>
-   * <li> Use {@link Page#mouse Page.mouse()} to double click in the center of the element, or the specified {@code position}.</li>
+   * <li> Use {@link com.microsoft.playwright.Page#mouse Page.mouse()} to double click in the center of the element, or the
+   * specified {@code position}.</li>
    * <li> Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set. Note that if the
    * first click of the {@code dblclick()} triggers a navigation event, this method will throw.</li>
    * </ol>
@@ -3888,7 +4001,8 @@ public interface Page extends AutoCloseable {
    * <li> Wait for <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks on the matched element,
    * unless {@code force} option is set. If the element is detached during the checks, the whole action is retried.</li>
    * <li> Scroll the element into view if needed.</li>
-   * <li> Use {@link Page#mouse Page.mouse()} to double click in the center of the element, or the specified {@code position}.</li>
+   * <li> Use {@link com.microsoft.playwright.Page#mouse Page.mouse()} to double click in the center of the element, or the
+   * specified {@code position}.</li>
    * <li> Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set. Note that if the
    * first click of the {@code dblclick()} triggers a navigation event, this method will throw.</li>
    * </ol>
@@ -3907,7 +4021,7 @@ public interface Page extends AutoCloseable {
    * {@code click} is dispatched. This is equivalent to calling <a
    * href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/click">element.click()</a>.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * page.dispatchEvent("button#submit", "click");
    * }</pre>
@@ -3953,7 +4067,7 @@ public interface Page extends AutoCloseable {
    * {@code click} is dispatched. This is equivalent to calling <a
    * href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/click">element.click()</a>.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * page.dispatchEvent("button#submit", "click");
    * }</pre>
@@ -3998,7 +4112,7 @@ public interface Page extends AutoCloseable {
    * {@code click} is dispatched. This is equivalent to calling <a
    * href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/click">element.click()</a>.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * page.dispatchEvent("button#submit", "click");
    * }</pre>
@@ -4041,7 +4155,7 @@ public interface Page extends AutoCloseable {
    * This method drags the source element to the target element. It will first move to the source element, perform a {@code
    * mousedown}, then move to the target element and perform a {@code mouseup}.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * page.dragAndDrop("#source", '#target');
    * // or specify exact positions relative to the top-left corners of the elements:
@@ -4062,7 +4176,7 @@ public interface Page extends AutoCloseable {
    * This method drags the source element to the target element. It will first move to the source element, perform a {@code
    * mousedown}, then move to the target element and perform a {@code mouseup}.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * page.dragAndDrop("#source", '#target');
    * // or specify exact positions relative to the top-left corners of the elements:
@@ -4081,7 +4195,7 @@ public interface Page extends AutoCloseable {
    * This method changes the {@code CSS media type} through the {@code media} argument, and/or the {@code
    * "prefers-colors-scheme"} media feature, using the {@code colorScheme} argument.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * page.evaluate("() => matchMedia('screen').matches");
    * // → true
@@ -4119,7 +4233,7 @@ public interface Page extends AutoCloseable {
    * This method changes the {@code CSS media type} through the {@code media} argument, and/or the {@code
    * "prefers-colors-scheme"} media feature, using the {@code colorScheme} argument.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * page.evaluate("() => matchMedia('screen').matches");
    * // → true
@@ -4157,9 +4271,10 @@ public interface Page extends AutoCloseable {
    *
    * <p> If {@code expression} returns a <a
    * href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>, then {@link
-   * Page#evalOnSelector Page.evalOnSelector()} would wait for the promise to resolve and return its value.
+   * com.microsoft.playwright.Page#evalOnSelector Page.evalOnSelector()} would wait for the promise to resolve and return its
+   * value.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * String searchValue = (String) page.evalOnSelector("#search", "el => el.value");
    * String preloadHref = (String) page.evalOnSelector("link[rel=preload]", "el => el.href");
@@ -4181,9 +4296,10 @@ public interface Page extends AutoCloseable {
    *
    * <p> If {@code expression} returns a <a
    * href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>, then {@link
-   * Page#evalOnSelector Page.evalOnSelector()} would wait for the promise to resolve and return its value.
+   * com.microsoft.playwright.Page#evalOnSelector Page.evalOnSelector()} would wait for the promise to resolve and return its
+   * value.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * String searchValue = (String) page.evalOnSelector("#search", "el => el.value");
    * String preloadHref = (String) page.evalOnSelector("link[rel=preload]", "el => el.href");
@@ -4204,9 +4320,10 @@ public interface Page extends AutoCloseable {
    *
    * <p> If {@code expression} returns a <a
    * href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>, then {@link
-   * Page#evalOnSelector Page.evalOnSelector()} would wait for the promise to resolve and return its value.
+   * com.microsoft.playwright.Page#evalOnSelector Page.evalOnSelector()} would wait for the promise to resolve and return its
+   * value.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * String searchValue = (String) page.evalOnSelector("#search", "el => el.value");
    * String preloadHref = (String) page.evalOnSelector("link[rel=preload]", "el => el.href");
@@ -4226,9 +4343,10 @@ public interface Page extends AutoCloseable {
    *
    * <p> If {@code expression} returns a <a
    * href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>, then {@link
-   * Page#evalOnSelectorAll Page.evalOnSelectorAll()} would wait for the promise to resolve and return its value.
+   * com.microsoft.playwright.Page#evalOnSelectorAll Page.evalOnSelectorAll()} would wait for the promise to resolve and
+   * return its value.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * boolean divCounts = (boolean) page.evalOnSelectorAll("div", "(divs, min) => divs.length >= min", 10);
    * }</pre>
@@ -4247,9 +4365,10 @@ public interface Page extends AutoCloseable {
    *
    * <p> If {@code expression} returns a <a
    * href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>, then {@link
-   * Page#evalOnSelectorAll Page.evalOnSelectorAll()} would wait for the promise to resolve and return its value.
+   * com.microsoft.playwright.Page#evalOnSelectorAll Page.evalOnSelectorAll()} would wait for the promise to resolve and
+   * return its value.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * boolean divCounts = (boolean) page.evalOnSelectorAll("div", "(divs, min) => divs.length >= min", 10);
    * }</pre>
@@ -4264,15 +4383,16 @@ public interface Page extends AutoCloseable {
   /**
    * Returns the value of the {@code expression} invocation.
    *
-   * <p> If the function passed to the {@link Page#evaluate Page.evaluate()} returns a <a
+   * <p> If the function passed to the {@link com.microsoft.playwright.Page#evaluate Page.evaluate()} returns a <a
    * href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>, then {@link
-   * Page#evaluate Page.evaluate()} would wait for the promise to resolve and return its value.
+   * com.microsoft.playwright.Page#evaluate Page.evaluate()} would wait for the promise to resolve and return its value.
    *
-   * <p> If the function passed to the {@link Page#evaluate Page.evaluate()} returns a non-[Serializable] value, then {@link
-   * Page#evaluate Page.evaluate()} resolves to {@code undefined}. Playwright also supports transferring some additional
-   * values that are not serializable by {@code JSON}: {@code -0}, {@code NaN}, {@code Infinity}, {@code -Infinity}.
+   * <p> If the function passed to the {@link com.microsoft.playwright.Page#evaluate Page.evaluate()} returns a
+   * non-[Serializable] value, then {@link com.microsoft.playwright.Page#evaluate Page.evaluate()} resolves to {@code
+   * undefined}. Playwright also supports transferring some additional values that are not serializable by {@code JSON}:
+   * {@code -0}, {@code NaN}, {@code Infinity}, {@code -Infinity}.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> Passing argument to {@code expression}:
    * <pre>{@code
@@ -4287,7 +4407,8 @@ public interface Page extends AutoCloseable {
    * System.out.println(page.evaluate("1 + 2")); // prints "3"
    * }</pre>
    *
-   * <p> {@code ElementHandle} instances can be passed as an argument to the {@link Page#evaluate Page.evaluate()}:
+   * <p> {@code ElementHandle} instances can be passed as an argument to the {@link com.microsoft.playwright.Page#evaluate
+   * Page.evaluate()}:
    * <pre>{@code
    * ElementHandle bodyHandle = page.evaluate("document.body");
    * String html = (String) page.evaluate("([body, suffix]) => body.innerHTML + suffix", Arrays.asList(bodyHandle, "hello"));
@@ -4304,15 +4425,16 @@ public interface Page extends AutoCloseable {
   /**
    * Returns the value of the {@code expression} invocation.
    *
-   * <p> If the function passed to the {@link Page#evaluate Page.evaluate()} returns a <a
+   * <p> If the function passed to the {@link com.microsoft.playwright.Page#evaluate Page.evaluate()} returns a <a
    * href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>, then {@link
-   * Page#evaluate Page.evaluate()} would wait for the promise to resolve and return its value.
+   * com.microsoft.playwright.Page#evaluate Page.evaluate()} would wait for the promise to resolve and return its value.
    *
-   * <p> If the function passed to the {@link Page#evaluate Page.evaluate()} returns a non-[Serializable] value, then {@link
-   * Page#evaluate Page.evaluate()} resolves to {@code undefined}. Playwright also supports transferring some additional
-   * values that are not serializable by {@code JSON}: {@code -0}, {@code NaN}, {@code Infinity}, {@code -Infinity}.
+   * <p> If the function passed to the {@link com.microsoft.playwright.Page#evaluate Page.evaluate()} returns a
+   * non-[Serializable] value, then {@link com.microsoft.playwright.Page#evaluate Page.evaluate()} resolves to {@code
+   * undefined}. Playwright also supports transferring some additional values that are not serializable by {@code JSON}:
+   * {@code -0}, {@code NaN}, {@code Infinity}, {@code -Infinity}.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> Passing argument to {@code expression}:
    * <pre>{@code
@@ -4327,7 +4449,8 @@ public interface Page extends AutoCloseable {
    * System.out.println(page.evaluate("1 + 2")); // prints "3"
    * }</pre>
    *
-   * <p> {@code ElementHandle} instances can be passed as an argument to the {@link Page#evaluate Page.evaluate()}:
+   * <p> {@code ElementHandle} instances can be passed as an argument to the {@link com.microsoft.playwright.Page#evaluate
+   * Page.evaluate()}:
    * <pre>{@code
    * ElementHandle bodyHandle = page.evaluate("document.body");
    * String html = (String) page.evaluate("([body, suffix]) => body.innerHTML + suffix", Arrays.asList(bodyHandle, "hello"));
@@ -4343,14 +4466,16 @@ public interface Page extends AutoCloseable {
   /**
    * Returns the value of the {@code expression} invocation as a {@code JSHandle}.
    *
-   * <p> The only difference between {@link Page#evaluate Page.evaluate()} and {@link Page#evaluateHandle Page.evaluateHandle()}
-   * is that {@link Page#evaluateHandle Page.evaluateHandle()} returns {@code JSHandle}.
+   * <p> The only difference between {@link com.microsoft.playwright.Page#evaluate Page.evaluate()} and {@link
+   * com.microsoft.playwright.Page#evaluateHandle Page.evaluateHandle()} is that {@link
+   * com.microsoft.playwright.Page#evaluateHandle Page.evaluateHandle()} returns {@code JSHandle}.
    *
-   * <p> If the function passed to the {@link Page#evaluateHandle Page.evaluateHandle()} returns a <a
+   * <p> If the function passed to the {@link com.microsoft.playwright.Page#evaluateHandle Page.evaluateHandle()} returns a <a
    * href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>, then {@link
-   * Page#evaluateHandle Page.evaluateHandle()} would wait for the promise to resolve and return its value.
+   * com.microsoft.playwright.Page#evaluateHandle Page.evaluateHandle()} would wait for the promise to resolve and return its
+   * value.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * // Handle for the window object.
    * JSHandle aWindowHandle = page.evaluateHandle("() => Promise.resolve(window)");
@@ -4361,7 +4486,8 @@ public interface Page extends AutoCloseable {
    * JSHandle aHandle = page.evaluateHandle("document"); // Handle for the "document".
    * }</pre>
    *
-   * <p> {@code JSHandle} instances can be passed as an argument to the {@link Page#evaluateHandle Page.evaluateHandle()}:
+   * <p> {@code JSHandle} instances can be passed as an argument to the {@link com.microsoft.playwright.Page#evaluateHandle
+   * Page.evaluateHandle()}:
    * <pre>{@code
    * JSHandle aHandle = page.evaluateHandle("() => document.body");
    * JSHandle resultHandle = page.evaluateHandle("([body, suffix]) => body.innerHTML + suffix", Arrays.asList(aHandle, "hello"));
@@ -4379,14 +4505,16 @@ public interface Page extends AutoCloseable {
   /**
    * Returns the value of the {@code expression} invocation as a {@code JSHandle}.
    *
-   * <p> The only difference between {@link Page#evaluate Page.evaluate()} and {@link Page#evaluateHandle Page.evaluateHandle()}
-   * is that {@link Page#evaluateHandle Page.evaluateHandle()} returns {@code JSHandle}.
+   * <p> The only difference between {@link com.microsoft.playwright.Page#evaluate Page.evaluate()} and {@link
+   * com.microsoft.playwright.Page#evaluateHandle Page.evaluateHandle()} is that {@link
+   * com.microsoft.playwright.Page#evaluateHandle Page.evaluateHandle()} returns {@code JSHandle}.
    *
-   * <p> If the function passed to the {@link Page#evaluateHandle Page.evaluateHandle()} returns a <a
+   * <p> If the function passed to the {@link com.microsoft.playwright.Page#evaluateHandle Page.evaluateHandle()} returns a <a
    * href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>, then {@link
-   * Page#evaluateHandle Page.evaluateHandle()} would wait for the promise to resolve and return its value.
+   * com.microsoft.playwright.Page#evaluateHandle Page.evaluateHandle()} would wait for the promise to resolve and return its
+   * value.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * // Handle for the window object.
    * JSHandle aWindowHandle = page.evaluateHandle("() => Promise.resolve(window)");
@@ -4397,7 +4525,8 @@ public interface Page extends AutoCloseable {
    * JSHandle aHandle = page.evaluateHandle("document"); // Handle for the "document".
    * }</pre>
    *
-   * <p> {@code JSHandle} instances can be passed as an argument to the {@link Page#evaluateHandle Page.evaluateHandle()}:
+   * <p> {@code JSHandle} instances can be passed as an argument to the {@link com.microsoft.playwright.Page#evaluateHandle
+   * Page.evaluateHandle()}:
    * <pre>{@code
    * JSHandle aHandle = page.evaluateHandle("() => document.body");
    * JSHandle resultHandle = page.evaluateHandle("([body, suffix]) => body.innerHTML + suffix", Arrays.asList(aHandle, "hello"));
@@ -4422,11 +4551,12 @@ public interface Page extends AutoCloseable {
    * <p> The first argument of the {@code callback} function contains information about the caller: {@code { browserContext:
    * BrowserContext, page: Page, frame: Frame }}.
    *
-   * <p> See {@link BrowserContext#exposeBinding BrowserContext.exposeBinding()} for the context-wide version.
+   * <p> See {@link com.microsoft.playwright.BrowserContext#exposeBinding BrowserContext.exposeBinding()} for the context-wide
+   * version.
    *
-   * <p> <strong>NOTE:</strong> Functions installed via {@link Page#exposeBinding Page.exposeBinding()} survive navigations.
+   * <p> <strong>NOTE:</strong> Functions installed via {@link com.microsoft.playwright.Page#exposeBinding Page.exposeBinding()} survive navigations.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> An example of exposing page URL to all frames in a page:
    * <pre>{@code
@@ -4486,11 +4616,12 @@ public interface Page extends AutoCloseable {
    * <p> The first argument of the {@code callback} function contains information about the caller: {@code { browserContext:
    * BrowserContext, page: Page, frame: Frame }}.
    *
-   * <p> See {@link BrowserContext#exposeBinding BrowserContext.exposeBinding()} for the context-wide version.
+   * <p> See {@link com.microsoft.playwright.BrowserContext#exposeBinding BrowserContext.exposeBinding()} for the context-wide
+   * version.
    *
-   * <p> <strong>NOTE:</strong> Functions installed via {@link Page#exposeBinding Page.exposeBinding()} survive navigations.
+   * <p> <strong>NOTE:</strong> Functions installed via {@link com.microsoft.playwright.Page#exposeBinding Page.exposeBinding()} survive navigations.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> An example of exposing page URL to all frames in a page:
    * <pre>{@code
@@ -4547,11 +4678,12 @@ public interface Page extends AutoCloseable {
    * href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>, it will be
    * awaited.
    *
-   * <p> See {@link BrowserContext#exposeFunction BrowserContext.exposeFunction()} for context-wide exposed function.
+   * <p> See {@link com.microsoft.playwright.BrowserContext#exposeFunction BrowserContext.exposeFunction()} for context-wide
+   * exposed function.
    *
-   * <p> <strong>NOTE:</strong> Functions installed via {@link Page#exposeFunction Page.exposeFunction()} survive navigations.
+   * <p> <strong>NOTE:</strong> Functions installed via {@link com.microsoft.playwright.Page#exposeFunction Page.exposeFunction()} survive navigations.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> An example of adding a {@code sha256} function to the page:
    * <pre>{@code
@@ -4607,7 +4739,8 @@ public interface Page extends AutoCloseable {
    * href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLLabelElement/control">control</a>, the control will be filled
    * instead.
    *
-   * <p> To send fine-grained keyboard events, use {@link Locator#pressSequentially Locator.pressSequentially()}.
+   * <p> To send fine-grained keyboard events, use {@link com.microsoft.playwright.Locator#pressSequentially
+   * Locator.pressSequentially()}.
    *
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used.
    * @param value Value to fill for the {@code <input>}, {@code <textarea>} or {@code [contenteditable]} element.
@@ -4626,7 +4759,8 @@ public interface Page extends AutoCloseable {
    * href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLLabelElement/control">control</a>, the control will be filled
    * instead.
    *
-   * <p> To send fine-grained keyboard events, use {@link Locator#pressSequentially Locator.pressSequentially()}.
+   * <p> To send fine-grained keyboard events, use {@link com.microsoft.playwright.Locator#pressSequentially
+   * Locator.pressSequentially()}.
    *
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used.
    * @param value Value to fill for the {@code <input>}, {@code <textarea>} or {@code [contenteditable]} element.
@@ -4654,7 +4788,7 @@ public interface Page extends AutoCloseable {
   /**
    * Returns frame matching the specified criteria. Either {@code name} or {@code url} must be specified.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * Frame frame = page.frame("frame-name");
    * }</pre>
@@ -4691,7 +4825,7 @@ public interface Page extends AutoCloseable {
    * When working with iframes, you can create a frame locator that will enter the iframe and allow selecting elements in
    * that iframe.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> Following snippet locates element with text "Submit" in the iframe with id {@code my-frame}, like {@code <iframe
    * id="my-frame">}:
@@ -4731,7 +4865,7 @@ public interface Page extends AutoCloseable {
   /**
    * Allows locating elements by their alt text.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> For example, this method will find the image by alt text "Playwright logo":
    * <pre>{@code
@@ -4747,7 +4881,7 @@ public interface Page extends AutoCloseable {
   /**
    * Allows locating elements by their alt text.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> For example, this method will find the image by alt text "Playwright logo":
    * <pre>{@code
@@ -4761,7 +4895,7 @@ public interface Page extends AutoCloseable {
   /**
    * Allows locating elements by their alt text.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> For example, this method will find the image by alt text "Playwright logo":
    * <pre>{@code
@@ -4777,7 +4911,7 @@ public interface Page extends AutoCloseable {
   /**
    * Allows locating elements by their alt text.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> For example, this method will find the image by alt text "Playwright logo":
    * <pre>{@code
@@ -4792,7 +4926,7 @@ public interface Page extends AutoCloseable {
    * Allows locating input elements by the text of the associated {@code <label>} or {@code aria-labelledby} element, or by
    * the {@code aria-label} attribute.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> For example, this method will find inputs by label "Username" and "Password" in the following DOM:
    * <pre>{@code
@@ -4810,7 +4944,7 @@ public interface Page extends AutoCloseable {
    * Allows locating input elements by the text of the associated {@code <label>} or {@code aria-labelledby} element, or by
    * the {@code aria-label} attribute.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> For example, this method will find inputs by label "Username" and "Password" in the following DOM:
    * <pre>{@code
@@ -4826,7 +4960,7 @@ public interface Page extends AutoCloseable {
    * Allows locating input elements by the text of the associated {@code <label>} or {@code aria-labelledby} element, or by
    * the {@code aria-label} attribute.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> For example, this method will find inputs by label "Username" and "Password" in the following DOM:
    * <pre>{@code
@@ -4844,7 +4978,7 @@ public interface Page extends AutoCloseable {
    * Allows locating input elements by the text of the associated {@code <label>} or {@code aria-labelledby} element, or by
    * the {@code aria-label} attribute.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> For example, this method will find inputs by label "Username" and "Password" in the following DOM:
    * <pre>{@code
@@ -4859,7 +4993,7 @@ public interface Page extends AutoCloseable {
   /**
    * Allows locating input elements by the placeholder text.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> For example, consider the following DOM structure.
    *
@@ -4877,7 +5011,7 @@ public interface Page extends AutoCloseable {
   /**
    * Allows locating input elements by the placeholder text.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> For example, consider the following DOM structure.
    *
@@ -4893,7 +5027,7 @@ public interface Page extends AutoCloseable {
   /**
    * Allows locating input elements by the placeholder text.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> For example, consider the following DOM structure.
    *
@@ -4911,7 +5045,7 @@ public interface Page extends AutoCloseable {
   /**
    * Allows locating input elements by the placeholder text.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> For example, consider the following DOM structure.
    *
@@ -4929,7 +5063,7 @@ public interface Page extends AutoCloseable {
    * href="https://www.w3.org/TR/wai-aria-1.2/#aria-attributes">ARIA attributes</a> and <a
    * href="https://w3c.github.io/accname/#dfn-accessible-name">accessible name</a>.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> Consider the following DOM structure.
    *
@@ -4950,7 +5084,7 @@ public interface Page extends AutoCloseable {
    *     .click();
    * }</pre>
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
    * <p> Role selector **does not replace** accessibility audits and conformance tests, but rather gives early feedback about the
    * ARIA guidelines.
@@ -4972,7 +5106,7 @@ public interface Page extends AutoCloseable {
    * href="https://www.w3.org/TR/wai-aria-1.2/#aria-attributes">ARIA attributes</a> and <a
    * href="https://w3c.github.io/accname/#dfn-accessible-name">accessible name</a>.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> Consider the following DOM structure.
    *
@@ -4993,7 +5127,7 @@ public interface Page extends AutoCloseable {
    *     .click();
    * }</pre>
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
    * <p> Role selector **does not replace** accessibility audits and conformance tests, but rather gives early feedback about the
    * ARIA guidelines.
@@ -5011,7 +5145,7 @@ public interface Page extends AutoCloseable {
   /**
    * Locate element by the test id.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> Consider the following DOM structure.
    *
@@ -5020,10 +5154,11 @@ public interface Page extends AutoCloseable {
    * page.getByTestId("directions").click();
    * }</pre>
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
-   * <p> By default, the {@code data-testid} attribute is used as a test id. Use {@link Selectors#setTestIdAttribute
-   * Selectors.setTestIdAttribute()} to configure a different test id attribute if necessary.
+   * <p> By default, the {@code data-testid} attribute is used as a test id. Use {@link
+   * com.microsoft.playwright.Selectors#setTestIdAttribute Selectors.setTestIdAttribute()} to configure a different test id
+   * attribute if necessary.
    *
    * @param testId Id to locate the element by.
    * @since v1.27
@@ -5032,7 +5167,7 @@ public interface Page extends AutoCloseable {
   /**
    * Locate element by the test id.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> Consider the following DOM structure.
    *
@@ -5041,10 +5176,11 @@ public interface Page extends AutoCloseable {
    * page.getByTestId("directions").click();
    * }</pre>
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
-   * <p> By default, the {@code data-testid} attribute is used as a test id. Use {@link Selectors#setTestIdAttribute
-   * Selectors.setTestIdAttribute()} to configure a different test id attribute if necessary.
+   * <p> By default, the {@code data-testid} attribute is used as a test id. Use {@link
+   * com.microsoft.playwright.Selectors#setTestIdAttribute Selectors.setTestIdAttribute()} to configure a different test id
+   * attribute if necessary.
    *
    * @param testId Id to locate the element by.
    * @since v1.27
@@ -5053,10 +5189,10 @@ public interface Page extends AutoCloseable {
   /**
    * Allows locating elements that contain given text.
    *
-   * <p> See also {@link Locator#filter Locator.filter()} that allows to match by another criteria, like an accessible role, and
-   * then filter by the text content.
+   * <p> See also {@link com.microsoft.playwright.Locator#filter Locator.filter()} that allows to match by another criteria, like
+   * an accessible role, and then filter by the text content.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> Consider the following DOM structure:
    *
@@ -5078,7 +5214,7 @@ public interface Page extends AutoCloseable {
    * page.getByText(Pattern.compile("^hello$", Pattern.CASE_INSENSITIVE))
    * }</pre>
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
    * <p> Matching by text always normalizes whitespace, even with exact match. For example, it turns multiple spaces into one,
    * turns line breaks into spaces and ignores leading and trailing whitespace.
@@ -5095,10 +5231,10 @@ public interface Page extends AutoCloseable {
   /**
    * Allows locating elements that contain given text.
    *
-   * <p> See also {@link Locator#filter Locator.filter()} that allows to match by another criteria, like an accessible role, and
-   * then filter by the text content.
+   * <p> See also {@link com.microsoft.playwright.Locator#filter Locator.filter()} that allows to match by another criteria, like
+   * an accessible role, and then filter by the text content.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> Consider the following DOM structure:
    *
@@ -5120,7 +5256,7 @@ public interface Page extends AutoCloseable {
    * page.getByText(Pattern.compile("^hello$", Pattern.CASE_INSENSITIVE))
    * }</pre>
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
    * <p> Matching by text always normalizes whitespace, even with exact match. For example, it turns multiple spaces into one,
    * turns line breaks into spaces and ignores leading and trailing whitespace.
@@ -5135,10 +5271,10 @@ public interface Page extends AutoCloseable {
   /**
    * Allows locating elements that contain given text.
    *
-   * <p> See also {@link Locator#filter Locator.filter()} that allows to match by another criteria, like an accessible role, and
-   * then filter by the text content.
+   * <p> See also {@link com.microsoft.playwright.Locator#filter Locator.filter()} that allows to match by another criteria, like
+   * an accessible role, and then filter by the text content.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> Consider the following DOM structure:
    *
@@ -5160,7 +5296,7 @@ public interface Page extends AutoCloseable {
    * page.getByText(Pattern.compile("^hello$", Pattern.CASE_INSENSITIVE))
    * }</pre>
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
    * <p> Matching by text always normalizes whitespace, even with exact match. For example, it turns multiple spaces into one,
    * turns line breaks into spaces and ignores leading and trailing whitespace.
@@ -5177,10 +5313,10 @@ public interface Page extends AutoCloseable {
   /**
    * Allows locating elements that contain given text.
    *
-   * <p> See also {@link Locator#filter Locator.filter()} that allows to match by another criteria, like an accessible role, and
-   * then filter by the text content.
+   * <p> See also {@link com.microsoft.playwright.Locator#filter Locator.filter()} that allows to match by another criteria, like
+   * an accessible role, and then filter by the text content.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> Consider the following DOM structure:
    *
@@ -5202,7 +5338,7 @@ public interface Page extends AutoCloseable {
    * page.getByText(Pattern.compile("^hello$", Pattern.CASE_INSENSITIVE))
    * }</pre>
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
    * <p> Matching by text always normalizes whitespace, even with exact match. For example, it turns multiple spaces into one,
    * turns line breaks into spaces and ignores leading and trailing whitespace.
@@ -5217,7 +5353,7 @@ public interface Page extends AutoCloseable {
   /**
    * Allows locating elements by their title attribute.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> Consider the following DOM structure.
    *
@@ -5235,7 +5371,7 @@ public interface Page extends AutoCloseable {
   /**
    * Allows locating elements by their title attribute.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> Consider the following DOM structure.
    *
@@ -5251,7 +5387,7 @@ public interface Page extends AutoCloseable {
   /**
    * Allows locating elements by their title attribute.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> Consider the following DOM structure.
    *
@@ -5269,7 +5405,7 @@ public interface Page extends AutoCloseable {
   /**
    * Allows locating elements by their title attribute.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> Consider the following DOM structure.
    *
@@ -5337,7 +5473,7 @@ public interface Page extends AutoCloseable {
    *
    * <p> The method will not throw an error when any valid HTTP status code is returned by the remote server, including 404 "Not
    * Found" and 500 "Internal Server Error".  The status code for such responses can be retrieved by calling {@link
-   * Response#status Response.status()}.
+   * com.microsoft.playwright.Response#status Response.status()}.
    *
    * <p> <strong>NOTE:</strong> The method either throws an error or returns a main resource response. The only exceptions are navigation to {@code
    * about:blank} or navigation to the same URL with a different hash, which would succeed and return {@code null}.
@@ -5368,7 +5504,7 @@ public interface Page extends AutoCloseable {
    *
    * <p> The method will not throw an error when any valid HTTP status code is returned by the remote server, including 404 "Not
    * Found" and 500 "Internal Server Error".  The status code for such responses can be retrieved by calling {@link
-   * Response#status Response.status()}.
+   * com.microsoft.playwright.Response#status Response.status()}.
    *
    * <p> <strong>NOTE:</strong> The method either throws an error or returns a main resource response. The only exceptions are navigation to {@code
    * about:blank} or navigation to the same URL with a different hash, which would succeed and return {@code null}.
@@ -5389,7 +5525,8 @@ public interface Page extends AutoCloseable {
    * <li> Wait for <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks on the matched element,
    * unless {@code force} option is set. If the element is detached during the checks, the whole action is retried.</li>
    * <li> Scroll the element into view if needed.</li>
-   * <li> Use {@link Page#mouse Page.mouse()} to hover over the center of the element, or the specified {@code position}.</li>
+   * <li> Use {@link com.microsoft.playwright.Page#mouse Page.mouse()} to hover over the center of the element, or the specified
+   * {@code position}.</li>
    * <li> Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.</li>
    * </ol>
    *
@@ -5409,7 +5546,8 @@ public interface Page extends AutoCloseable {
    * <li> Wait for <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks on the matched element,
    * unless {@code force} option is set. If the element is detached during the checks, the whole action is retried.</li>
    * <li> Scroll the element into view if needed.</li>
-   * <li> Use {@link Page#mouse Page.mouse()} to hover over the center of the element, or the specified {@code position}.</li>
+   * <li> Use {@link com.microsoft.playwright.Page#mouse Page.mouse()} to hover over the center of the element, or the specified
+   * {@code position}.</li>
    * <li> Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.</li>
    * </ol>
    *
@@ -5660,8 +5798,8 @@ public interface Page extends AutoCloseable {
    * System.out.println(page.evaluate("prompt('Enter string:')"));
    * }</pre>
    *
-   * @param handler Receives the {@code Dialog} object, it **must** either {@link Dialog#accept Dialog.accept()} or {@link Dialog#dismiss
-   * Dialog.dismiss()} the dialog - otherwise the page will <a
+   * @param handler Receives the {@code Dialog} object, it **must** either {@link com.microsoft.playwright.Dialog#accept Dialog.accept()} or
+   * {@link com.microsoft.playwright.Dialog#dismiss Dialog.dismiss()} the dialog - otherwise the page will <a
    * href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/EventLoop#never_blocking">freeze</a> waiting for the
    * dialog, and actions like click will never finish.
    * @since v1.10
@@ -5682,7 +5820,7 @@ public interface Page extends AutoCloseable {
    * the place it was paused.
    *
    * <p> <strong>NOTE:</strong> This method requires Playwright to be started in a headed mode, with a falsy {@code headless} value in the {@link
-   * BrowserType#launch BrowserType.launch()}.
+   * com.microsoft.playwright.BrowserType#launch BrowserType.launch()}.
    *
    * @since v1.9
    */
@@ -5693,13 +5831,13 @@ public interface Page extends AutoCloseable {
    * <p> <strong>NOTE:</strong> Generating a pdf is currently only supported in Chromium headless.
    *
    * <p> {@code page.pdf()} generates a pdf of the page with {@code print} css media. To generate a pdf with {@code screen}
-   * media, call {@link Page#emulateMedia Page.emulateMedia()} before calling {@code page.pdf()}:
+   * media, call {@link com.microsoft.playwright.Page#emulateMedia Page.emulateMedia()} before calling {@code page.pdf()}:
    *
    * <p> <strong>NOTE:</strong> By default, {@code page.pdf()} generates a pdf with modified colors for printing. Use the <a
    * href="https://developer.mozilla.org/en-US/docs/Web/CSS/-webkit-print-color-adjust">{@code
    * -webkit-print-color-adjust}</a> property to force rendering of exact colors.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * // Generates a PDF with "screen" media type.
    * page.emulateMedia(new Page.EmulateMediaOptions().setMedia(Media.SCREEN));
@@ -5753,13 +5891,13 @@ public interface Page extends AutoCloseable {
    * <p> <strong>NOTE:</strong> Generating a pdf is currently only supported in Chromium headless.
    *
    * <p> {@code page.pdf()} generates a pdf of the page with {@code print} css media. To generate a pdf with {@code screen}
-   * media, call {@link Page#emulateMedia Page.emulateMedia()} before calling {@code page.pdf()}:
+   * media, call {@link com.microsoft.playwright.Page#emulateMedia Page.emulateMedia()} before calling {@code page.pdf()}:
    *
    * <p> <strong>NOTE:</strong> By default, {@code page.pdf()} generates a pdf with modified colors for printing. Use the <a
    * href="https://developer.mozilla.org/en-US/docs/Web/CSS/-webkit-print-color-adjust">{@code
    * -webkit-print-color-adjust}</a> property to force rendering of exact colors.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * // Generates a PDF with "screen" media type.
    * page.emulateMedia(new Page.EmulateMediaOptions().setMedia(Media.SCREEN));
@@ -5806,7 +5944,8 @@ public interface Page extends AutoCloseable {
    */
   byte[] pdf(PdfOptions options);
   /**
-   * Focuses the element, and then uses {@link Keyboard#down Keyboard.down()} and {@link Keyboard#up Keyboard.up()}.
+   * Focuses the element, and then uses {@link com.microsoft.playwright.Keyboard#down Keyboard.down()} and {@link
+   * com.microsoft.playwright.Keyboard#up Keyboard.up()}.
    *
    * <p> {@code key} can specify the intended <a
    * href="https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key">keyboardEvent.key</a> value or a single
@@ -5829,7 +5968,7 @@ public interface Page extends AutoCloseable {
    * <p> Shortcuts such as {@code key: "Control+o"}, {@code key: "Control++} or {@code key: "Control+Shift+T"} are supported as
    * well. When specified with the modifier, modifier is pressed and being held while the subsequent key is being pressed.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * Page page = browser.newPage();
    * page.navigate("https://keycode.info");
@@ -5849,7 +5988,8 @@ public interface Page extends AutoCloseable {
     press(selector, key, null);
   }
   /**
-   * Focuses the element, and then uses {@link Keyboard#down Keyboard.down()} and {@link Keyboard#up Keyboard.up()}.
+   * Focuses the element, and then uses {@link com.microsoft.playwright.Keyboard#down Keyboard.down()} and {@link
+   * com.microsoft.playwright.Keyboard#up Keyboard.up()}.
    *
    * <p> {@code key} can specify the intended <a
    * href="https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key">keyboardEvent.key</a> value or a single
@@ -5872,7 +6012,7 @@ public interface Page extends AutoCloseable {
    * <p> Shortcuts such as {@code key: "Control+o"}, {@code key: "Control++} or {@code key: "Control+Shift+T"} are supported as
    * well. When specified with the modifier, modifier is pressed and being held while the subsequent key is being pressed.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * Page page = browser.newPage();
    * page.navigate("https://keycode.info");
@@ -5891,8 +6031,8 @@ public interface Page extends AutoCloseable {
   void press(String selector, String key, PressOptions options);
   /**
    * The method finds an element matching the specified selector within the page. If no elements match the selector, the
-   * return value resolves to {@code null}. To wait for an element on the page, use {@link Locator#waitFor
-   * Locator.waitFor()}.
+   * return value resolves to {@code null}. To wait for an element on the page, use {@link
+   * com.microsoft.playwright.Locator#waitFor Locator.waitFor()}.
    *
    * @param selector A selector to query for.
    * @since v1.9
@@ -5902,8 +6042,8 @@ public interface Page extends AutoCloseable {
   }
   /**
    * The method finds an element matching the specified selector within the page. If no elements match the selector, the
-   * return value resolves to {@code null}. To wait for an element on the page, use {@link Locator#waitFor
-   * Locator.waitFor()}.
+   * return value resolves to {@code null}. To wait for an element on the page, use {@link
+   * com.microsoft.playwright.Locator#waitFor Locator.waitFor()}.
    *
    * @param selector A selector to query for.
    * @since v1.9
@@ -5930,7 +6070,8 @@ public interface Page extends AutoCloseable {
    * <p> Things to keep in mind:
    * <ul>
    * <li> When an overlay is shown predictably, we recommend explicitly waiting for it in your test and dismissing it as a part of
-   * your normal test flow, instead of using {@link Page#addLocatorHandler Page.addLocatorHandler()}.</li>
+   * your normal test flow, instead of using {@link com.microsoft.playwright.Page#addLocatorHandler
+   * Page.addLocatorHandler()}.</li>
    * <li> Playwright checks for the overlay every time before executing or retrying an action that requires an <a
    * href="https://playwright.dev/java/docs/actionability">actionability check</a>, or before performing an auto-waiting
    * assertion check. When overlay is visible, Playwright calls the handler first, and then proceeds with the
@@ -5944,15 +6085,17 @@ public interface Page extends AutoCloseable {
    *
    * <p> <strong>NOTE:</strong> Running the handler will alter your page state mid-test. For example it will change the currently focused element and
    * move the mouse. Make sure that actions that run after the handler are self-contained and do not rely on the focus and
-   * mouse state being unchanged. <br /> <br /> For example, consider a test that calls {@link Locator#focus Locator.focus()}
-   * followed by {@link Keyboard#press Keyboard.press()}. If your handler clicks a button between these two actions, the
-   * focused element most likely will be wrong, and key press will happen on the unexpected element. Use {@link Locator#press
+   * mouse state being unchanged. <br /> <br /> For example, consider a test that calls {@link
+   * com.microsoft.playwright.Locator#focus Locator.focus()} followed by {@link com.microsoft.playwright.Keyboard#press
+   * Keyboard.press()}. If your handler clicks a button between these two actions, the focused element most likely will be
+   * wrong, and key press will happen on the unexpected element. Use {@link com.microsoft.playwright.Locator#press
    * Locator.press()} instead to avoid this problem. <br /> <br /> Another example is a series of mouse actions, where {@link
-   * Mouse#move Mouse.move()} is followed by {@link Mouse#down Mouse.down()}. Again, when the handler runs between these two
-   * actions, the mouse position will be wrong during the mouse down. Prefer self-contained actions like {@link Locator#click
-   * Locator.click()} that do not rely on the state being unchanged by a handler.
+   * com.microsoft.playwright.Mouse#move Mouse.move()} is followed by {@link com.microsoft.playwright.Mouse#down
+   * Mouse.down()}. Again, when the handler runs between these two actions, the mouse position will be wrong during the mouse
+   * down. Prefer self-contained actions like {@link com.microsoft.playwright.Locator#click Locator.click()} that do not rely
+   * on the state being unchanged by a handler.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> An example that closes a "Sign up to the newsletter" dialog when it appears:
    * <pre>{@code
@@ -6014,9 +6157,9 @@ public interface Page extends AutoCloseable {
    */
   Response reload(ReloadOptions options);
   /**
-   * API testing helper associated with this page. This method returns the same instance as {@link BrowserContext#request
-   * BrowserContext.request()} on the page's context. See {@link BrowserContext#request BrowserContext.request()} for more
-   * details.
+   * API testing helper associated with this page. This method returns the same instance as {@link
+   * com.microsoft.playwright.BrowserContext#request BrowserContext.request()} on the page's context. See {@link
+   * com.microsoft.playwright.BrowserContext#request BrowserContext.request()} for more details.
    *
    * @since v1.16
    */
@@ -6028,11 +6171,11 @@ public interface Page extends AutoCloseable {
    *
    * <p> <strong>NOTE:</strong> The handler will only be called for the first url if the response is a redirect.
    *
-   * <p> <strong>NOTE:</strong> {@link Page#route Page.route()} will not intercept requests intercepted by Service Worker. See <a
-   * href="https://github.com/microsoft/playwright/issues/1090">this</a> issue. We recommend disabling Service Workers when
-   * using request interception by setting {@code Browser.newContext.serviceWorkers} to {@code "block"}.
+   * <p> <strong>NOTE:</strong> {@link com.microsoft.playwright.Page#route Page.route()} will not intercept requests intercepted by Service Worker. See
+   * <a href="https://github.com/microsoft/playwright/issues/1090">this</a> issue. We recommend disabling Service Workers
+   * when using request interception by setting {@code Browser.newContext.serviceWorkers} to {@code "block"}.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> An example of a naive handler that aborts all image requests:
    * <pre>{@code
@@ -6061,10 +6204,10 @@ public interface Page extends AutoCloseable {
    * });
    * }</pre>
    *
-   * <p> Page routes take precedence over browser context routes (set up with {@link BrowserContext#route
-   * BrowserContext.route()}) when request matches both handlers.
+   * <p> Page routes take precedence over browser context routes (set up with {@link
+   * com.microsoft.playwright.BrowserContext#route BrowserContext.route()}) when request matches both handlers.
    *
-   * <p> To remove a route with its handler you can use {@link Page#unroute Page.unroute()}.
+   * <p> To remove a route with its handler you can use {@link com.microsoft.playwright.Page#unroute Page.unroute()}.
    *
    * <p> <strong>NOTE:</strong> Enabling routing disables http cache.
    *
@@ -6084,11 +6227,11 @@ public interface Page extends AutoCloseable {
    *
    * <p> <strong>NOTE:</strong> The handler will only be called for the first url if the response is a redirect.
    *
-   * <p> <strong>NOTE:</strong> {@link Page#route Page.route()} will not intercept requests intercepted by Service Worker. See <a
-   * href="https://github.com/microsoft/playwright/issues/1090">this</a> issue. We recommend disabling Service Workers when
-   * using request interception by setting {@code Browser.newContext.serviceWorkers} to {@code "block"}.
+   * <p> <strong>NOTE:</strong> {@link com.microsoft.playwright.Page#route Page.route()} will not intercept requests intercepted by Service Worker. See
+   * <a href="https://github.com/microsoft/playwright/issues/1090">this</a> issue. We recommend disabling Service Workers
+   * when using request interception by setting {@code Browser.newContext.serviceWorkers} to {@code "block"}.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> An example of a naive handler that aborts all image requests:
    * <pre>{@code
@@ -6117,10 +6260,10 @@ public interface Page extends AutoCloseable {
    * });
    * }</pre>
    *
-   * <p> Page routes take precedence over browser context routes (set up with {@link BrowserContext#route
-   * BrowserContext.route()}) when request matches both handlers.
+   * <p> Page routes take precedence over browser context routes (set up with {@link
+   * com.microsoft.playwright.BrowserContext#route BrowserContext.route()}) when request matches both handlers.
    *
-   * <p> To remove a route with its handler you can use {@link Page#unroute Page.unroute()}.
+   * <p> To remove a route with its handler you can use {@link com.microsoft.playwright.Page#unroute Page.unroute()}.
    *
    * <p> <strong>NOTE:</strong> Enabling routing disables http cache.
    *
@@ -6138,11 +6281,11 @@ public interface Page extends AutoCloseable {
    *
    * <p> <strong>NOTE:</strong> The handler will only be called for the first url if the response is a redirect.
    *
-   * <p> <strong>NOTE:</strong> {@link Page#route Page.route()} will not intercept requests intercepted by Service Worker. See <a
-   * href="https://github.com/microsoft/playwright/issues/1090">this</a> issue. We recommend disabling Service Workers when
-   * using request interception by setting {@code Browser.newContext.serviceWorkers} to {@code "block"}.
+   * <p> <strong>NOTE:</strong> {@link com.microsoft.playwright.Page#route Page.route()} will not intercept requests intercepted by Service Worker. See
+   * <a href="https://github.com/microsoft/playwright/issues/1090">this</a> issue. We recommend disabling Service Workers
+   * when using request interception by setting {@code Browser.newContext.serviceWorkers} to {@code "block"}.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> An example of a naive handler that aborts all image requests:
    * <pre>{@code
@@ -6171,10 +6314,10 @@ public interface Page extends AutoCloseable {
    * });
    * }</pre>
    *
-   * <p> Page routes take precedence over browser context routes (set up with {@link BrowserContext#route
-   * BrowserContext.route()}) when request matches both handlers.
+   * <p> Page routes take precedence over browser context routes (set up with {@link
+   * com.microsoft.playwright.BrowserContext#route BrowserContext.route()}) when request matches both handlers.
    *
-   * <p> To remove a route with its handler you can use {@link Page#unroute Page.unroute()}.
+   * <p> To remove a route with its handler you can use {@link com.microsoft.playwright.Page#unroute Page.unroute()}.
    *
    * <p> <strong>NOTE:</strong> Enabling routing disables http cache.
    *
@@ -6194,11 +6337,11 @@ public interface Page extends AutoCloseable {
    *
    * <p> <strong>NOTE:</strong> The handler will only be called for the first url if the response is a redirect.
    *
-   * <p> <strong>NOTE:</strong> {@link Page#route Page.route()} will not intercept requests intercepted by Service Worker. See <a
-   * href="https://github.com/microsoft/playwright/issues/1090">this</a> issue. We recommend disabling Service Workers when
-   * using request interception by setting {@code Browser.newContext.serviceWorkers} to {@code "block"}.
+   * <p> <strong>NOTE:</strong> {@link com.microsoft.playwright.Page#route Page.route()} will not intercept requests intercepted by Service Worker. See
+   * <a href="https://github.com/microsoft/playwright/issues/1090">this</a> issue. We recommend disabling Service Workers
+   * when using request interception by setting {@code Browser.newContext.serviceWorkers} to {@code "block"}.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> An example of a naive handler that aborts all image requests:
    * <pre>{@code
@@ -6227,10 +6370,10 @@ public interface Page extends AutoCloseable {
    * });
    * }</pre>
    *
-   * <p> Page routes take precedence over browser context routes (set up with {@link BrowserContext#route
-   * BrowserContext.route()}) when request matches both handlers.
+   * <p> Page routes take precedence over browser context routes (set up with {@link
+   * com.microsoft.playwright.BrowserContext#route BrowserContext.route()}) when request matches both handlers.
    *
-   * <p> To remove a route with its handler you can use {@link Page#unroute Page.unroute()}.
+   * <p> To remove a route with its handler you can use {@link com.microsoft.playwright.Page#unroute Page.unroute()}.
    *
    * <p> <strong>NOTE:</strong> Enabling routing disables http cache.
    *
@@ -6248,11 +6391,11 @@ public interface Page extends AutoCloseable {
    *
    * <p> <strong>NOTE:</strong> The handler will only be called for the first url if the response is a redirect.
    *
-   * <p> <strong>NOTE:</strong> {@link Page#route Page.route()} will not intercept requests intercepted by Service Worker. See <a
-   * href="https://github.com/microsoft/playwright/issues/1090">this</a> issue. We recommend disabling Service Workers when
-   * using request interception by setting {@code Browser.newContext.serviceWorkers} to {@code "block"}.
+   * <p> <strong>NOTE:</strong> {@link com.microsoft.playwright.Page#route Page.route()} will not intercept requests intercepted by Service Worker. See
+   * <a href="https://github.com/microsoft/playwright/issues/1090">this</a> issue. We recommend disabling Service Workers
+   * when using request interception by setting {@code Browser.newContext.serviceWorkers} to {@code "block"}.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> An example of a naive handler that aborts all image requests:
    * <pre>{@code
@@ -6281,10 +6424,10 @@ public interface Page extends AutoCloseable {
    * });
    * }</pre>
    *
-   * <p> Page routes take precedence over browser context routes (set up with {@link BrowserContext#route
-   * BrowserContext.route()}) when request matches both handlers.
+   * <p> Page routes take precedence over browser context routes (set up with {@link
+   * com.microsoft.playwright.BrowserContext#route BrowserContext.route()}) when request matches both handlers.
    *
-   * <p> To remove a route with its handler you can use {@link Page#unroute Page.unroute()}.
+   * <p> To remove a route with its handler you can use {@link com.microsoft.playwright.Page#unroute Page.unroute()}.
    *
    * <p> <strong>NOTE:</strong> Enabling routing disables http cache.
    *
@@ -6304,11 +6447,11 @@ public interface Page extends AutoCloseable {
    *
    * <p> <strong>NOTE:</strong> The handler will only be called for the first url if the response is a redirect.
    *
-   * <p> <strong>NOTE:</strong> {@link Page#route Page.route()} will not intercept requests intercepted by Service Worker. See <a
-   * href="https://github.com/microsoft/playwright/issues/1090">this</a> issue. We recommend disabling Service Workers when
-   * using request interception by setting {@code Browser.newContext.serviceWorkers} to {@code "block"}.
+   * <p> <strong>NOTE:</strong> {@link com.microsoft.playwright.Page#route Page.route()} will not intercept requests intercepted by Service Worker. See
+   * <a href="https://github.com/microsoft/playwright/issues/1090">this</a> issue. We recommend disabling Service Workers
+   * when using request interception by setting {@code Browser.newContext.serviceWorkers} to {@code "block"}.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> An example of a naive handler that aborts all image requests:
    * <pre>{@code
@@ -6337,10 +6480,10 @@ public interface Page extends AutoCloseable {
    * });
    * }</pre>
    *
-   * <p> Page routes take precedence over browser context routes (set up with {@link BrowserContext#route
-   * BrowserContext.route()}) when request matches both handlers.
+   * <p> Page routes take precedence over browser context routes (set up with {@link
+   * com.microsoft.playwright.BrowserContext#route BrowserContext.route()}) when request matches both handlers.
    *
-   * <p> To remove a route with its handler you can use {@link Page#unroute Page.unroute()}.
+   * <p> To remove a route with its handler you can use {@link com.microsoft.playwright.Page#unroute Page.unroute()}.
    *
    * <p> <strong>NOTE:</strong> Enabling routing disables http cache.
    *
@@ -6407,7 +6550,7 @@ public interface Page extends AutoCloseable {
    *
    * <p> Triggers a {@code change} and {@code input} event once all the provided options have been selected.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * // Single selection matching the value or label
    * page.selectOption("select#colors", "blue");
@@ -6440,7 +6583,7 @@ public interface Page extends AutoCloseable {
    *
    * <p> Triggers a {@code change} and {@code input} event once all the provided options have been selected.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * // Single selection matching the value or label
    * page.selectOption("select#colors", "blue");
@@ -6471,7 +6614,7 @@ public interface Page extends AutoCloseable {
    *
    * <p> Triggers a {@code change} and {@code input} event once all the provided options have been selected.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * // Single selection matching the value or label
    * page.selectOption("select#colors", "blue");
@@ -6504,7 +6647,7 @@ public interface Page extends AutoCloseable {
    *
    * <p> Triggers a {@code change} and {@code input} event once all the provided options have been selected.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * // Single selection matching the value or label
    * page.selectOption("select#colors", "blue");
@@ -6535,7 +6678,7 @@ public interface Page extends AutoCloseable {
    *
    * <p> Triggers a {@code change} and {@code input} event once all the provided options have been selected.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * // Single selection matching the value or label
    * page.selectOption("select#colors", "blue");
@@ -6568,7 +6711,7 @@ public interface Page extends AutoCloseable {
    *
    * <p> Triggers a {@code change} and {@code input} event once all the provided options have been selected.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * // Single selection matching the value or label
    * page.selectOption("select#colors", "blue");
@@ -6599,7 +6742,7 @@ public interface Page extends AutoCloseable {
    *
    * <p> Triggers a {@code change} and {@code input} event once all the provided options have been selected.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * // Single selection matching the value or label
    * page.selectOption("select#colors", "blue");
@@ -6632,7 +6775,7 @@ public interface Page extends AutoCloseable {
    *
    * <p> Triggers a {@code change} and {@code input} event once all the provided options have been selected.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * // Single selection matching the value or label
    * page.selectOption("select#colors", "blue");
@@ -6663,7 +6806,7 @@ public interface Page extends AutoCloseable {
    *
    * <p> Triggers a {@code change} and {@code input} event once all the provided options have been selected.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * // Single selection matching the value or label
    * page.selectOption("select#colors", "blue");
@@ -6696,7 +6839,7 @@ public interface Page extends AutoCloseable {
    *
    * <p> Triggers a {@code change} and {@code input} event once all the provided options have been selected.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * // Single selection matching the value or label
    * page.selectOption("select#colors", "blue");
@@ -6727,7 +6870,7 @@ public interface Page extends AutoCloseable {
    *
    * <p> Triggers a {@code change} and {@code input} event once all the provided options have been selected.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * // Single selection matching the value or label
    * page.selectOption("select#colors", "blue");
@@ -6760,7 +6903,7 @@ public interface Page extends AutoCloseable {
    *
    * <p> Triggers a {@code change} and {@code input} event once all the provided options have been selected.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * // Single selection matching the value or label
    * page.selectOption("select#colors", "blue");
@@ -6786,7 +6929,7 @@ public interface Page extends AutoCloseable {
    * <li> Wait for <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks on the matched element,
    * unless {@code force} option is set. If the element is detached during the checks, the whole action is retried.</li>
    * <li> Scroll the element into view if needed.</li>
-   * <li> Use {@link Page#mouse Page.mouse()} to click in the center of the element.</li>
+   * <li> Use {@link com.microsoft.playwright.Page#mouse Page.mouse()} to click in the center of the element.</li>
    * <li> Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.</li>
    * <li> Ensure that the element is now checked or unchecked. If not, this method throws.</li>
    * </ol>
@@ -6810,7 +6953,7 @@ public interface Page extends AutoCloseable {
    * <li> Wait for <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks on the matched element,
    * unless {@code force} option is set. If the element is detached during the checks, the whole action is retried.</li>
    * <li> Scroll the element into view if needed.</li>
-   * <li> Use {@link Page#mouse Page.mouse()} to click in the center of the element.</li>
+   * <li> Use {@link com.microsoft.playwright.Page#mouse Page.mouse()} to click in the center of the element.</li>
    * <li> Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.</li>
    * <li> Ensure that the element is now checked or unchecked. If not, this method throws.</li>
    * </ol>
@@ -6846,19 +6989,19 @@ public interface Page extends AutoCloseable {
   /**
    * This setting will change the default maximum navigation time for the following methods and related shortcuts:
    * <ul>
-   * <li> {@link Page#goBack Page.goBack()}</li>
-   * <li> {@link Page#goForward Page.goForward()}</li>
-   * <li> {@link Page#navigate Page.navigate()}</li>
-   * <li> {@link Page#reload Page.reload()}</li>
-   * <li> {@link Page#setContent Page.setContent()}</li>
-   * <li> {@link Page#waitForNavigation Page.waitForNavigation()}</li>
-   * <li> {@link Page#waitForURL Page.waitForURL()}</li>
+   * <li> {@link com.microsoft.playwright.Page#goBack Page.goBack()}</li>
+   * <li> {@link com.microsoft.playwright.Page#goForward Page.goForward()}</li>
+   * <li> {@link com.microsoft.playwright.Page#navigate Page.navigate()}</li>
+   * <li> {@link com.microsoft.playwright.Page#reload Page.reload()}</li>
+   * <li> {@link com.microsoft.playwright.Page#setContent Page.setContent()}</li>
+   * <li> {@link com.microsoft.playwright.Page#waitForNavigation Page.waitForNavigation()}</li>
+   * <li> {@link com.microsoft.playwright.Page#waitForURL Page.waitForURL()}</li>
    * </ul>
    *
-   * <p> <strong>NOTE:</strong> {@link Page#setDefaultNavigationTimeout Page.setDefaultNavigationTimeout()} takes priority over {@link
-   * Page#setDefaultTimeout Page.setDefaultTimeout()}, {@link BrowserContext#setDefaultTimeout
-   * BrowserContext.setDefaultTimeout()} and {@link BrowserContext#setDefaultNavigationTimeout
-   * BrowserContext.setDefaultNavigationTimeout()}.
+   * <p> <strong>NOTE:</strong> {@link com.microsoft.playwright.Page#setDefaultNavigationTimeout Page.setDefaultNavigationTimeout()} takes priority over
+   * {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}, {@link
+   * com.microsoft.playwright.BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()} and {@link
+   * com.microsoft.playwright.BrowserContext#setDefaultNavigationTimeout BrowserContext.setDefaultNavigationTimeout()}.
    *
    * @param timeout Maximum navigation time in milliseconds
    * @since v1.8
@@ -6867,8 +7010,8 @@ public interface Page extends AutoCloseable {
   /**
    * This setting will change the default maximum time for all the methods accepting {@code timeout} option.
    *
-   * <p> <strong>NOTE:</strong> {@link Page#setDefaultNavigationTimeout Page.setDefaultNavigationTimeout()} takes priority over {@link
-   * Page#setDefaultTimeout Page.setDefaultTimeout()}.
+   * <p> <strong>NOTE:</strong> {@link com.microsoft.playwright.Page#setDefaultNavigationTimeout Page.setDefaultNavigationTimeout()} takes priority over
+   * {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}.
    *
    * @param timeout Maximum time in milliseconds
    * @since v1.8
@@ -6877,8 +7020,8 @@ public interface Page extends AutoCloseable {
   /**
    * The extra HTTP headers will be sent with every request the page initiates.
    *
-   * <p> <strong>NOTE:</strong> {@link Page#setExtraHTTPHeaders Page.setExtraHTTPHeaders()} does not guarantee the order of headers in the outgoing
-   * requests.
+   * <p> <strong>NOTE:</strong> {@link com.microsoft.playwright.Page#setExtraHTTPHeaders Page.setExtraHTTPHeaders()} does not guarantee the order of
+   * headers in the outgoing requests.
    *
    * @param headers An object containing additional HTTP headers to be sent with every request. All header values must be strings.
    * @since v1.8
@@ -7006,14 +7149,16 @@ public interface Page extends AutoCloseable {
   void setInputFiles(String selector, FilePayload[] files, SetInputFilesOptions options);
   /**
    * In the case of multiple pages in a single browser, each page can have its own viewport size. However, {@link
-   * Browser#newContext Browser.newContext()} allows to set viewport size (and more) for all pages in the context at once.
+   * com.microsoft.playwright.Browser#newContext Browser.newContext()} allows to set viewport size (and more) for all pages
+   * in the context at once.
    *
-   * <p> {@link Page#setViewportSize Page.setViewportSize()} will resize the page. A lot of websites don't expect phones to
-   * change size, so you should set the viewport size before navigating to the page. {@link Page#setViewportSize
-   * Page.setViewportSize()} will also reset {@code screen} size, use {@link Browser#newContext Browser.newContext()} with
-   * {@code screen} and {@code viewport} parameters if you need better control of these properties.
+   * <p> {@link com.microsoft.playwright.Page#setViewportSize Page.setViewportSize()} will resize the page. A lot of websites
+   * don't expect phones to change size, so you should set the viewport size before navigating to the page. {@link
+   * com.microsoft.playwright.Page#setViewportSize Page.setViewportSize()} will also reset {@code screen} size, use {@link
+   * com.microsoft.playwright.Browser#newContext Browser.newContext()} with {@code screen} and {@code viewport} parameters if
+   * you need better control of these properties.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * Page page = browser.newPage();
    * page.setViewportSize(640, 480);
@@ -7030,14 +7175,16 @@ public interface Page extends AutoCloseable {
    * <li> Wait for <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks on the matched element,
    * unless {@code force} option is set. If the element is detached during the checks, the whole action is retried.</li>
    * <li> Scroll the element into view if needed.</li>
-   * <li> Use {@link Page#touchscreen Page.touchscreen()} to tap the center of the element, or the specified {@code position}.</li>
+   * <li> Use {@link com.microsoft.playwright.Page#touchscreen Page.touchscreen()} to tap the center of the element, or the
+   * specified {@code position}.</li>
    * <li> Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.</li>
    * </ol>
    *
    * <p> When all steps combined have not finished during the specified {@code timeout}, this method throws a {@code
    * TimeoutError}. Passing zero timeout disables this.
    *
-   * <p> <strong>NOTE:</strong> {@link Page#tap Page.tap()} the method will throw if {@code hasTouch} option of the browser context is false.
+   * <p> <strong>NOTE:</strong> {@link com.microsoft.playwright.Page#tap Page.tap()} the method will throw if {@code hasTouch} option of the browser
+   * context is false.
    *
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used.
    * @since v1.8
@@ -7052,14 +7199,16 @@ public interface Page extends AutoCloseable {
    * <li> Wait for <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks on the matched element,
    * unless {@code force} option is set. If the element is detached during the checks, the whole action is retried.</li>
    * <li> Scroll the element into view if needed.</li>
-   * <li> Use {@link Page#touchscreen Page.touchscreen()} to tap the center of the element, or the specified {@code position}.</li>
+   * <li> Use {@link com.microsoft.playwright.Page#touchscreen Page.touchscreen()} to tap the center of the element, or the
+   * specified {@code position}.</li>
    * <li> Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.</li>
    * </ol>
    *
    * <p> When all steps combined have not finished during the specified {@code timeout}, this method throws a {@code
    * TimeoutError}. Passing zero timeout disables this.
    *
-   * <p> <strong>NOTE:</strong> {@link Page#tap Page.tap()} the method will throw if {@code hasTouch} option of the browser context is false.
+   * <p> <strong>NOTE:</strong> {@link com.microsoft.playwright.Page#tap Page.tap()} the method will throw if {@code hasTouch} option of the browser
+   * context is false.
    *
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used.
    * @since v1.8
@@ -7094,9 +7243,9 @@ public interface Page extends AutoCloseable {
    */
   Touchscreen touchscreen();
   /**
-   * @deprecated In most cases, you should use {@link Locator#fill Locator.fill()} instead. You only need to press keys one by one if
-   * there is special keyboard handling on the page - in this case use {@link Locator#pressSequentially
-   * Locator.pressSequentially()}.
+   * @deprecated In most cases, you should use {@link com.microsoft.playwright.Locator#fill Locator.fill()} instead. You only need to
+   * press keys one by one if there is special keyboard handling on the page - in this case use {@link
+   * com.microsoft.playwright.Locator#pressSequentially Locator.pressSequentially()}.
    *
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used.
    * @param text A text to type into a focused element.
@@ -7106,9 +7255,9 @@ public interface Page extends AutoCloseable {
     type(selector, text, null);
   }
   /**
-   * @deprecated In most cases, you should use {@link Locator#fill Locator.fill()} instead. You only need to press keys one by one if
-   * there is special keyboard handling on the page - in this case use {@link Locator#pressSequentially
-   * Locator.pressSequentially()}.
+   * @deprecated In most cases, you should use {@link com.microsoft.playwright.Locator#fill Locator.fill()} instead. You only need to
+   * press keys one by one if there is special keyboard handling on the page - in this case use {@link
+   * com.microsoft.playwright.Locator#pressSequentially Locator.pressSequentially()}.
    *
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used.
    * @param text A text to type into a focused element.
@@ -7124,7 +7273,7 @@ public interface Page extends AutoCloseable {
    * <li> Wait for <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks on the matched element,
    * unless {@code force} option is set. If the element is detached during the checks, the whole action is retried.</li>
    * <li> Scroll the element into view if needed.</li>
-   * <li> Use {@link Page#mouse Page.mouse()} to click in the center of the element.</li>
+   * <li> Use {@link com.microsoft.playwright.Page#mouse Page.mouse()} to click in the center of the element.</li>
    * <li> Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.</li>
    * <li> Ensure that the element is now unchecked. If not, this method throws.</li>
    * </ol>
@@ -7147,7 +7296,7 @@ public interface Page extends AutoCloseable {
    * <li> Wait for <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks on the matched element,
    * unless {@code force} option is set. If the element is detached during the checks, the whole action is retried.</li>
    * <li> Scroll the element into view if needed.</li>
-   * <li> Use {@link Page#mouse Page.mouse()} to click in the center of the element.</li>
+   * <li> Use {@link com.microsoft.playwright.Page#mouse Page.mouse()} to click in the center of the element.</li>
    * <li> Wait for initiated navigations to either succeed or fail, unless {@code noWaitAfter} option is set.</li>
    * <li> Ensure that the element is now unchecked. If not, this method throws.</li>
    * </ol>
@@ -7160,14 +7309,15 @@ public interface Page extends AutoCloseable {
    */
   void uncheck(String selector, UncheckOptions options);
   /**
-   * Removes all routes created with {@link Page#route Page.route()} and {@link Page#routeFromHAR Page.routeFromHAR()}.
+   * Removes all routes created with {@link com.microsoft.playwright.Page#route Page.route()} and {@link
+   * com.microsoft.playwright.Page#routeFromHAR Page.routeFromHAR()}.
    *
    * @since v1.41
    */
   void unrouteAll();
   /**
-   * Removes a route created with {@link Page#route Page.route()}. When {@code handler} is not specified, removes all routes
-   * for the {@code url}.
+   * Removes a route created with {@link com.microsoft.playwright.Page#route Page.route()}. When {@code handler} is not
+   * specified, removes all routes for the {@code url}.
    *
    * @param url A glob pattern, regex pattern or predicate receiving [URL] to match while routing.
    * @since v1.8
@@ -7176,8 +7326,8 @@ public interface Page extends AutoCloseable {
     unroute(url, null);
   }
   /**
-   * Removes a route created with {@link Page#route Page.route()}. When {@code handler} is not specified, removes all routes
-   * for the {@code url}.
+   * Removes a route created with {@link com.microsoft.playwright.Page#route Page.route()}. When {@code handler} is not
+   * specified, removes all routes for the {@code url}.
    *
    * @param url A glob pattern, regex pattern or predicate receiving [URL] to match while routing.
    * @param handler Optional handler function to route the request.
@@ -7185,8 +7335,8 @@ public interface Page extends AutoCloseable {
    */
   void unroute(String url, Consumer<Route> handler);
   /**
-   * Removes a route created with {@link Page#route Page.route()}. When {@code handler} is not specified, removes all routes
-   * for the {@code url}.
+   * Removes a route created with {@link com.microsoft.playwright.Page#route Page.route()}. When {@code handler} is not
+   * specified, removes all routes for the {@code url}.
    *
    * @param url A glob pattern, regex pattern or predicate receiving [URL] to match while routing.
    * @since v1.8
@@ -7195,8 +7345,8 @@ public interface Page extends AutoCloseable {
     unroute(url, null);
   }
   /**
-   * Removes a route created with {@link Page#route Page.route()}. When {@code handler} is not specified, removes all routes
-   * for the {@code url}.
+   * Removes a route created with {@link com.microsoft.playwright.Page#route Page.route()}. When {@code handler} is not
+   * specified, removes all routes for the {@code url}.
    *
    * @param url A glob pattern, regex pattern or predicate receiving [URL] to match while routing.
    * @param handler Optional handler function to route the request.
@@ -7204,8 +7354,8 @@ public interface Page extends AutoCloseable {
    */
   void unroute(Pattern url, Consumer<Route> handler);
   /**
-   * Removes a route created with {@link Page#route Page.route()}. When {@code handler} is not specified, removes all routes
-   * for the {@code url}.
+   * Removes a route created with {@link com.microsoft.playwright.Page#route Page.route()}. When {@code handler} is not
+   * specified, removes all routes for the {@code url}.
    *
    * @param url A glob pattern, regex pattern or predicate receiving [URL] to match while routing.
    * @since v1.8
@@ -7214,8 +7364,8 @@ public interface Page extends AutoCloseable {
     unroute(url, null);
   }
   /**
-   * Removes a route created with {@link Page#route Page.route()}. When {@code handler} is not specified, removes all routes
-   * for the {@code url}.
+   * Removes a route created with {@link com.microsoft.playwright.Page#route Page.route()}. When {@code handler} is not
+   * specified, removes all routes for the {@code url}.
    *
    * @param url A glob pattern, regex pattern or predicate receiving [URL] to match while routing.
    * @param handler Optional handler function to route the request.
@@ -7259,8 +7409,8 @@ public interface Page extends AutoCloseable {
   /**
    * Performs action and waits for a {@code ConsoleMessage} to be logged by in the page. If predicate is provided, it passes
    * {@code ConsoleMessage} value into the {@code predicate} function and waits for {@code predicate(message)} to return a
-   * truthy value. Will throw an error if the page is closed before the {@link Page#onConsoleMessage Page.onConsoleMessage()}
-   * event is fired.
+   * truthy value. Will throw an error if the page is closed before the {@link com.microsoft.playwright.Page#onConsoleMessage
+   * Page.onConsoleMessage()} event is fired.
    *
    * @param callback Callback that performs the action triggering the event.
    * @since v1.9
@@ -7271,8 +7421,8 @@ public interface Page extends AutoCloseable {
   /**
    * Performs action and waits for a {@code ConsoleMessage} to be logged by in the page. If predicate is provided, it passes
    * {@code ConsoleMessage} value into the {@code predicate} function and waits for {@code predicate(message)} to return a
-   * truthy value. Will throw an error if the page is closed before the {@link Page#onConsoleMessage Page.onConsoleMessage()}
-   * event is fired.
+   * truthy value. Will throw an error if the page is closed before the {@link com.microsoft.playwright.Page#onConsoleMessage
+   * Page.onConsoleMessage()} event is fired.
    *
    * @param callback Callback that performs the action triggering the event.
    * @since v1.9
@@ -7321,9 +7471,10 @@ public interface Page extends AutoCloseable {
   /**
    * Returns when the {@code expression} returns a truthy value. It resolves to a JSHandle of the truthy value.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
-   * <p> The {@link Page#waitForFunction Page.waitForFunction()} can be used to observe viewport size change:
+   * <p> The {@link com.microsoft.playwright.Page#waitForFunction Page.waitForFunction()} can be used to observe viewport size
+   * change:
    * <pre>{@code
    * import com.microsoft.playwright.*;
    *
@@ -7341,7 +7492,8 @@ public interface Page extends AutoCloseable {
    * }
    * }</pre>
    *
-   * <p> To pass an argument to the predicate of {@link Page#waitForFunction Page.waitForFunction()} function:
+   * <p> To pass an argument to the predicate of {@link com.microsoft.playwright.Page#waitForFunction Page.waitForFunction()}
+   * function:
    * <pre>{@code
    * String selector = ".foo";
    * page.waitForFunction("selector => !!document.querySelector(selector)", selector);
@@ -7358,9 +7510,10 @@ public interface Page extends AutoCloseable {
   /**
    * Returns when the {@code expression} returns a truthy value. It resolves to a JSHandle of the truthy value.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
-   * <p> The {@link Page#waitForFunction Page.waitForFunction()} can be used to observe viewport size change:
+   * <p> The {@link com.microsoft.playwright.Page#waitForFunction Page.waitForFunction()} can be used to observe viewport size
+   * change:
    * <pre>{@code
    * import com.microsoft.playwright.*;
    *
@@ -7378,7 +7531,8 @@ public interface Page extends AutoCloseable {
    * }
    * }</pre>
    *
-   * <p> To pass an argument to the predicate of {@link Page#waitForFunction Page.waitForFunction()} function:
+   * <p> To pass an argument to the predicate of {@link com.microsoft.playwright.Page#waitForFunction Page.waitForFunction()}
+   * function:
    * <pre>{@code
    * String selector = ".foo";
    * page.waitForFunction("selector => !!document.querySelector(selector)", selector);
@@ -7394,9 +7548,10 @@ public interface Page extends AutoCloseable {
   /**
    * Returns when the {@code expression} returns a truthy value. It resolves to a JSHandle of the truthy value.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
-   * <p> The {@link Page#waitForFunction Page.waitForFunction()} can be used to observe viewport size change:
+   * <p> The {@link com.microsoft.playwright.Page#waitForFunction Page.waitForFunction()} can be used to observe viewport size
+   * change:
    * <pre>{@code
    * import com.microsoft.playwright.*;
    *
@@ -7414,7 +7569,8 @@ public interface Page extends AutoCloseable {
    * }
    * }</pre>
    *
-   * <p> To pass an argument to the predicate of {@link Page#waitForFunction Page.waitForFunction()} function:
+   * <p> To pass an argument to the predicate of {@link com.microsoft.playwright.Page#waitForFunction Page.waitForFunction()}
+   * function:
    * <pre>{@code
    * String selector = ".foo";
    * page.waitForFunction("selector => !!document.querySelector(selector)", selector);
@@ -7432,7 +7588,7 @@ public interface Page extends AutoCloseable {
    * <p> This resolves when the page reaches a required load state, {@code load} by default. The navigation must have been
    * committed when this method is called. If current document has already reached the required state, resolves immediately.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * page.getByRole(AriaRole.BUTTON).click(); // Click triggers navigation.
    * page.waitForLoadState(); // The promise resolves after "load" event.
@@ -7465,7 +7621,7 @@ public interface Page extends AutoCloseable {
    * <p> This resolves when the page reaches a required load state, {@code load} by default. The navigation must have been
    * committed when this method is called. If current document has already reached the required state, resolves immediately.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * page.getByRole(AriaRole.BUTTON).click(); // Click triggers navigation.
    * page.waitForLoadState(); // The promise resolves after "load" event.
@@ -7490,7 +7646,7 @@ public interface Page extends AutoCloseable {
    * <p> This resolves when the page reaches a required load state, {@code load} by default. The navigation must have been
    * committed when this method is called. If current document has already reached the required state, resolves immediately.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * page.getByRole(AriaRole.BUTTON).click(); // Click triggers navigation.
    * page.waitForLoadState(); // The promise resolves after "load" event.
@@ -7516,7 +7672,7 @@ public interface Page extends AutoCloseable {
    */
   void waitForLoadState(LoadState state, WaitForLoadStateOptions options);
   /**
-   * @deprecated This method is inherently racy, please use {@link Page#waitForURL Page.waitForURL()} instead.
+   * @deprecated This method is inherently racy, please use {@link com.microsoft.playwright.Page#waitForURL Page.waitForURL()} instead.
    *
    * @param callback Callback that performs the action triggering the event.
    * @since v1.8
@@ -7525,7 +7681,7 @@ public interface Page extends AutoCloseable {
     return waitForNavigation(null, callback);
   }
   /**
-   * @deprecated This method is inherently racy, please use {@link Page#waitForURL Page.waitForURL()} instead.
+   * @deprecated This method is inherently racy, please use {@link com.microsoft.playwright.Page#waitForURL Page.waitForURL()} instead.
    *
    * @param callback Callback that performs the action triggering the event.
    * @since v1.8
@@ -7555,7 +7711,7 @@ public interface Page extends AutoCloseable {
    * Waits for the matching request and returns it. See <a
    * href="https://playwright.dev/java/docs/events#waiting-for-event">waiting for event</a> for more details about events.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * // Waits for the next request with the specified url
    * Request request = page.waitForRequest("https://example.com/resource", () -> {
@@ -7583,7 +7739,7 @@ public interface Page extends AutoCloseable {
    * Waits for the matching request and returns it. See <a
    * href="https://playwright.dev/java/docs/events#waiting-for-event">waiting for event</a> for more details about events.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * // Waits for the next request with the specified url
    * Request request = page.waitForRequest("https://example.com/resource", () -> {
@@ -7609,7 +7765,7 @@ public interface Page extends AutoCloseable {
    * Waits for the matching request and returns it. See <a
    * href="https://playwright.dev/java/docs/events#waiting-for-event">waiting for event</a> for more details about events.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * // Waits for the next request with the specified url
    * Request request = page.waitForRequest("https://example.com/resource", () -> {
@@ -7637,7 +7793,7 @@ public interface Page extends AutoCloseable {
    * Waits for the matching request and returns it. See <a
    * href="https://playwright.dev/java/docs/events#waiting-for-event">waiting for event</a> for more details about events.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * // Waits for the next request with the specified url
    * Request request = page.waitForRequest("https://example.com/resource", () -> {
@@ -7663,7 +7819,7 @@ public interface Page extends AutoCloseable {
    * Waits for the matching request and returns it. See <a
    * href="https://playwright.dev/java/docs/events#waiting-for-event">waiting for event</a> for more details about events.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * // Waits for the next request with the specified url
    * Request request = page.waitForRequest("https://example.com/resource", () -> {
@@ -7691,7 +7847,7 @@ public interface Page extends AutoCloseable {
    * Waits for the matching request and returns it. See <a
    * href="https://playwright.dev/java/docs/events#waiting-for-event">waiting for event</a> for more details about events.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * // Waits for the next request with the specified url
    * Request request = page.waitForRequest("https://example.com/resource", () -> {
@@ -7716,7 +7872,8 @@ public interface Page extends AutoCloseable {
   /**
    * Performs action and waits for a {@code Request} to finish loading. If predicate is provided, it passes {@code Request}
    * value into the {@code predicate} function and waits for {@code predicate(request)} to return a truthy value. Will throw
-   * an error if the page is closed before the {@link Page#onRequestFinished Page.onRequestFinished()} event is fired.
+   * an error if the page is closed before the {@link com.microsoft.playwright.Page#onRequestFinished
+   * Page.onRequestFinished()} event is fired.
    *
    * @param callback Callback that performs the action triggering the event.
    * @since v1.12
@@ -7727,7 +7884,8 @@ public interface Page extends AutoCloseable {
   /**
    * Performs action and waits for a {@code Request} to finish loading. If predicate is provided, it passes {@code Request}
    * value into the {@code predicate} function and waits for {@code predicate(request)} to return a truthy value. Will throw
-   * an error if the page is closed before the {@link Page#onRequestFinished Page.onRequestFinished()} event is fired.
+   * an error if the page is closed before the {@link com.microsoft.playwright.Page#onRequestFinished
+   * Page.onRequestFinished()} event is fired.
    *
    * @param callback Callback that performs the action triggering the event.
    * @since v1.12
@@ -7737,7 +7895,7 @@ public interface Page extends AutoCloseable {
    * Returns the matched response. See <a href="https://playwright.dev/java/docs/events#waiting-for-event">waiting for
    * event</a> for more details about events.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * // Waits for the next response with the specified url
    * Response response = page.waitForResponse("https://example.com/resource", () -> {
@@ -7765,7 +7923,7 @@ public interface Page extends AutoCloseable {
    * Returns the matched response. See <a href="https://playwright.dev/java/docs/events#waiting-for-event">waiting for
    * event</a> for more details about events.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * // Waits for the next response with the specified url
    * Response response = page.waitForResponse("https://example.com/resource", () -> {
@@ -7791,7 +7949,7 @@ public interface Page extends AutoCloseable {
    * Returns the matched response. See <a href="https://playwright.dev/java/docs/events#waiting-for-event">waiting for
    * event</a> for more details about events.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * // Waits for the next response with the specified url
    * Response response = page.waitForResponse("https://example.com/resource", () -> {
@@ -7819,7 +7977,7 @@ public interface Page extends AutoCloseable {
    * Returns the matched response. See <a href="https://playwright.dev/java/docs/events#waiting-for-event">waiting for
    * event</a> for more details about events.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * // Waits for the next response with the specified url
    * Response response = page.waitForResponse("https://example.com/resource", () -> {
@@ -7845,7 +8003,7 @@ public interface Page extends AutoCloseable {
    * Returns the matched response. See <a href="https://playwright.dev/java/docs/events#waiting-for-event">waiting for
    * event</a> for more details about events.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * // Waits for the next response with the specified url
    * Response response = page.waitForResponse("https://example.com/resource", () -> {
@@ -7873,7 +8031,7 @@ public interface Page extends AutoCloseable {
    * Returns the matched response. See <a href="https://playwright.dev/java/docs/events#waiting-for-event">waiting for
    * event</a> for more details about events.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * // Waits for the next response with the specified url
    * Response response = page.waitForResponse("https://example.com/resource", () -> {
@@ -7907,7 +8065,7 @@ public interface Page extends AutoCloseable {
    * will return immediately. If the selector doesn't satisfy the condition for the {@code timeout} milliseconds, the
    * function will throw.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> This method works across navigations:
    * <pre>{@code
@@ -7948,7 +8106,7 @@ public interface Page extends AutoCloseable {
    * will return immediately. If the selector doesn't satisfy the condition for the {@code timeout} milliseconds, the
    * function will throw.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> This method works across navigations:
    * <pre>{@code
@@ -7979,7 +8137,7 @@ public interface Page extends AutoCloseable {
    * The method will block until the condition returns true. All Playwright events will be dispatched while the method is
    * waiting for the condition.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> Use the method to wait for a condition that depends on page events:
    * <pre>{@code
@@ -7999,7 +8157,7 @@ public interface Page extends AutoCloseable {
    * The method will block until the condition returns true. All Playwright events will be dispatched while the method is
    * waiting for the condition.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> Use the method to wait for a condition that depends on page events:
    * <pre>{@code
@@ -8019,7 +8177,7 @@ public interface Page extends AutoCloseable {
    * <p> Note that {@code page.waitForTimeout()} should only be used for debugging. Tests using the timer in production are going
    * to be flaky. Use signals such as network events, selectors becoming visible and others instead.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * // wait for 1 second
    * page.waitForTimeout(1000);
@@ -8032,7 +8190,7 @@ public interface Page extends AutoCloseable {
   /**
    * Waits for the main frame to navigate to the given URL.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * page.click("a.delayed-navigation"); // Clicking the link will indirectly cause a navigation
    * page.waitForURL("**\/target.html");
@@ -8049,7 +8207,7 @@ public interface Page extends AutoCloseable {
   /**
    * Waits for the main frame to navigate to the given URL.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * page.click("a.delayed-navigation"); // Clicking the link will indirectly cause a navigation
    * page.waitForURL("**\/target.html");
@@ -8064,7 +8222,7 @@ public interface Page extends AutoCloseable {
   /**
    * Waits for the main frame to navigate to the given URL.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * page.click("a.delayed-navigation"); // Clicking the link will indirectly cause a navigation
    * page.waitForURL("**\/target.html");
@@ -8081,7 +8239,7 @@ public interface Page extends AutoCloseable {
   /**
    * Waits for the main frame to navigate to the given URL.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * page.click("a.delayed-navigation"); // Clicking the link will indirectly cause a navigation
    * page.waitForURL("**\/target.html");
@@ -8096,7 +8254,7 @@ public interface Page extends AutoCloseable {
   /**
    * Waits for the main frame to navigate to the given URL.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * page.click("a.delayed-navigation"); // Clicking the link will indirectly cause a navigation
    * page.waitForURL("**\/target.html");
@@ -8113,7 +8271,7 @@ public interface Page extends AutoCloseable {
   /**
    * Waits for the main frame to navigate to the given URL.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * page.click("a.delayed-navigation"); // Clicking the link will indirectly cause a navigation
    * page.waitForURL("**\/target.html");

--- a/playwright/src/main/java/com/microsoft/playwright/Playwright.java
+++ b/playwright/src/main/java/com/microsoft/playwright/Playwright.java
@@ -94,8 +94,8 @@ public interface Playwright extends AutoCloseable {
    */
   void close();
   /**
-   * Launches new Playwright driver process and connects to it. {@link Playwright#close Playwright.close()} should be called
-   * when the instance is no longer needed.
+   * Launches new Playwright driver process and connects to it. {@link com.microsoft.playwright.Playwright#close
+   * Playwright.close()} should be called when the instance is no longer needed.
    * <pre>{@code
    * Playwright playwright = Playwright.create();
    * Browser browser = playwright.webkit().launch();

--- a/playwright/src/main/java/com/microsoft/playwright/Request.java
+++ b/playwright/src/main/java/com/microsoft/playwright/Request.java
@@ -22,14 +22,15 @@ import java.util.*;
 /**
  * Whenever the page sends a request for a network resource the following sequence of events are emitted by {@code Page}:
  * <ul>
- * <li> {@link Page#onRequest Page.onRequest()} emitted when the request is issued by the page.</li>
- * <li> {@link Page#onResponse Page.onResponse()} emitted when/if the response status and headers are received for the request.</li>
- * <li> {@link Page#onRequestFinished Page.onRequestFinished()} emitted when the response body is downloaded and the request is
- * complete.</li>
+ * <li> {@link com.microsoft.playwright.Page#onRequest Page.onRequest()} emitted when the request is issued by the page.</li>
+ * <li> {@link com.microsoft.playwright.Page#onResponse Page.onResponse()} emitted when/if the response status and headers are
+ * received for the request.</li>
+ * <li> {@link com.microsoft.playwright.Page#onRequestFinished Page.onRequestFinished()} emitted when the response body is
+ * downloaded and the request is complete.</li>
  * </ul>
  *
  * <p> If request fails at some point, then instead of {@code "requestfinished"} event (and possibly instead of 'response'
- * event), the  {@link Page#onRequestFailed Page.onRequestFailed()} event is emitted.
+ * event), the  {@link com.microsoft.playwright.Page#onRequestFailed Page.onRequestFailed()} event is emitted.
  *
  * <p> <strong>NOTE:</strong> HTTP Error responses, such as 404 or 503, are still successful responses from HTTP standpoint, so request will complete
  * with {@code "requestfinished"} event.
@@ -47,7 +48,7 @@ public interface Request {
   /**
    * The method returns {@code null} unless this request has failed, as reported by {@code requestfailed} event.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> Example of logging of all the failed requests:
    * <pre>{@code
@@ -62,18 +63,18 @@ public interface Request {
   /**
    * Returns the {@code Frame} that initiated this request.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * String frameUrl = request.frame().url();
    * }</pre>
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
    * <p> Note that in some cases the frame is not available, and this method will throw.
    * <ul>
    * <li> When request originates in the Service Worker. You can use {@code request.serviceWorker()} to check that.</li>
    * <li> When navigation request is issued before the corresponding frame is created. You can use {@link
-   * Request#isNavigationRequest Request.isNavigationRequest()} to check that.</li>
+   * com.microsoft.playwright.Request#isNavigationRequest Request.isNavigationRequest()} to check that.</li>
    * </ul>
    *
    * <p> Here is an example that handles all the cases:
@@ -83,16 +84,16 @@ public interface Request {
   Frame frame();
   /**
    * An object with the request HTTP headers. The header names are lower-cased. Note that this method does not return
-   * security-related headers, including cookie-related ones. You can use {@link Request#allHeaders Request.allHeaders()} for
-   * complete list of headers that include {@code cookie} information.
+   * security-related headers, including cookie-related ones. You can use {@link com.microsoft.playwright.Request#allHeaders
+   * Request.allHeaders()} for complete list of headers that include {@code cookie} information.
    *
    * @since v1.8
    */
   Map<String, String> headers();
   /**
-   * An array with all the request HTTP headers associated with this request. Unlike {@link Request#allHeaders
-   * Request.allHeaders()}, header names are NOT lower-cased. Headers with multiple entries, such as {@code Set-Cookie},
-   * appear in the array multiple times.
+   * An array with all the request HTTP headers associated with this request. Unlike {@link
+   * com.microsoft.playwright.Request#allHeaders Request.allHeaders()}, header names are NOT lower-cased. Headers with
+   * multiple entries, such as {@code Set-Cookie}, appear in the array multiple times.
    *
    * @since v1.15
    */
@@ -108,7 +109,7 @@ public interface Request {
    * Whether this request is driving frame's navigation.
    *
    * <p> Some navigation requests are issued before the corresponding frame is created, and therefore do not have {@link
-   * Request#frame Request.frame()} available.
+   * com.microsoft.playwright.Request#frame Request.frame()} available.
    *
    * @since v1.8
    */
@@ -138,7 +139,7 @@ public interface Request {
    * connected by {@code redirectedFrom()} and {@code redirectedTo()} methods. When multiple server redirects has happened,
    * it is possible to construct the whole redirect chain by repeatedly calling {@code redirectedFrom()}.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> For example, if the website {@code http://example.com} redirects to {@code https://example.com}:
    * <pre>{@code
@@ -158,9 +159,9 @@ public interface Request {
   /**
    * New request issued by the browser if the server responded with redirect.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
-   * <p> This method is the opposite of {@link Request#redirectedFrom Request.redirectedFrom()}:
+   * <p> This method is the opposite of {@link com.microsoft.playwright.Request#redirectedFrom Request.redirectedFrom()}:
    * <pre>{@code
    * System.out.println(request.redirectedFrom().redirectedTo() == request); // true
    * }</pre>
@@ -193,7 +194,7 @@ public interface Request {
    * {@code responseEnd} becomes available when request finishes. Find more information at <a
    * href="https://developer.mozilla.org/en-US/docs/Web/API/PerformanceResourceTiming">Resource Timing API</a>.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * page.onRequestFinished(request -> {
    *   Timing timing = request.timing();

--- a/playwright/src/main/java/com/microsoft/playwright/Response.java
+++ b/playwright/src/main/java/com/microsoft/playwright/Response.java
@@ -56,16 +56,16 @@ public interface Response {
   boolean fromServiceWorker();
   /**
    * An object with the response HTTP headers. The header names are lower-cased. Note that this method does not return
-   * security-related headers, including cookie-related ones. You can use {@link Response#allHeaders Response.allHeaders()}
-   * for complete list of headers that include {@code cookie} information.
+   * security-related headers, including cookie-related ones. You can use {@link com.microsoft.playwright.Response#allHeaders
+   * Response.allHeaders()} for complete list of headers that include {@code cookie} information.
    *
    * @since v1.8
    */
   Map<String, String> headers();
   /**
-   * An array with all the request HTTP headers associated with this response. Unlike {@link Response#allHeaders
-   * Response.allHeaders()}, header names are NOT lower-cased. Headers with multiple entries, such as {@code Set-Cookie},
-   * appear in the array multiple times.
+   * An array with all the request HTTP headers associated with this response. Unlike {@link
+   * com.microsoft.playwright.Response#allHeaders Response.allHeaders()}, header names are NOT lower-cased. Headers with
+   * multiple entries, such as {@code Set-Cookie}, appear in the array multiple times.
    *
    * @since v1.15
    */

--- a/playwright/src/main/java/com/microsoft/playwright/Route.java
+++ b/playwright/src/main/java/com/microsoft/playwright/Route.java
@@ -20,8 +20,9 @@ import java.nio.file.Path;
 import java.util.*;
 
 /**
- * Whenever a network route is set up with {@link Page#route Page.route()} or {@link BrowserContext#route
- * BrowserContext.route()}, the {@code Route} object allows to handle the route.
+ * Whenever a network route is set up with {@link com.microsoft.playwright.Page#route Page.route()} or {@link
+ * com.microsoft.playwright.BrowserContext#route BrowserContext.route()}, the {@code Route} object allows to handle the
+ * route.
  *
  * <p> Learn more about <a href="https://playwright.dev/java/docs/network">networking</a>.
  */
@@ -334,7 +335,7 @@ public interface Route {
   /**
    * Continues route's request with optional overrides.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * page.route("**\/*", route -> {
    *   // Override headers
@@ -345,12 +346,12 @@ public interface Route {
    * });
    * }</pre>
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
    * <p> Note that any overrides such as {@code url} or {@code headers} only apply to the request being routed. If this request
    * results in a redirect, overrides will not be applied to the new redirected request. If you want to propagate a header
-   * through redirects, use the combination of {@link Route#fetch Route.fetch()} and {@link Route#fulfill Route.fulfill()}
-   * instead.
+   * through redirects, use the combination of {@link com.microsoft.playwright.Route#fetch Route.fetch()} and {@link
+   * com.microsoft.playwright.Route#fulfill Route.fulfill()} instead.
    *
    * @since v1.8
    */
@@ -360,7 +361,7 @@ public interface Route {
   /**
    * Continues route's request with optional overrides.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * page.route("**\/*", route -> {
    *   // Override headers
@@ -371,12 +372,12 @@ public interface Route {
    * });
    * }</pre>
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
    * <p> Note that any overrides such as {@code url} or {@code headers} only apply to the request being routed. If this request
    * results in a redirect, overrides will not be applied to the new redirected request. If you want to propagate a header
-   * through redirects, use the combination of {@link Route#fetch Route.fetch()} and {@link Route#fulfill Route.fulfill()}
-   * instead.
+   * through redirects, use the combination of {@link com.microsoft.playwright.Route#fetch Route.fetch()} and {@link
+   * com.microsoft.playwright.Route#fulfill Route.fulfill()} instead.
    *
    * @since v1.8
    */
@@ -387,7 +388,7 @@ public interface Route {
    * bottom-most handler first, then it'll fall back to the previous one and in the end will be aborted by the first
    * registered route.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * page.route("**\/*", route -> {
    *   // Runs last.
@@ -452,7 +453,7 @@ public interface Route {
    * bottom-most handler first, then it'll fall back to the previous one and in the end will be aborted by the first
    * registered route.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * page.route("**\/*", route -> {
    *   // Runs last.
@@ -513,7 +514,7 @@ public interface Route {
    * Performs the request and fetches result without fulfilling it, so that the response could be modified and then
    * fulfilled.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * page.route("https://dog.ceo/api/breeds/list/all", route -> {
    *   APIResponse response = route.fetch();
@@ -526,11 +527,11 @@ public interface Route {
    * });
    * }</pre>
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
    * <p> Note that {@code headers} option will apply to the fetched request as well as any redirects initiated by it. If you want
-   * to only apply {@code headers} to the original request, but not to redirects, look into {@link Route#resume
-   * Route.resume()} instead.
+   * to only apply {@code headers} to the original request, but not to redirects, look into {@link
+   * com.microsoft.playwright.Route#resume Route.resume()} instead.
    *
    * @since v1.29
    */
@@ -541,7 +542,7 @@ public interface Route {
    * Performs the request and fetches result without fulfilling it, so that the response could be modified and then
    * fulfilled.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * page.route("https://dog.ceo/api/breeds/list/all", route -> {
    *   APIResponse response = route.fetch();
@@ -554,11 +555,11 @@ public interface Route {
    * });
    * }</pre>
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
    * <p> Note that {@code headers} option will apply to the fetched request as well as any redirects initiated by it. If you want
-   * to only apply {@code headers} to the original request, but not to redirects, look into {@link Route#resume
-   * Route.resume()} instead.
+   * to only apply {@code headers} to the original request, but not to redirects, look into {@link
+   * com.microsoft.playwright.Route#resume Route.resume()} instead.
    *
    * @since v1.29
    */
@@ -566,7 +567,7 @@ public interface Route {
   /**
    * Fulfills route's request with given response.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> An example of fulfilling all requests with 404 responses:
    * <pre>{@code
@@ -592,7 +593,7 @@ public interface Route {
   /**
    * Fulfills route's request with given response.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> An example of fulfilling all requests with 404 responses:
    * <pre>{@code

--- a/playwright/src/main/java/com/microsoft/playwright/Selectors.java
+++ b/playwright/src/main/java/com/microsoft/playwright/Selectors.java
@@ -44,7 +44,7 @@ public interface Selectors {
   /**
    * Selectors must be registered before creating the page.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> An example of registering selector engine that queries elements based on a tag name:
    * <pre>{@code
@@ -84,7 +84,7 @@ public interface Selectors {
   /**
    * Selectors must be registered before creating the page.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> An example of registering selector engine that queries elements based on a tag name:
    * <pre>{@code
@@ -122,7 +122,7 @@ public interface Selectors {
   /**
    * Selectors must be registered before creating the page.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> An example of registering selector engine that queries elements based on a tag name:
    * <pre>{@code
@@ -162,7 +162,7 @@ public interface Selectors {
   /**
    * Selectors must be registered before creating the page.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> An example of registering selector engine that queries elements based on a tag name:
    * <pre>{@code
@@ -198,8 +198,8 @@ public interface Selectors {
    */
   void register(String name, Path script, RegisterOptions options);
   /**
-   * Defines custom attribute name to be used in {@link Page#getByTestId Page.getByTestId()}. {@code data-testid} is used by
-   * default.
+   * Defines custom attribute name to be used in {@link com.microsoft.playwright.Page#getByTestId Page.getByTestId()}. {@code
+   * data-testid} is used by default.
    *
    * @param attributeName Test id attribute name.
    * @since v1.27

--- a/playwright/src/main/java/com/microsoft/playwright/Touchscreen.java
+++ b/playwright/src/main/java/com/microsoft/playwright/Touchscreen.java
@@ -25,7 +25,8 @@ public interface Touchscreen {
   /**
    * Dispatches a {@code touchstart} and {@code touchend} event with a single touch at the position ({@code x},{@code y}).
    *
-   * <p> <strong>NOTE:</strong> {@link Page#tap Page.tap()} the method will throw if {@code hasTouch} option of the browser context is false.
+   * <p> <strong>NOTE:</strong> {@link com.microsoft.playwright.Page#tap Page.tap()} the method will throw if {@code hasTouch} option of the browser
+   * context is false.
    *
    * @since v1.8
    */

--- a/playwright/src/main/java/com/microsoft/playwright/Tracing.java
+++ b/playwright/src/main/java/com/microsoft/playwright/Tracing.java
@@ -39,8 +39,9 @@ public interface Tracing {
   class StartOptions {
     /**
      * If specified, intermediate trace files are going to be saved into the files with the given name prefix inside the {@code
-     * tracesDir} folder specified in {@link BrowserType#launch BrowserType.launch()}. To specify the final trace zip file
-     * name, you need to pass {@code path} option to {@link Tracing#stop Tracing.stop()} instead.
+     * tracesDir} folder specified in {@link com.microsoft.playwright.BrowserType#launch BrowserType.launch()}. To specify the
+     * final trace zip file name, you need to pass {@code path} option to {@link com.microsoft.playwright.Tracing#stop
+     * Tracing.stop()} instead.
      */
     public String name;
     /**
@@ -68,8 +69,9 @@ public interface Tracing {
 
     /**
      * If specified, intermediate trace files are going to be saved into the files with the given name prefix inside the {@code
-     * tracesDir} folder specified in {@link BrowserType#launch BrowserType.launch()}. To specify the final trace zip file
-     * name, you need to pass {@code path} option to {@link Tracing#stop Tracing.stop()} instead.
+     * tracesDir} folder specified in {@link com.microsoft.playwright.BrowserType#launch BrowserType.launch()}. To specify the
+     * final trace zip file name, you need to pass {@code path} option to {@link com.microsoft.playwright.Tracing#stop
+     * Tracing.stop()} instead.
      */
     public StartOptions setName(String name) {
       this.name = name;
@@ -113,8 +115,9 @@ public interface Tracing {
   class StartChunkOptions {
     /**
      * If specified, intermediate trace files are going to be saved into the files with the given name prefix inside the {@code
-     * tracesDir} folder specified in {@link BrowserType#launch BrowserType.launch()}. To specify the final trace zip file
-     * name, you need to pass {@code path} option to {@link Tracing#stopChunk Tracing.stopChunk()} instead.
+     * tracesDir} folder specified in {@link com.microsoft.playwright.BrowserType#launch BrowserType.launch()}. To specify the
+     * final trace zip file name, you need to pass {@code path} option to {@link com.microsoft.playwright.Tracing#stopChunk
+     * Tracing.stopChunk()} instead.
      */
     public String name;
     /**
@@ -124,8 +127,9 @@ public interface Tracing {
 
     /**
      * If specified, intermediate trace files are going to be saved into the files with the given name prefix inside the {@code
-     * tracesDir} folder specified in {@link BrowserType#launch BrowserType.launch()}. To specify the final trace zip file
-     * name, you need to pass {@code path} option to {@link Tracing#stopChunk Tracing.stopChunk()} instead.
+     * tracesDir} folder specified in {@link com.microsoft.playwright.BrowserType#launch BrowserType.launch()}. To specify the
+     * final trace zip file name, you need to pass {@code path} option to {@link com.microsoft.playwright.Tracing#stopChunk
+     * Tracing.stopChunk()} instead.
      */
     public StartChunkOptions setName(String name) {
       this.name = name;
@@ -155,14 +159,14 @@ public interface Tracing {
   }
   class StopChunkOptions {
     /**
-     * Export trace collected since the last {@link Tracing#startChunk Tracing.startChunk()} call into the file with the given
-     * path.
+     * Export trace collected since the last {@link com.microsoft.playwright.Tracing#startChunk Tracing.startChunk()} call into
+     * the file with the given path.
      */
     public Path path;
 
     /**
-     * Export trace collected since the last {@link Tracing#startChunk Tracing.startChunk()} call into the file with the given
-     * path.
+     * Export trace collected since the last {@link com.microsoft.playwright.Tracing#startChunk Tracing.startChunk()} call into
+     * the file with the given path.
      */
     public StopChunkOptions setPath(Path path) {
       this.path = path;
@@ -172,7 +176,7 @@ public interface Tracing {
   /**
    * Start tracing.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * context.tracing().start(new Tracing.StartOptions()
    *   .setScreenshots(true)
@@ -191,7 +195,7 @@ public interface Tracing {
   /**
    * Start tracing.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * context.tracing().start(new Tracing.StartOptions()
    *   .setScreenshots(true)
@@ -207,10 +211,11 @@ public interface Tracing {
   void start(StartOptions options);
   /**
    * Start a new trace chunk. If you'd like to record multiple traces on the same {@code BrowserContext}, use {@link
-   * Tracing#start Tracing.start()} once, and then create multiple trace chunks with {@link Tracing#startChunk
-   * Tracing.startChunk()} and {@link Tracing#stopChunk Tracing.stopChunk()}.
+   * com.microsoft.playwright.Tracing#start Tracing.start()} once, and then create multiple trace chunks with {@link
+   * com.microsoft.playwright.Tracing#startChunk Tracing.startChunk()} and {@link com.microsoft.playwright.Tracing#stopChunk
+   * Tracing.stopChunk()}.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * context.tracing().start(new Tracing.StartOptions()
    *   .setScreenshots(true)
@@ -238,10 +243,11 @@ public interface Tracing {
   }
   /**
    * Start a new trace chunk. If you'd like to record multiple traces on the same {@code BrowserContext}, use {@link
-   * Tracing#start Tracing.start()} once, and then create multiple trace chunks with {@link Tracing#startChunk
-   * Tracing.startChunk()} and {@link Tracing#stopChunk Tracing.stopChunk()}.
+   * com.microsoft.playwright.Tracing#start Tracing.start()} once, and then create multiple trace chunks with {@link
+   * com.microsoft.playwright.Tracing#startChunk Tracing.startChunk()} and {@link com.microsoft.playwright.Tracing#stopChunk
+   * Tracing.stopChunk()}.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * context.tracing().start(new Tracing.StartOptions()
    *   .setScreenshots(true)
@@ -280,7 +286,8 @@ public interface Tracing {
    */
   void stop(StopOptions options);
   /**
-   * Stop the trace chunk. See {@link Tracing#startChunk Tracing.startChunk()} for more details about multiple trace chunks.
+   * Stop the trace chunk. See {@link com.microsoft.playwright.Tracing#startChunk Tracing.startChunk()} for more details
+   * about multiple trace chunks.
    *
    * @since v1.15
    */
@@ -288,7 +295,8 @@ public interface Tracing {
     stopChunk(null);
   }
   /**
-   * Stop the trace chunk. See {@link Tracing#startChunk Tracing.startChunk()} for more details about multiple trace chunks.
+   * Stop the trace chunk. See {@link com.microsoft.playwright.Tracing#startChunk Tracing.startChunk()} for more details
+   * about multiple trace chunks.
    *
    * @since v1.15
    */

--- a/playwright/src/main/java/com/microsoft/playwright/WebError.java
+++ b/playwright/src/main/java/com/microsoft/playwright/WebError.java
@@ -19,7 +19,7 @@ package com.microsoft.playwright;
 
 /**
  * {@code WebError} class represents an unhandled exception thrown in the page. It is dispatched via the {@link
- * BrowserContext#onWebError BrowserContext.onWebError()} event.
+ * com.microsoft.playwright.BrowserContext#onWebError BrowserContext.onWebError()} event.
  * <pre>{@code
  * // Log all uncaught errors to the terminal
  * context.onWebError(webError -> {

--- a/playwright/src/main/java/com/microsoft/playwright/WebSocket.java
+++ b/playwright/src/main/java/com/microsoft/playwright/WebSocket.java
@@ -67,7 +67,8 @@ public interface WebSocket {
     public Predicate<WebSocketFrame> predicate;
     /**
      * Maximum time to wait for in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The
-     * default value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()}.
+     * default value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()}.
      */
     public Double timeout;
 
@@ -80,7 +81,8 @@ public interface WebSocket {
     }
     /**
      * Maximum time to wait for in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The
-     * default value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()}.
+     * default value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()}.
      */
     public WaitForFrameReceivedOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -94,7 +96,8 @@ public interface WebSocket {
     public Predicate<WebSocketFrame> predicate;
     /**
      * Maximum time to wait for in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The
-     * default value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()}.
+     * default value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()}.
      */
     public Double timeout;
 
@@ -107,7 +110,8 @@ public interface WebSocket {
     }
     /**
      * Maximum time to wait for in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The
-     * default value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()}.
+     * default value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()}.
      */
     public WaitForFrameSentOptions setTimeout(double timeout) {
       this.timeout = timeout;

--- a/playwright/src/main/java/com/microsoft/playwright/WebSocketFrame.java
+++ b/playwright/src/main/java/com/microsoft/playwright/WebSocketFrame.java
@@ -19,8 +19,8 @@ package com.microsoft.playwright;
 
 /**
  * The {@code WebSocketFrame} class represents frames sent over {@code WebSocket} connections in the page. Frame payload is
- * returned by either {@link WebSocketFrame#text WebSocketFrame.text()} or {@link WebSocketFrame#binary
- * WebSocketFrame.binary()} method depending on the its type.
+ * returned by either {@link com.microsoft.playwright.WebSocketFrame#text WebSocketFrame.text()} or {@link
+ * com.microsoft.playwright.WebSocketFrame#binary WebSocketFrame.binary()} method depending on the its type.
  */
 public interface WebSocketFrame {
   /**

--- a/playwright/src/main/java/com/microsoft/playwright/Worker.java
+++ b/playwright/src/main/java/com/microsoft/playwright/Worker.java
@@ -47,13 +47,15 @@ public interface Worker {
   class WaitForCloseOptions {
     /**
      * Maximum time to wait for in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The
-     * default value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()}.
+     * default value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()}.
      */
     public Double timeout;
 
     /**
      * Maximum time to wait for in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The
-     * default value can be changed by using the {@link BrowserContext#setDefaultTimeout BrowserContext.setDefaultTimeout()}.
+     * default value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
+     * BrowserContext.setDefaultTimeout()}.
      */
     public WaitForCloseOptions setTimeout(double timeout) {
       this.timeout = timeout;
@@ -63,13 +65,14 @@ public interface Worker {
   /**
    * Returns the return value of {@code expression}.
    *
-   * <p> If the function passed to the {@link Worker#evaluate Worker.evaluate()} returns a <a
+   * <p> If the function passed to the {@link com.microsoft.playwright.Worker#evaluate Worker.evaluate()} returns a <a
    * href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>, then {@link
-   * Worker#evaluate Worker.evaluate()} would wait for the promise to resolve and return its value.
+   * com.microsoft.playwright.Worker#evaluate Worker.evaluate()} would wait for the promise to resolve and return its value.
    *
-   * <p> If the function passed to the {@link Worker#evaluate Worker.evaluate()} returns a non-[Serializable] value, then {@link
-   * Worker#evaluate Worker.evaluate()} returns {@code undefined}. Playwright also supports transferring some additional
-   * values that are not serializable by {@code JSON}: {@code -0}, {@code NaN}, {@code Infinity}, {@code -Infinity}.
+   * <p> If the function passed to the {@link com.microsoft.playwright.Worker#evaluate Worker.evaluate()} returns a
+   * non-[Serializable] value, then {@link com.microsoft.playwright.Worker#evaluate Worker.evaluate()} returns {@code
+   * undefined}. Playwright also supports transferring some additional values that are not serializable by {@code JSON}:
+   * {@code -0}, {@code NaN}, {@code Infinity}, {@code -Infinity}.
    *
    * @param expression JavaScript expression to be evaluated in the browser context. If the expression evaluates to a function, the function is
    * automatically invoked.
@@ -81,13 +84,14 @@ public interface Worker {
   /**
    * Returns the return value of {@code expression}.
    *
-   * <p> If the function passed to the {@link Worker#evaluate Worker.evaluate()} returns a <a
+   * <p> If the function passed to the {@link com.microsoft.playwright.Worker#evaluate Worker.evaluate()} returns a <a
    * href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>, then {@link
-   * Worker#evaluate Worker.evaluate()} would wait for the promise to resolve and return its value.
+   * com.microsoft.playwright.Worker#evaluate Worker.evaluate()} would wait for the promise to resolve and return its value.
    *
-   * <p> If the function passed to the {@link Worker#evaluate Worker.evaluate()} returns a non-[Serializable] value, then {@link
-   * Worker#evaluate Worker.evaluate()} returns {@code undefined}. Playwright also supports transferring some additional
-   * values that are not serializable by {@code JSON}: {@code -0}, {@code NaN}, {@code Infinity}, {@code -Infinity}.
+   * <p> If the function passed to the {@link com.microsoft.playwright.Worker#evaluate Worker.evaluate()} returns a
+   * non-[Serializable] value, then {@link com.microsoft.playwright.Worker#evaluate Worker.evaluate()} returns {@code
+   * undefined}. Playwright also supports transferring some additional values that are not serializable by {@code JSON}:
+   * {@code -0}, {@code NaN}, {@code Infinity}, {@code -Infinity}.
    *
    * @param expression JavaScript expression to be evaluated in the browser context. If the expression evaluates to a function, the function is
    * automatically invoked.
@@ -98,12 +102,14 @@ public interface Worker {
   /**
    * Returns the return value of {@code expression} as a {@code JSHandle}.
    *
-   * <p> The only difference between {@link Worker#evaluate Worker.evaluate()} and {@link Worker#evaluateHandle
-   * Worker.evaluateHandle()} is that {@link Worker#evaluateHandle Worker.evaluateHandle()} returns {@code JSHandle}.
+   * <p> The only difference between {@link com.microsoft.playwright.Worker#evaluate Worker.evaluate()} and {@link
+   * com.microsoft.playwright.Worker#evaluateHandle Worker.evaluateHandle()} is that {@link
+   * com.microsoft.playwright.Worker#evaluateHandle Worker.evaluateHandle()} returns {@code JSHandle}.
    *
-   * <p> If the function passed to the {@link Worker#evaluateHandle Worker.evaluateHandle()} returns a <a
-   * href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>, then {@link
-   * Worker#evaluateHandle Worker.evaluateHandle()} would wait for the promise to resolve and return its value.
+   * <p> If the function passed to the {@link com.microsoft.playwright.Worker#evaluateHandle Worker.evaluateHandle()} returns a
+   * <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>, then
+   * {@link com.microsoft.playwright.Worker#evaluateHandle Worker.evaluateHandle()} would wait for the promise to resolve and
+   * return its value.
    *
    * @param expression JavaScript expression to be evaluated in the browser context. If the expression evaluates to a function, the function is
    * automatically invoked.
@@ -115,12 +121,14 @@ public interface Worker {
   /**
    * Returns the return value of {@code expression} as a {@code JSHandle}.
    *
-   * <p> The only difference between {@link Worker#evaluate Worker.evaluate()} and {@link Worker#evaluateHandle
-   * Worker.evaluateHandle()} is that {@link Worker#evaluateHandle Worker.evaluateHandle()} returns {@code JSHandle}.
+   * <p> The only difference between {@link com.microsoft.playwright.Worker#evaluate Worker.evaluate()} and {@link
+   * com.microsoft.playwright.Worker#evaluateHandle Worker.evaluateHandle()} is that {@link
+   * com.microsoft.playwright.Worker#evaluateHandle Worker.evaluateHandle()} returns {@code JSHandle}.
    *
-   * <p> If the function passed to the {@link Worker#evaluateHandle Worker.evaluateHandle()} returns a <a
-   * href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>, then {@link
-   * Worker#evaluateHandle Worker.evaluateHandle()} would wait for the promise to resolve and return its value.
+   * <p> If the function passed to the {@link com.microsoft.playwright.Worker#evaluateHandle Worker.evaluateHandle()} returns a
+   * <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>, then
+   * {@link com.microsoft.playwright.Worker#evaluateHandle Worker.evaluateHandle()} would wait for the promise to resolve and
+   * return its value.
    *
    * @param expression JavaScript expression to be evaluated in the browser context. If the expression evaluates to a function, the function is
    * automatically invoked.

--- a/playwright/src/main/java/com/microsoft/playwright/assertions/APIResponseAssertions.java
+++ b/playwright/src/main/java/com/microsoft/playwright/assertions/APIResponseAssertions.java
@@ -49,7 +49,7 @@ public interface APIResponseAssertions {
   /**
    * Ensures the response status code is within {@code 200..299} range.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * assertThat(response).isOK();
    * }</pre>

--- a/playwright/src/main/java/com/microsoft/playwright/assertions/LocatorAssertions.java
+++ b/playwright/src/main/java/com/microsoft/playwright/assertions/LocatorAssertions.java
@@ -430,7 +430,7 @@ public interface LocatorAssertions {
    * Ensures that {@code Locator} points to an element that is <a
    * href="https://developer.mozilla.org/en-US/docs/Web/API/Node/isConnected">connected</a> to a Document or a ShadowRoot.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * assertThat(page.getByText("Hidden text")).isAttached();
    * }</pre>
@@ -444,7 +444,7 @@ public interface LocatorAssertions {
    * Ensures that {@code Locator} points to an element that is <a
    * href="https://developer.mozilla.org/en-US/docs/Web/API/Node/isConnected">connected</a> to a Document or a ShadowRoot.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * assertThat(page.getByText("Hidden text")).isAttached();
    * }</pre>
@@ -455,7 +455,7 @@ public interface LocatorAssertions {
   /**
    * Ensures the {@code Locator} points to a checked input.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * assertThat(page.getByLabel("Subscribe to newsletter")).isChecked();
    * }</pre>
@@ -468,7 +468,7 @@ public interface LocatorAssertions {
   /**
    * Ensures the {@code Locator} points to a checked input.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * assertThat(page.getByLabel("Subscribe to newsletter")).isChecked();
    * }</pre>
@@ -484,7 +484,7 @@ public interface LocatorAssertions {
    * {@code option}, {@code optgroup} can be disabled by setting "disabled" attribute. "disabled" attribute on other elements
    * is ignored by the browser.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * assertThat(page.locator("button.submit")).isDisabled();
    * }</pre>
@@ -502,7 +502,7 @@ public interface LocatorAssertions {
    * {@code option}, {@code optgroup} can be disabled by setting "disabled" attribute. "disabled" attribute on other elements
    * is ignored by the browser.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * assertThat(page.locator("button.submit")).isDisabled();
    * }</pre>
@@ -513,7 +513,7 @@ public interface LocatorAssertions {
   /**
    * Ensures the {@code Locator} points to an editable element.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * assertThat(page.getByRole(AriaRole.TEXTBOX)).isEditable();
    * }</pre>
@@ -526,7 +526,7 @@ public interface LocatorAssertions {
   /**
    * Ensures the {@code Locator} points to an editable element.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * assertThat(page.getByRole(AriaRole.TEXTBOX)).isEditable();
    * }</pre>
@@ -537,7 +537,7 @@ public interface LocatorAssertions {
   /**
    * Ensures the {@code Locator} points to an empty editable element or to a DOM node that has no text.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * assertThat(page.locator("div.warning")).isEmpty();
    * }</pre>
@@ -550,7 +550,7 @@ public interface LocatorAssertions {
   /**
    * Ensures the {@code Locator} points to an empty editable element or to a DOM node that has no text.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * assertThat(page.locator("div.warning")).isEmpty();
    * }</pre>
@@ -561,7 +561,7 @@ public interface LocatorAssertions {
   /**
    * Ensures the {@code Locator} points to an enabled element.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * assertThat(page.locator("button.submit")).isEnabled();
    * }</pre>
@@ -574,7 +574,7 @@ public interface LocatorAssertions {
   /**
    * Ensures the {@code Locator} points to an enabled element.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * assertThat(page.locator("button.submit")).isEnabled();
    * }</pre>
@@ -585,7 +585,7 @@ public interface LocatorAssertions {
   /**
    * Ensures the {@code Locator} points to a focused DOM node.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * assertThat(page.getByRole(AriaRole.TEXTBOX)).isFocused();
    * }</pre>
@@ -598,7 +598,7 @@ public interface LocatorAssertions {
   /**
    * Ensures the {@code Locator} points to a focused DOM node.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * assertThat(page.getByRole(AriaRole.TEXTBOX)).isFocused();
    * }</pre>
@@ -610,7 +610,7 @@ public interface LocatorAssertions {
    * Ensures that {@code Locator} either does not resolve to any DOM node, or resolves to a <a
    * href="https://playwright.dev/java/docs/actionability#visible">non-visible</a> one.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * assertThat(page.locator(".my-element")).isHidden();
    * }</pre>
@@ -624,7 +624,7 @@ public interface LocatorAssertions {
    * Ensures that {@code Locator} either does not resolve to any DOM node, or resolves to a <a
    * href="https://playwright.dev/java/docs/actionability#visible">non-visible</a> one.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * assertThat(page.locator(".my-element")).isHidden();
    * }</pre>
@@ -636,7 +636,7 @@ public interface LocatorAssertions {
    * Ensures the {@code Locator} points to an element that intersects viewport, according to the <a
    * href="https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API">intersection observer API</a>.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * Locator locator = page.getByRole(AriaRole.BUTTON);
    * // Make sure at least some part of element intersects viewport.
@@ -656,7 +656,7 @@ public interface LocatorAssertions {
    * Ensures the {@code Locator} points to an element that intersects viewport, according to the <a
    * href="https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API">intersection observer API</a>.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * Locator locator = page.getByRole(AriaRole.BUTTON);
    * // Make sure at least some part of element intersects viewport.
@@ -674,9 +674,10 @@ public interface LocatorAssertions {
    * Ensures that {@code Locator} points to an attached and <a
    * href="https://playwright.dev/java/docs/actionability#visible">visible</a> DOM node.
    *
-   * <p> To check that at least one element from the list is visible, use {@link Locator#first Locator.first()}.
+   * <p> To check that at least one element from the list is visible, use {@link com.microsoft.playwright.Locator#first
+   * Locator.first()}.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * // A specific element is visible.
    * assertThat(page.getByText("Welcome")).isVisible();
@@ -701,9 +702,10 @@ public interface LocatorAssertions {
    * Ensures that {@code Locator} points to an attached and <a
    * href="https://playwright.dev/java/docs/actionability#visible">visible</a> DOM node.
    *
-   * <p> To check that at least one element from the list is visible, use {@link Locator#first Locator.first()}.
+   * <p> To check that at least one element from the list is visible, use {@link com.microsoft.playwright.Locator#first
+   * Locator.first()}.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * // A specific element is visible.
    * assertThat(page.getByText("Welcome")).isVisible();
@@ -726,12 +728,12 @@ public interface LocatorAssertions {
    * Ensures the {@code Locator} points to an element that contains the given text. All nested elements will be considered
    * when computing the text content of the element. You can use regular expressions for the value as well.
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
    * <p> When {@code expected} parameter is a string, Playwright will normalize whitespaces and line breaks both in the actual
    * text and in the expected string before matching. When regular expression is used, the actual text is matched as is.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * assertThat(page.locator(".title")).containsText("substring");
    * }</pre>
@@ -771,12 +773,12 @@ public interface LocatorAssertions {
    * Ensures the {@code Locator} points to an element that contains the given text. All nested elements will be considered
    * when computing the text content of the element. You can use regular expressions for the value as well.
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
    * <p> When {@code expected} parameter is a string, Playwright will normalize whitespaces and line breaks both in the actual
    * text and in the expected string before matching. When regular expression is used, the actual text is matched as is.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * assertThat(page.locator(".title")).containsText("substring");
    * }</pre>
@@ -814,12 +816,12 @@ public interface LocatorAssertions {
    * Ensures the {@code Locator} points to an element that contains the given text. All nested elements will be considered
    * when computing the text content of the element. You can use regular expressions for the value as well.
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
    * <p> When {@code expected} parameter is a string, Playwright will normalize whitespaces and line breaks both in the actual
    * text and in the expected string before matching. When regular expression is used, the actual text is matched as is.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * assertThat(page.locator(".title")).containsText("substring");
    * }</pre>
@@ -859,12 +861,12 @@ public interface LocatorAssertions {
    * Ensures the {@code Locator} points to an element that contains the given text. All nested elements will be considered
    * when computing the text content of the element. You can use regular expressions for the value as well.
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
    * <p> When {@code expected} parameter is a string, Playwright will normalize whitespaces and line breaks both in the actual
    * text and in the expected string before matching. When regular expression is used, the actual text is matched as is.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * assertThat(page.locator(".title")).containsText("substring");
    * }</pre>
@@ -902,12 +904,12 @@ public interface LocatorAssertions {
    * Ensures the {@code Locator} points to an element that contains the given text. All nested elements will be considered
    * when computing the text content of the element. You can use regular expressions for the value as well.
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
    * <p> When {@code expected} parameter is a string, Playwright will normalize whitespaces and line breaks both in the actual
    * text and in the expected string before matching. When regular expression is used, the actual text is matched as is.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * assertThat(page.locator(".title")).containsText("substring");
    * }</pre>
@@ -947,12 +949,12 @@ public interface LocatorAssertions {
    * Ensures the {@code Locator} points to an element that contains the given text. All nested elements will be considered
    * when computing the text content of the element. You can use regular expressions for the value as well.
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
    * <p> When {@code expected} parameter is a string, Playwright will normalize whitespaces and line breaks both in the actual
    * text and in the expected string before matching. When regular expression is used, the actual text is matched as is.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * assertThat(page.locator(".title")).containsText("substring");
    * }</pre>
@@ -990,12 +992,12 @@ public interface LocatorAssertions {
    * Ensures the {@code Locator} points to an element that contains the given text. All nested elements will be considered
    * when computing the text content of the element. You can use regular expressions for the value as well.
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
    * <p> When {@code expected} parameter is a string, Playwright will normalize whitespaces and line breaks both in the actual
    * text and in the expected string before matching. When regular expression is used, the actual text is matched as is.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * assertThat(page.locator(".title")).containsText("substring");
    * }</pre>
@@ -1035,12 +1037,12 @@ public interface LocatorAssertions {
    * Ensures the {@code Locator} points to an element that contains the given text. All nested elements will be considered
    * when computing the text content of the element. You can use regular expressions for the value as well.
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
    * <p> When {@code expected} parameter is a string, Playwright will normalize whitespaces and line breaks both in the actual
    * text and in the expected string before matching. When regular expression is used, the actual text is matched as is.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * assertThat(page.locator(".title")).containsText("substring");
    * }</pre>
@@ -1077,7 +1079,7 @@ public interface LocatorAssertions {
   /**
    * Ensures the {@code Locator} points to an element with given attribute.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * assertThat(page.locator("input")).hasAttribute("type", "text");
    * }</pre>
@@ -1092,7 +1094,7 @@ public interface LocatorAssertions {
   /**
    * Ensures the {@code Locator} points to an element with given attribute.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * assertThat(page.locator("input")).hasAttribute("type", "text");
    * }</pre>
@@ -1105,7 +1107,7 @@ public interface LocatorAssertions {
   /**
    * Ensures the {@code Locator} points to an element with given attribute.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * assertThat(page.locator("input")).hasAttribute("type", "text");
    * }</pre>
@@ -1120,7 +1122,7 @@ public interface LocatorAssertions {
   /**
    * Ensures the {@code Locator} points to an element with given attribute.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * assertThat(page.locator("input")).hasAttribute("type", "text");
    * }</pre>
@@ -1134,7 +1136,7 @@ public interface LocatorAssertions {
    * Ensures the {@code Locator} points to an element with given CSS classes. This needs to be a full match or using a
    * relaxed regular expression.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * assertThat(page.locator("#component")).hasClass(Pattern.compile("selected"));
    * assertThat(page.locator("#component")).hasClass("selected row");
@@ -1155,7 +1157,7 @@ public interface LocatorAssertions {
    * Ensures the {@code Locator} points to an element with given CSS classes. This needs to be a full match or using a
    * relaxed regular expression.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * assertThat(page.locator("#component")).hasClass(Pattern.compile("selected"));
    * assertThat(page.locator("#component")).hasClass("selected row");
@@ -1174,7 +1176,7 @@ public interface LocatorAssertions {
    * Ensures the {@code Locator} points to an element with given CSS classes. This needs to be a full match or using a
    * relaxed regular expression.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * assertThat(page.locator("#component")).hasClass(Pattern.compile("selected"));
    * assertThat(page.locator("#component")).hasClass("selected row");
@@ -1195,7 +1197,7 @@ public interface LocatorAssertions {
    * Ensures the {@code Locator} points to an element with given CSS classes. This needs to be a full match or using a
    * relaxed regular expression.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * assertThat(page.locator("#component")).hasClass(Pattern.compile("selected"));
    * assertThat(page.locator("#component")).hasClass("selected row");
@@ -1214,7 +1216,7 @@ public interface LocatorAssertions {
    * Ensures the {@code Locator} points to an element with given CSS classes. This needs to be a full match or using a
    * relaxed regular expression.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * assertThat(page.locator("#component")).hasClass(Pattern.compile("selected"));
    * assertThat(page.locator("#component")).hasClass("selected row");
@@ -1235,7 +1237,7 @@ public interface LocatorAssertions {
    * Ensures the {@code Locator} points to an element with given CSS classes. This needs to be a full match or using a
    * relaxed regular expression.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * assertThat(page.locator("#component")).hasClass(Pattern.compile("selected"));
    * assertThat(page.locator("#component")).hasClass("selected row");
@@ -1254,7 +1256,7 @@ public interface LocatorAssertions {
    * Ensures the {@code Locator} points to an element with given CSS classes. This needs to be a full match or using a
    * relaxed regular expression.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * assertThat(page.locator("#component")).hasClass(Pattern.compile("selected"));
    * assertThat(page.locator("#component")).hasClass("selected row");
@@ -1275,7 +1277,7 @@ public interface LocatorAssertions {
    * Ensures the {@code Locator} points to an element with given CSS classes. This needs to be a full match or using a
    * relaxed regular expression.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * assertThat(page.locator("#component")).hasClass(Pattern.compile("selected"));
    * assertThat(page.locator("#component")).hasClass("selected row");
@@ -1293,7 +1295,7 @@ public interface LocatorAssertions {
   /**
    * Ensures the {@code Locator} resolves to an exact number of DOM nodes.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * assertThat(page.locator("list > .component")).hasCount(3);
    * }</pre>
@@ -1307,7 +1309,7 @@ public interface LocatorAssertions {
   /**
    * Ensures the {@code Locator} resolves to an exact number of DOM nodes.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * assertThat(page.locator("list > .component")).hasCount(3);
    * }</pre>
@@ -1319,7 +1321,7 @@ public interface LocatorAssertions {
   /**
    * Ensures the {@code Locator} resolves to an element with the given computed CSS style.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * assertThat(page.getByRole(AriaRole.BUTTON)).hasCSS("display", "flex");
    * }</pre>
@@ -1334,7 +1336,7 @@ public interface LocatorAssertions {
   /**
    * Ensures the {@code Locator} resolves to an element with the given computed CSS style.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * assertThat(page.getByRole(AriaRole.BUTTON)).hasCSS("display", "flex");
    * }</pre>
@@ -1347,7 +1349,7 @@ public interface LocatorAssertions {
   /**
    * Ensures the {@code Locator} resolves to an element with the given computed CSS style.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * assertThat(page.getByRole(AriaRole.BUTTON)).hasCSS("display", "flex");
    * }</pre>
@@ -1362,7 +1364,7 @@ public interface LocatorAssertions {
   /**
    * Ensures the {@code Locator} resolves to an element with the given computed CSS style.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * assertThat(page.getByRole(AriaRole.BUTTON)).hasCSS("display", "flex");
    * }</pre>
@@ -1375,7 +1377,7 @@ public interface LocatorAssertions {
   /**
    * Ensures the {@code Locator} points to an element with the given DOM Node ID.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * assertThat(page.getByRole(AriaRole.TEXTBOX)).hasId("lastname");
    * }</pre>
@@ -1389,7 +1391,7 @@ public interface LocatorAssertions {
   /**
    * Ensures the {@code Locator} points to an element with the given DOM Node ID.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * assertThat(page.getByRole(AriaRole.TEXTBOX)).hasId("lastname");
    * }</pre>
@@ -1401,7 +1403,7 @@ public interface LocatorAssertions {
   /**
    * Ensures the {@code Locator} points to an element with the given DOM Node ID.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * assertThat(page.getByRole(AriaRole.TEXTBOX)).hasId("lastname");
    * }</pre>
@@ -1415,7 +1417,7 @@ public interface LocatorAssertions {
   /**
    * Ensures the {@code Locator} points to an element with the given DOM Node ID.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * assertThat(page.getByRole(AriaRole.TEXTBOX)).hasId("lastname");
    * }</pre>
@@ -1428,7 +1430,7 @@ public interface LocatorAssertions {
    * Ensures the {@code Locator} points to an element with given JavaScript property. Note that this property can be of a
    * primitive type as well as a plain serializable JavaScript object.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * assertThat(page.locator("input")).hasJSProperty("loaded", true);
    * }</pre>
@@ -1444,7 +1446,7 @@ public interface LocatorAssertions {
    * Ensures the {@code Locator} points to an element with given JavaScript property. Note that this property can be of a
    * primitive type as well as a plain serializable JavaScript object.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * assertThat(page.locator("input")).hasJSProperty("loaded", true);
    * }</pre>
@@ -1458,12 +1460,12 @@ public interface LocatorAssertions {
    * Ensures the {@code Locator} points to an element with the given text. All nested elements will be considered when
    * computing the text content of the element. You can use regular expressions for the value as well.
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
    * <p> When {@code expected} parameter is a string, Playwright will normalize whitespaces and line breaks both in the actual
    * text and in the expected string before matching. When regular expression is used, the actual text is matched as is.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * assertThat(page.locator(".title")).hasText("Welcome, Test User");
    * assertThat(page.locator(".title")).hasText(Pattern.compile("Welcome, .*"));
@@ -1503,12 +1505,12 @@ public interface LocatorAssertions {
    * Ensures the {@code Locator} points to an element with the given text. All nested elements will be considered when
    * computing the text content of the element. You can use regular expressions for the value as well.
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
    * <p> When {@code expected} parameter is a string, Playwright will normalize whitespaces and line breaks both in the actual
    * text and in the expected string before matching. When regular expression is used, the actual text is matched as is.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * assertThat(page.locator(".title")).hasText("Welcome, Test User");
    * assertThat(page.locator(".title")).hasText(Pattern.compile("Welcome, .*"));
@@ -1546,12 +1548,12 @@ public interface LocatorAssertions {
    * Ensures the {@code Locator} points to an element with the given text. All nested elements will be considered when
    * computing the text content of the element. You can use regular expressions for the value as well.
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
    * <p> When {@code expected} parameter is a string, Playwright will normalize whitespaces and line breaks both in the actual
    * text and in the expected string before matching. When regular expression is used, the actual text is matched as is.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * assertThat(page.locator(".title")).hasText("Welcome, Test User");
    * assertThat(page.locator(".title")).hasText(Pattern.compile("Welcome, .*"));
@@ -1591,12 +1593,12 @@ public interface LocatorAssertions {
    * Ensures the {@code Locator} points to an element with the given text. All nested elements will be considered when
    * computing the text content of the element. You can use regular expressions for the value as well.
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
    * <p> When {@code expected} parameter is a string, Playwright will normalize whitespaces and line breaks both in the actual
    * text and in the expected string before matching. When regular expression is used, the actual text is matched as is.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * assertThat(page.locator(".title")).hasText("Welcome, Test User");
    * assertThat(page.locator(".title")).hasText(Pattern.compile("Welcome, .*"));
@@ -1634,12 +1636,12 @@ public interface LocatorAssertions {
    * Ensures the {@code Locator} points to an element with the given text. All nested elements will be considered when
    * computing the text content of the element. You can use regular expressions for the value as well.
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
    * <p> When {@code expected} parameter is a string, Playwright will normalize whitespaces and line breaks both in the actual
    * text and in the expected string before matching. When regular expression is used, the actual text is matched as is.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * assertThat(page.locator(".title")).hasText("Welcome, Test User");
    * assertThat(page.locator(".title")).hasText(Pattern.compile("Welcome, .*"));
@@ -1679,12 +1681,12 @@ public interface LocatorAssertions {
    * Ensures the {@code Locator} points to an element with the given text. All nested elements will be considered when
    * computing the text content of the element. You can use regular expressions for the value as well.
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
    * <p> When {@code expected} parameter is a string, Playwright will normalize whitespaces and line breaks both in the actual
    * text and in the expected string before matching. When regular expression is used, the actual text is matched as is.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * assertThat(page.locator(".title")).hasText("Welcome, Test User");
    * assertThat(page.locator(".title")).hasText(Pattern.compile("Welcome, .*"));
@@ -1722,12 +1724,12 @@ public interface LocatorAssertions {
    * Ensures the {@code Locator} points to an element with the given text. All nested elements will be considered when
    * computing the text content of the element. You can use regular expressions for the value as well.
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
    * <p> When {@code expected} parameter is a string, Playwright will normalize whitespaces and line breaks both in the actual
    * text and in the expected string before matching. When regular expression is used, the actual text is matched as is.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * assertThat(page.locator(".title")).hasText("Welcome, Test User");
    * assertThat(page.locator(".title")).hasText(Pattern.compile("Welcome, .*"));
@@ -1767,12 +1769,12 @@ public interface LocatorAssertions {
    * Ensures the {@code Locator} points to an element with the given text. All nested elements will be considered when
    * computing the text content of the element. You can use regular expressions for the value as well.
    *
-   * <p> **Details**
+   * <p> <strong>Details</strong>
    *
    * <p> When {@code expected} parameter is a string, Playwright will normalize whitespaces and line breaks both in the actual
    * text and in the expected string before matching. When regular expression is used, the actual text is matched as is.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * assertThat(page.locator(".title")).hasText("Welcome, Test User");
    * assertThat(page.locator(".title")).hasText(Pattern.compile("Welcome, .*"));
@@ -1810,7 +1812,7 @@ public interface LocatorAssertions {
    * Ensures the {@code Locator} points to an element with the given input value. You can use regular expressions for the
    * value as well.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * assertThat(page.locator("input[type=number]")).hasValue(Pattern.compile("[0-9]"));
    * }</pre>
@@ -1825,7 +1827,7 @@ public interface LocatorAssertions {
    * Ensures the {@code Locator} points to an element with the given input value. You can use regular expressions for the
    * value as well.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * assertThat(page.locator("input[type=number]")).hasValue(Pattern.compile("[0-9]"));
    * }</pre>
@@ -1838,7 +1840,7 @@ public interface LocatorAssertions {
    * Ensures the {@code Locator} points to an element with the given input value. You can use regular expressions for the
    * value as well.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * assertThat(page.locator("input[type=number]")).hasValue(Pattern.compile("[0-9]"));
    * }</pre>
@@ -1853,7 +1855,7 @@ public interface LocatorAssertions {
    * Ensures the {@code Locator} points to an element with the given input value. You can use regular expressions for the
    * value as well.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * assertThat(page.locator("input[type=number]")).hasValue(Pattern.compile("[0-9]"));
    * }</pre>
@@ -1866,7 +1868,7 @@ public interface LocatorAssertions {
    * Ensures the {@code Locator} points to multi-select/combobox (i.e. a {@code select} with the {@code multiple} attribute)
    * and the specified values are selected.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> For example, given the following element:
    * <pre>{@code
@@ -1884,7 +1886,7 @@ public interface LocatorAssertions {
    * Ensures the {@code Locator} points to multi-select/combobox (i.e. a {@code select} with the {@code multiple} attribute)
    * and the specified values are selected.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> For example, given the following element:
    * <pre>{@code
@@ -1900,7 +1902,7 @@ public interface LocatorAssertions {
    * Ensures the {@code Locator} points to multi-select/combobox (i.e. a {@code select} with the {@code multiple} attribute)
    * and the specified values are selected.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> For example, given the following element:
    * <pre>{@code
@@ -1918,7 +1920,7 @@ public interface LocatorAssertions {
    * Ensures the {@code Locator} points to multi-select/combobox (i.e. a {@code select} with the {@code multiple} attribute)
    * and the specified values are selected.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    *
    * <p> For example, given the following element:
    * <pre>{@code

--- a/playwright/src/main/java/com/microsoft/playwright/assertions/PageAssertions.java
+++ b/playwright/src/main/java/com/microsoft/playwright/assertions/PageAssertions.java
@@ -78,7 +78,7 @@ public interface PageAssertions {
   /**
    * Ensures the page has the given title.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * assertThat(page).hasTitle("Playwright");
    * }</pre>
@@ -92,7 +92,7 @@ public interface PageAssertions {
   /**
    * Ensures the page has the given title.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * assertThat(page).hasTitle("Playwright");
    * }</pre>
@@ -104,7 +104,7 @@ public interface PageAssertions {
   /**
    * Ensures the page has the given title.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * assertThat(page).hasTitle("Playwright");
    * }</pre>
@@ -118,7 +118,7 @@ public interface PageAssertions {
   /**
    * Ensures the page has the given title.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * assertThat(page).hasTitle("Playwright");
    * }</pre>
@@ -130,7 +130,7 @@ public interface PageAssertions {
   /**
    * Ensures the page is navigated to the given URL.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * assertThat(page).hasURL(".com");
    * }</pre>
@@ -144,7 +144,7 @@ public interface PageAssertions {
   /**
    * Ensures the page is navigated to the given URL.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * assertThat(page).hasURL(".com");
    * }</pre>
@@ -156,7 +156,7 @@ public interface PageAssertions {
   /**
    * Ensures the page is navigated to the given URL.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * assertThat(page).hasURL(".com");
    * }</pre>
@@ -170,7 +170,7 @@ public interface PageAssertions {
   /**
    * Ensures the page is navigated to the given URL.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * assertThat(page).hasURL(".com");
    * }</pre>

--- a/playwright/src/main/java/com/microsoft/playwright/assertions/PlaywrightAssertions.java
+++ b/playwright/src/main/java/com/microsoft/playwright/assertions/PlaywrightAssertions.java
@@ -54,7 +54,7 @@ public interface PlaywrightAssertions {
   /**
    * Creates a {@code APIResponseAssertions} object for the given {@code APIResponse}.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * PlaywrightAssertions.assertThat(response).isOK();
    * }</pre>
@@ -69,7 +69,7 @@ public interface PlaywrightAssertions {
   /**
    * Creates a {@code LocatorAssertions} object for the given {@code Locator}.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * PlaywrightAssertions.assertThat(locator).isVisible();
    * }</pre>
@@ -84,7 +84,7 @@ public interface PlaywrightAssertions {
   /**
    * Creates a {@code PageAssertions} object for the given {@code Page}.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * PlaywrightAssertions.assertThat(page).hasTitle("News");
    * }</pre>
@@ -99,7 +99,7 @@ public interface PlaywrightAssertions {
   /**
    * Changes default timeout for Playwright assertions from 5 seconds to the specified value.
    *
-   * <p> **Usage**
+   * <p> <strong>Usage</strong>
    * <pre>{@code
    * PlaywrightAssertions.setDefaultAssertionTimeout(30_000);
    * }</pre>
@@ -107,8 +107,8 @@ public interface PlaywrightAssertions {
    * @param timeout Timeout in milliseconds.
    * @since v1.25
    */
-  static void setDefaultAssertionTimeout(double milliseconds) {
-    AssertionsTimeout.setDefaultTimeout(milliseconds);
+  static void setDefaultAssertionTimeout(double timeout) {
+    AssertionsTimeout.setDefaultTimeout(timeout);
   }
 
 }

--- a/playwright/src/main/java/com/microsoft/playwright/options/RequestOptions.java
+++ b/playwright/src/main/java/com/microsoft/playwright/options/RequestOptions.java
@@ -29,7 +29,7 @@ import com.microsoft.playwright.impl.RequestOptionsImpl;
  *     .setData("My data"));
  * }</pre>
  *
- * <p> **Uploading html form data**
+ * <p> <strong>Uploading html form data</strong>
  *
  * <p> {@code FormData} class can be used to send a form to the server, by default the request will use {@code
  * application/x-www-form-urlencoded} encoding:

--- a/tools/api-generator/src/main/java/com/microsoft/playwright/tools/ApiGenerator.java
+++ b/tools/api-generator/src/main/java/com/microsoft/playwright/tools/ApiGenerator.java
@@ -132,18 +132,14 @@ abstract class Element {
         out.add("<pre>{@code");
         for (JsonElement line : node.getAsJsonArray("lines")) {
           out.add(line.getAsString());
-          if ("client.send(\"Animation.setPlaybackRate\", params);".equals(line.getAsString())) {
-            System.out.println(line);
-          }
         }
         out.add("}</pre>");
       } else {
         String paragraph = node.get("text").getAsString();
-        Matcher matcher = Pattern.compile("\\*\\*(.+)\\*\\*").matcher(paragraph);
+        Matcher matcher = Pattern.compile("^\\*\\*(.+)\\*\\*$").matcher(paragraph);
         // Format **Usage**, **Details** as bold text.
         if (matcher.matches()) {
           String title = matcher.group(1);
-          System.out.println(title);
           paragraph = "<strong>" + title + "</strong>";
         } else {
           paragraph = beautify(paragraph);

--- a/tools/api-generator/src/main/java/com/microsoft/playwright/tools/ApiGenerator.java
+++ b/tools/api-generator/src/main/java/com/microsoft/playwright/tools/ApiGenerator.java
@@ -102,16 +102,7 @@ abstract class Element {
     for (JsonElement item : spec) {
       JsonObject node = item.getAsJsonObject();
       String type = node.get("type").getAsString();
-      if ("code".equals(type)) {
-        if (!node.get("codeLang").getAsString().contains("java")) {
-          continue;
-        }
-        out.add("<pre>{@code");
-        for (JsonElement line : node.getAsJsonArray("lines")) {
-          out.add(line.getAsString());
-        }
-        out.add("}</pre>");
-      } else if ("li".equals(type)) {
+      if ("li".equals(type)) {
         String text = node.get("text").getAsString();
         if (text.startsWith("extends: ")) {
           continue;
@@ -127,15 +118,38 @@ abstract class Element {
           }
         }
         out.add("<li> " + beautify(text) + "</li>");
+        continue;
       } else {
         if (currentItemList != null) {
           out.add("</" + currentItemList + ">");
           currentItemList = null;
         }
+      }
+      if ("code".equals(type)) {
+        if (!node.get("codeLang").getAsString().contains("java")) {
+          continue;
+        }
+        out.add("<pre>{@code");
+        for (JsonElement line : node.getAsJsonArray("lines")) {
+          out.add(line.getAsString());
+          if ("client.send(\"Animation.setPlaybackRate\", params);".equals(line.getAsString())) {
+            System.out.println(line);
+          }
+        }
+        out.add("}</pre>");
+      } else {
         String paragraph = node.get("text").getAsString();
-        paragraph = beautify(paragraph);
-        if ("note".equals(type)) {
-          paragraph = "<strong>NOTE:</strong> " + paragraph;
+        Matcher matcher = Pattern.compile("\\*\\*(.+)\\*\\*").matcher(paragraph);
+        // Format **Usage**, **Details** as bold text.
+        if (matcher.matches()) {
+          String title = matcher.group(1);
+          System.out.println(title);
+          paragraph = "<strong>" + title + "</strong>";
+        } else {
+          paragraph = beautify(paragraph);
+          if ("note".equals(type)) {
+            paragraph = "<strong>NOTE:</strong> " + paragraph;
+          }
         }
         if (!out.isEmpty())
           paragraph = "\n<p> " + paragraph;
@@ -173,7 +187,13 @@ abstract class Element {
         String[] parts = name.split("\\.");
         name = parts[0] + ".on" + toTitle(parts[1]);
       }
-      linkified += "{@link " + name.replace(".", "#") + " " + name + "()}";
+      String packagePrefix = "";
+      if (ApiGenerator.isAssertionClass(name.split("\\.")[0])) {
+        packagePrefix = "com.microsoft.playwright.assertions.";
+      } else {
+        packagePrefix = "com.microsoft.playwright.";
+      }
+      linkified += "{@link " + packagePrefix + name.replace(".", "#") + " " + name + "()}";
       start = matcher.end();
     }
     linkified += paragraph.substring(start);
@@ -682,8 +702,8 @@ class Method extends Element {
     }
     if ("PlaywrightAssertions.setDefaultAssertionTimeout".equals(jsonPath)) {
       writeJavadoc(params, output, offset);
-      output.add(offset + "static void setDefaultAssertionTimeout(double milliseconds) {");
-      output.add(offset + "  AssertionsTimeout.setDefaultTimeout(milliseconds);");
+      output.add(offset + "static void setDefaultAssertionTimeout(double timeout) {");
+      output.add(offset + "  AssertionsTimeout.setDefaultTimeout(timeout);");
       output.add(offset + "}");
       output.add("");
       return;
@@ -1160,7 +1180,11 @@ public class ApiGenerator {
   }
 
   private static Predicate<String> isAssertion() {
-    return className -> className.toLowerCase().contains("assert");
+    return className -> isAssertionClass(className);
+  }
+
+  static boolean isAssertionClass(String className) {
+    return className.toLowerCase().contains("assert");
   }
 
   // TODO: Remove this predicate once SoftAssertions are implemented.


### PR DESCRIPTION
* Fix broken links from library to assertion classes by adding full package name
* Properly format `**Details**`, `**Usage**` and other bold titles
* Fixed an error with misplaced `</ul>` tag