### PR TITLE
devops: stop producing .sha256 files, they are not required anymore

### DIFF
--- a/.azure-pipelines/publish.yml
+++ b/.azure-pipelines/publish.yml
@@ -55,16 +55,6 @@ extends:
           env:
             GPG_PASSPHRASE: $(GPG_PASSPHRASE) # secret variable has to be mapped to an env variable
         
-        - bash: |
-            for file in $(find snapshots -type f); do
-              echo "processing: $file"
-              if [[ $file =~ \.(md5|sha1|sha256)$ ]]; then
-                continue
-              fi
-              sha256sum "$file" | cut -f1 -d \ > "$file.sha256"
-            done
-          displayName: 'Create .sha256 files'
-        
         - task: EsrpRelease@7
           inputs:
             connectedservicename: 'Playwright-ESRP-Azure'


### PR DESCRIPTION
And were actually not produced in the recent release https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=9394315&view=logs&j=c5c5d0ad-9fc4-5fcb-d69d-7db2ecc16a23&t=bbccc425-c27d-5062-b951-856f97a85174