### PR TITLE
fix: Update README.md to fix wrong demo code

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ public class MobileAndGeolocation {
         .setPermissions(asList("geolocation")));
       Page page = context.newPage();
       page.navigate("https://www.openstreetmap.org/");
-      page.click("a[data-original-title=\"Show My Location\"]");
+      page.click("a[data-bs-original-title=\"Show My Location\"]");
       page.screenshot(new Page.ScreenshotOptions().setPath(Paths.get("colosseum-pixel2.png")));
     }
   }


### PR DESCRIPTION
In Mobile and geolocation demo, code `page.click("a[data-original-title=\"Show My Location\"]")` will cause error while running.Because the website already change the attribute.