### PR TITLE
fix: add 'window-management' to chromium browser fixes #1628 java-playwright

### DIFF
--- a/playwright/src/main/java/com/microsoft/playwright/BrowserContext.java
+++ b/playwright/src/main/java/com/microsoft/playwright/BrowserContext.java
@@ -853,6 +853,7 @@ public interface BrowserContext extends AutoCloseable {
    * <li> {@code "notifications"}</li>
    * <li> {@code "payment-handler"}</li>
    * <li> {@code "storage-access"}</li>
+   * <li> {@code "window-management"}</li>
    * </ul>
    * @since v1.8
    */
@@ -881,6 +882,7 @@ public interface BrowserContext extends AutoCloseable {
    * <li> {@code "notifications"}</li>
    * <li> {@code "payment-handler"}</li>
    * <li> {@code "storage-access"}</li>
+   * <li> {@code "window-management"}</li>
    * </ul>
    * @since v1.8
    */


### PR DESCRIPTION
This fixes #1628 I have done the same fix for https://github.com/microsoft/playwright/issues/27198 of the js version but actually needed it for java