### PR TITLE
devops(dependabot): update all deps in single PR monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,17 @@ updates:
   - package-ecosystem: "maven"
     directory: "/" # Location of the pom.xml file
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     open-pull-requests-limit: 10
+    groups:
+      # Create a group of dependencies to be updated together in one pull request
+      all:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
     allow:
       - dependency-type: "direct" # Optional: Only update direct dependencies
       - dependency-type: "indirect" # Optional: Only update indirect (transitive) dependencies


### PR DESCRIPTION
Otherwise it generates one PR per patch update which is too much noise.

See https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups