### PR TITLE
test: fix client-certificate tests

### DIFF
--- a/playwright/src/test/java/com/microsoft/playwright/HttpsConfiguratorImpl.java
+++ b/playwright/src/test/java/com/microsoft/playwright/HttpsConfiguratorImpl.java
@@ -43,8 +43,8 @@ class HttpsConfiguratorImpl extends HttpsConfigurator {
   public void configure(HttpsParameters params) {
     SSLContext sslContext = getSSLContext();
     SSLParameters sslParams = sslContext.getDefaultSSLParameters();
-    sslParams.setNeedClientAuth(true);
-    params.setNeedClientAuth(true);
+    sslParams.setWantClientAuth(true);
+    params.setWantClientAuth(true);
     params.setSSLParameters(sslParams);
   }
 

--- a/playwright/src/test/java/com/microsoft/playwright/ServerWithClientCertificate.java
+++ b/playwright/src/test/java/com/microsoft/playwright/ServerWithClientCertificate.java
@@ -136,8 +136,8 @@ public class ServerWithClientCertificate implements HttpHandler {
   public void handle(HttpExchange exchange) throws IOException {
     SSLSession sslSession = ((HttpsExchange) exchange).getSSLSession();
     String response = div("servername", sslSession.getPeerHost());
-    Certificate[] certs = sslSession.getPeerCertificates();
-    if (certs.length > 0 && certs[0] instanceof X509Certificate) {
+    try {
+      Certificate[] certs = sslSession.getPeerCertificates();
       X509Certificate cert = (X509Certificate) certs[0];
       exchange.getResponseHeaders().add("Content-Type", "text/html");
       if (validateCertChain(certs)) {
@@ -149,7 +149,7 @@ public class ServerWithClientCertificate implements HttpHandler {
           cert.getSubjectX500Principal().getName(), cert.getIssuerX500Principal().getName()));
         exchange.sendResponseHeaders(403, 0);
       }
-    } else {
+    } catch (SSLPeerUnverifiedException e) {
       response += div("message", "Sorry, but you need to provide a client certificate to continue.");
       exchange.sendResponseHeaders(401, 0);
     }

--- a/playwright/src/test/java/com/microsoft/playwright/TestClientCertificates.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestClientCertificates.java
@@ -61,8 +61,8 @@ public class TestClientCertificates extends TestBase {
   public void shouldFailWithNoClientCertificatesProvided() {
     APIRequestContext request = playwright.request().newContext(
         new APIRequest.NewContextOptions().setIgnoreHTTPSErrors(true));
-    PlaywrightException e = assertThrows(PlaywrightException.class, () -> request.get(customServer.url));
-    assertTrue(e.getMessage().contains("Error: socket hang up"), e.getMessage());
+    APIResponse response = request.get(customServer.url);
+    assertTrue(response.text().contains("Sorry, but you need to provide a client certificate to continue."), response.text());
     request.dispose();
   }
 
@@ -136,8 +136,14 @@ public class TestClientCertificates extends TestBase {
 
     try (BrowserContext context = browser.newContext(options)) {
       Page page = context.newPage();
-      assertThrows(PlaywrightException.class, () -> page.navigate(customServer.crossOrigin));
-      assertThrows(PlaywrightException.class, () -> page.request().get(customServer.crossOrigin));
+      {
+        APIResponse response = page.request().get(customServer.crossOrigin);
+        assertTrue(response.text().contains("Sorry, but you need to provide a client certificate to continue."), response.text());
+      }
+      {
+        page.navigate(customServer.crossOrigin);
+        assertThat(page.getByTestId("message")).hasText("Sorry, but you need to provide a client certificate to continue.");
+      }
       page.navigate(customServer.url);
       assertThat(page.getByText("Hello CN=Alice")).isVisible();
       APIResponse response = page.request().get(customServer.url);
@@ -156,8 +162,14 @@ public class TestClientCertificates extends TestBase {
           .setKeyPath(asset("client-certificates/client/trusted/key.pem"))));
 
     try (Page page = browser.newPage(options)) {
-      assertThrows(PlaywrightException.class, () -> page.navigate(customServer.crossOrigin));
-      assertThrows(PlaywrightException.class, () -> page.request().get(customServer.crossOrigin));
+      {
+        page.navigate(customServer.crossOrigin);
+        assertThat(page.getByTestId("message")).hasText("Sorry, but you need to provide a client certificate to continue.");
+      }
+      {
+        APIResponse response = page.request().get(customServer.crossOrigin);
+        assertTrue(response.text().contains("Sorry, but you need to provide a client certificate to continue."), response.text());
+      }
       page.navigate(customServer.url);
       assertThat(page.getByText("Hello CN=Alice")).isVisible();
       APIResponse response = page.request().get(customServer.url);
@@ -176,8 +188,14 @@ public class TestClientCertificates extends TestBase {
           .setKey(readAllBytes(asset("client-certificates/client/trusted/key.pem")))));
 
     try (Page page = browser.newPage(options)) {
-      assertThrows(PlaywrightException.class, () -> page.navigate(customServer.crossOrigin));
-      assertThrows(PlaywrightException.class, () -> page.request().get(customServer.crossOrigin));
+       {
+        page.navigate(customServer.crossOrigin);
+        assertThat(page.getByTestId("message")).hasText("Sorry, but you need to provide a client certificate to continue.");
+      }
+      {
+        APIResponse response = page.request().get(customServer.crossOrigin);
+        assertTrue(response.text().contains("Sorry, but you need to provide a client certificate to continue."), response.text());
+      }
       page.navigate(customServer.url);
       assertThat(page.getByText("Hello CN=Alice")).isVisible();
       APIResponse response = page.request().get(customServer.url);
@@ -197,8 +215,14 @@ public class TestClientCertificates extends TestBase {
 
     try (BrowserContext context = browser.browserType().launchPersistentContext(tmpDir.resolve("profile") , options)) {
       Page page = context.pages().get(0);
-      assertThrows(PlaywrightException.class, () -> page.navigate(customServer.crossOrigin));
-      assertThrows(PlaywrightException.class, () -> page.request().get(customServer.crossOrigin));
+      {
+        page.navigate(customServer.crossOrigin);
+        assertThat(page.getByTestId("message")).hasText("Sorry, but you need to provide a client certificate to continue.");
+      }
+      {
+        APIResponse response = page.request().get(customServer.crossOrigin);
+        assertTrue(response.text().contains("Sorry, but you need to provide a client certificate to continue."), response.text());
+      }
       page.navigate(customServer.url);
       assertThat(page.getByText("Hello CN=Alice")).isVisible();
       APIResponse response = page.request().get(customServer.url);

--- a/playwright/src/test/java/com/microsoft/playwright/TestPageInterception.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestPageInterception.java
@@ -81,7 +81,6 @@ public class TestPageInterception extends TestBase {
   void shouldFulfillInterceptedResponseUsingAlias() {
     page.route("**/*", route -> {
       APIResponse response = route.fetch();
-      System.out.println(response.headers().get("content-type"));
       route.fulfill(new Route.FulfillOptions().setResponse(response));
     });
     Response response = page.navigate(server.PREFIX + "/empty.html");

--- a/playwright/src/test/java/com/microsoft/playwright/TestPlaywrightCreate.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestPlaywrightCreate.java
@@ -35,7 +35,6 @@ import static org.junit.jupiter.api.Assertions.*;
 public class TestPlaywrightCreate {
   @Test
   void shouldSupportEnvSkipBrowserDownload(@TempDir Path browsersDir) throws IOException, NoSuchFieldException, IllegalAccessException {
-    System.err.println("shouldSupportEnvSkipBrowserDownload PLAYWRIGHT_BROWSERS_PATH = " + browsersDir);
     Map<String, String> env = mapOf("PLAYWRIGHT_BROWSERS_PATH", browsersDir.toString(),
       "PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD", "1");
     Playwright.CreateOptions options = new Playwright.CreateOptions().setEnv(env);


### PR DESCRIPTION
The problem before was that the Java WebServer was configured in a way, that when no client certificates were passed during the TLS handshake, it was closing the connection / aborting the handshake immediately. This meant for us that we were closing the Socks connections which triggered `is interrupted by another navigation` or `EMPTY_RESPONSE`. Also this lead to differences to the tests compared to upstream and failing tests across the board.

This PR aligns it with upstream and fixed the tests.