### PR TITLE
test: unflake TestPageClock

### DIFF
--- a/playwright/src/test/java/com/microsoft/playwright/TestPageClock.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestPageClock.java
@@ -290,8 +290,9 @@ public class TestPageClock {
     Page popup = page.waitForPopup(() -> {
       page.evaluate("url => window.open(url)", server.PREFIX + "/popup.html");
     });
+    popup.waitForURL(server.PREFIX + "/popup.html");
     Double popupTime = (Double) popup.evaluate("time");
-    assertTrue(popupTime >= 2000);
+    assertTrue(popupTime >= 2000, "popupTime = " + popupTime);
   }
 
   @Test
@@ -310,6 +311,7 @@ public class TestPageClock {
     Page popup = page.waitForPopup(() -> {
       page.evaluate("url => window.open(url)", server.PREFIX + "/popup.html");
     });
+    popup.waitForURL(server.PREFIX + "/popup.html");
     Object popupTime = popup.evaluate("time");
     assertEquals(1000, popupTime);
   }


### PR DESCRIPTION
Fixes the following error on the bots:
```
Error:    TestPageClock.shouldNotRunTimeBeforePopupOnPause:313 » Playwright Error {
  message='ReferenceError: time is not defined
    at eval (eval at evaluate (:234:30), <anonymous>:1:1)
    at eval (<anonymous>)
    at UtilityScript.evaluate (<anonymous>:234:30)
    at UtilityScript.<anonymous> (<anonymous>:1:44)
  name='Error
  stack='Error: ReferenceError: time is not defined
    at eval (eval at evaluate (:234:30), <anonymous>:1:1)
    at eval (<anonymous>)
    at UtilityScript.evaluate (<anonymous>:234:30)
    at UtilityScript.<anonymous> (<anonymous>:1:44)
    at CRExecutionContext.evaluateWithArguments (/tmp/playwright-java-947970650740572645/package/lib/server/chromium/crExecutionContext.js:79:33)
    at async LongStandingScope._race (/tmp/playwright-java-947970650740572645/package/lib/utils/manualPromise.js:96:14)
    at async Object.evaluateExpression (/tmp/playwright-java-947970650740572645/package/lib/server/javascript.js:229:12)
    at async Frame.evaluateExpression (/tmp/playwright-java-947970650740572645/package/lib/server/frames.js:608:19)
    at async FrameDispatcher.evaluateExpression (/tmp/playwright-java-947970650740572645/package/lib/server/dispatchers/frameDispatcher.js:92:55)
    at async LongStandingScope._race (/tmp/playwright-java-947970650740572645/package/lib/utils/manualPromise.js:96:14)
    at async FrameDispatcher._handleCommand (/tmp/playwright-java-947970650740572645/package/lib/server/dispatchers/dispatcher.js:96:14)
    at async DispatcherConnection.dispatch (/tmp/playwright-java-947970650740572645/package/lib/server/dispatchers/dispatcher.js:361:22)
}
```