### PR TITLE
chore: refactor UrlMatcher

### DIFF
--- a/playwright/src/main/java/com/microsoft/playwright/impl/UrlMatcher.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/UrlMatcher.java
@@ -84,10 +84,6 @@ class UrlMatcher {
   }
 
   boolean test(String value) {
-    return testImpl(baseURL, pattern, predicate, glob, value);
-  }
-
-  private static boolean testImpl(URL baseURL, Pattern pattern, Predicate<String> predicate, String glob, String value) {
     if (pattern != null) {
       return pattern.matcher(value).find();
     }
@@ -105,14 +101,14 @@ class UrlMatcher {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
     UrlMatcher that = (UrlMatcher) o;
-    if (pattern != null && !pattern.pattern().equals(that.pattern.pattern()) && pattern.flags() == that.pattern.flags()) {
-      return false;
+    if (pattern != null) {
+      return that.pattern != null && pattern.pattern().equals(that.pattern.pattern()) && pattern.flags() == that.pattern.flags();
     }
-    if (predicate != null && !predicate.equals(that.predicate)) {
-      return false;
+    if (predicate != null) {
+      return predicate.equals(that.predicate);
     }
-    if (glob != null && !glob.equals(that.glob)) {
-      return false;
+    if (glob != null) {
+      return glob.equals(that.glob);
     }
     return true;
   }
@@ -125,7 +121,10 @@ class UrlMatcher {
     if (predicate != null) {
       return predicate.hashCode();
     }
-    return glob.hashCode();
+    if (glob != null) {
+      return glob.hashCode();
+    }
+    return super.hashCode();
   }
 
   @Override

--- a/playwright/src/main/java/com/microsoft/playwright/impl/UrlMatcher.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/UrlMatcher.java
@@ -110,7 +110,7 @@ class UrlMatcher {
     if (glob != null) {
       return glob.equals(that.glob);
     }
-    return true;
+    return that.pattern == null  && that.predicate == null && that.glob == null;
   }
 
   @Override

--- a/playwright/src/main/java/com/microsoft/playwright/impl/UrlMatcher.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/UrlMatcher.java
@@ -124,7 +124,7 @@ class UrlMatcher {
     if (glob != null) {
       return glob.hashCode();
     }
-    return super.hashCode();
+    return 0;
   }
 
   @Override

--- a/playwright/src/main/java/com/microsoft/playwright/impl/UrlMatcher.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/UrlMatcher.java
@@ -22,6 +22,8 @@ import com.microsoft.playwright.PlaywrightException;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
@@ -30,20 +32,14 @@ import static com.microsoft.playwright.impl.Utils.globToRegex;
 import static com.microsoft.playwright.impl.Utils.toJsRegexFlags;
 
 class UrlMatcher {
-  final Object rawSource;
-  private final Predicate<String> predicate;
-
-  private static Predicate<String> toPredicate(Pattern pattern) {
-    return s -> pattern.matcher(s).find();
-  }
-
-  static UrlMatcher any() {
-    return new UrlMatcher((Object) null, null);
-  }
+  private final URL baseURL;
+  public final String glob;
+  public final Pattern pattern;
+  public final Predicate<String> predicate;
 
   static UrlMatcher forOneOf(URL baseUrl, Object object) {
     if (object == null) {
-      return UrlMatcher.any();
+      return new UrlMatcher(null, null, null, null);
     }
     if (object instanceof String) {
       return new UrlMatcher(baseUrl, (String) object);
@@ -68,24 +64,40 @@ class UrlMatcher {
     }
   }
 
-  UrlMatcher(URL base, String url) {
-    this(url, toPredicate(Pattern.compile(globToRegex(resolveUrl(base, url)))).or(s -> url == null || url.equals(s)));
+  UrlMatcher(URL baseURL, String glob) {
+    this(baseURL, glob, null, null);
   }
 
   UrlMatcher(Pattern pattern) {
-    this(pattern, toPredicate(pattern));
-  }
-  UrlMatcher(Predicate<String> predicate) {
-    this(predicate, predicate);
+    this(null, null, pattern, null);
   }
 
-  private UrlMatcher(Object rawSource, Predicate<String> predicate) {
-    this.rawSource = rawSource;
+  UrlMatcher(Predicate<String> predicate) {
+    this(null, null, null, predicate);
+  }
+
+  private UrlMatcher(URL baseURL, String glob, Pattern pattern, Predicate<String> predicate) {
+    this.baseURL = baseURL;
+    this.glob = glob;
+    this.pattern = pattern;
     this.predicate = predicate;
   }
 
   boolean test(String value) {
-    return predicate == null || predicate.test(value);
+    return testImpl(baseURL, pattern, predicate, glob, value);
+  }
+
+  private static boolean testImpl(URL baseURL, Pattern pattern, Predicate<String> predicate, String glob, String value) {
+    if (pattern != null) {
+      return pattern.matcher(value).find();
+    }
+    if (predicate != null) {
+      return predicate.test(value);
+    }
+    if (glob != null) {
+      return Pattern.compile(globToRegex(resolveUrl(baseURL, glob))).matcher(value).find();
+    }
+    return true;
   }
 
   @Override
@@ -93,25 +105,35 @@ class UrlMatcher {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
     UrlMatcher that = (UrlMatcher) o;
-    if (rawSource instanceof Pattern && that.rawSource instanceof Pattern) {
-      Pattern a = (Pattern) rawSource;
-      Pattern b = (Pattern) that.rawSource;
-      return a.pattern().equals(b.pattern()) && a.flags() == b.flags();
+    if (pattern != null && !pattern.pattern().equals(that.pattern.pattern()) && pattern.flags() == that.pattern.flags()) {
+      return false;
     }
-    return Objects.equals(rawSource, that.rawSource);
+    if (predicate != null && !predicate.equals(that.predicate)) {
+      return false;
+    }
+    if (glob != null && !glob.equals(that.glob)) {
+      return false;
+    }
+    return true;
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(rawSource);
+    if (pattern != null) {
+      return pattern.hashCode();
+    }
+    if (predicate != null) {
+      return predicate.hashCode();
+    }
+    return glob.hashCode();
   }
 
   @Override
   public String toString() {
-    if (rawSource == null)
-      return "<any>";
-    if (rawSource instanceof Predicate)
-      return "matching predicate";
-    return rawSource.toString();
+    if (pattern != null)
+      return String.format("<regex pattern=\"%s\" flags=\"%s\">", pattern.pattern(), toJsRegexFlags(pattern));
+    if (this.predicate != null)
+      return "<predicate>";
+    return String.format("<glob pattern=\"%s\">", glob);
   }
 }

--- a/playwright/src/main/java/com/microsoft/playwright/impl/Utils.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/Utils.java
@@ -462,13 +462,11 @@ public class Utils {
     JsonArray jsonPatterns = new JsonArray();
     for (UrlMatcher matcher: matchers) {
       JsonObject jsonPattern = new JsonObject();
-      Object urlFilter = matcher.rawSource;
-      if (urlFilter instanceof String) {
-        jsonPattern.addProperty("glob", (String) urlFilter);
-      } else if (urlFilter instanceof Pattern) {
-        Pattern pattern = (Pattern) urlFilter;
-        jsonPattern.addProperty("regexSource", pattern.pattern());
-        jsonPattern.addProperty("regexFlags", toJsRegexFlags(pattern));
+      if (matcher.glob != null) {
+        jsonPattern.addProperty("glob", matcher.glob);
+      } else if (matcher.pattern != null) {
+        jsonPattern.addProperty("regexSource", matcher.pattern.pattern());
+        jsonPattern.addProperty("regexFlags", toJsRegexFlags(matcher.pattern));
       } else {
         // Match all requests.
         jsonPattern.addProperty("glob", "**/*");

--- a/playwright/src/test/java/com/microsoft/playwright/TestPageRoute.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestPageRoute.java
@@ -98,6 +98,18 @@ public class TestPageRoute extends TestBase {
   }
 
   @Test
+  void shouldUnrouteNonExistentPatternHandler() {
+    List<Integer> intercepted = new ArrayList<>();
+    page.route(Pattern.compile("empty.html"), route -> {
+      intercepted.add(1);
+      route.fallback();
+    });
+    page.unroute("**/*");
+    page.navigate(server.EMPTY_PAGE);
+    assertEquals(asList( 1), intercepted);
+  }
+
+  @Test
   void shouldSupportQuestionMarkInGlobPattern() {
     server.setRoute("/index", exchange -> {
       exchange.sendResponseHeaders(200, 0);


### PR DESCRIPTION
Extracted from https://github.com/microsoft/playwright-java/pull/1717. There should be no behaviour changes.

This moves `rawSource` towards having it lazily determined which matching source it is - this helps us to align with upstream.