### PR TITLE
fix: waitForCondition should not call predicate after it returned true

### DIFF
--- a/playwright/src/test/java/com/microsoft/playwright/TestBrowserContextBasic.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestBrowserContextBasic.java
@@ -300,6 +300,13 @@ public class TestBrowserContextBasic {
   }
 
   @Test
+  void waitForConditionThatMayChangeToFalse(BrowserContext context) {
+    int[] var = {0};
+    context.waitForCondition(() -> ++var[0] == 1);
+    assertEquals(1, var[0], "The predicate should be called only once.");
+  }
+
+  @Test
   void shouldPropagateCloseReasonToPendingActions(Browser browser) {
     BrowserContext context = browser.newContext();
     Page page = context.newPage();


### PR DESCRIPTION
Previously it would fail with this exception:

```
java.lang.AssertionError
	at com.microsoft.playwright.impl.WaitableRace.get(WaitableRace.java:40)
	at com.microsoft.playwright.impl.ChannelOwner.runUntil(ChannelOwner.java:132)
	at com.microsoft.playwright.impl.BrowserContextImpl.waitForCondition(BrowserContextImpl.java:670)
	at com.microsoft.playwright.BrowserContext.waitForCondition(BrowserContext.java:1545)
```