### PR TITLE
fix(tracing): Properly log Clock calls

### DIFF
--- a/playwright/src/main/java/com/microsoft/playwright/impl/ClockImpl.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/ClockImpl.java
@@ -12,18 +12,22 @@ class ClockImpl implements Clock {
     this.browserContext = browserContext;
   }
 
+  private void sendMessageWithLogging(String method, JsonObject params) {
+    browserContext.withLogging("BrowserContext." + method, () -> browserContext.sendMessage(method, params));
+  }
+
   @Override
   public void fastForward(long ticks) {
     JsonObject params = new JsonObject();
     params.addProperty("ticksNumber", ticks);
-    browserContext.sendMessage("clockFastForward", params);
+    sendMessageWithLogging("clockFastForward", params);
   }
 
   @Override
   public void fastForward(String ticks) {
     JsonObject params = new JsonObject();
     params.addProperty("ticksString", ticks);
-    browserContext.sendMessage("clockFastForward", params);
+    sendMessageWithLogging("clockFastForward", params);
   }
 
   @Override
@@ -32,89 +36,89 @@ class ClockImpl implements Clock {
     if (options != null) {
       parseTime(options.time, params);
     }
-    browserContext.sendMessage("clockInstall", params);
+    sendMessageWithLogging("clockInstall", params);
   }
 
   @Override
   public void runFor(long ticks) {
     JsonObject params = new JsonObject();
     params.addProperty("ticksNumber", ticks);
-    browserContext.sendMessage("clockRunFor", params);
+    sendMessageWithLogging("clockRunFor", params);
   }
 
   @Override
   public void runFor(String ticks) {
     JsonObject params = new JsonObject();
     params.addProperty("ticksString", ticks);
-    browserContext.sendMessage("clockRunFor", params);
+    sendMessageWithLogging("clockRunFor", params);
   }
 
   @Override
   public void pauseAt(long time) {
     JsonObject params = new JsonObject();
     params.addProperty("timeNumber", time);
-    browserContext.sendMessage("clockPauseAt", params);
+    sendMessageWithLogging("clockPauseAt", params);
   }
 
   @Override
   public void pauseAt(String time) {
     JsonObject params = new JsonObject();
     params.addProperty("timeString", time);
-    browserContext.sendMessage("clockPauseAt", params);
+    sendMessageWithLogging("clockPauseAt", params);
   }
 
   @Override
   public void pauseAt(Date time) {
     JsonObject params = new JsonObject();
     params.addProperty("timeNumber", time.getTime());
-    browserContext.sendMessage("clockPauseAt", params);
+    sendMessageWithLogging("clockPauseAt", params);
   }
 
   @Override
   public void resume() {
-    browserContext.sendMessage("clockResume");
+    sendMessageWithLogging("clockResume", new JsonObject());
   }
 
   @Override
   public void setFixedTime(long time) {
     JsonObject params = new JsonObject();
     params.addProperty("timeNumber", time);
-    browserContext.sendMessage("clockSetFixedTime", params);
+    sendMessageWithLogging("clockSetFixedTime", params);
   }
 
   @Override
   public void setFixedTime(String time) {
     JsonObject params = new JsonObject();
     params.addProperty("timeString", time);
-    browserContext.sendMessage("clockSetFixedTime", params);
+    sendMessageWithLogging("clockSetFixedTime", params);
   }
 
   @Override
   public void setFixedTime(Date time) {
     JsonObject params = new JsonObject();
     params.addProperty("timeNumber", time.getTime());
-    browserContext.sendMessage("clockSetFixedTime", params);
+    sendMessageWithLogging("clockSetFixedTime", params);
   }
 
   @Override
   public void setSystemTime(long time) {
     JsonObject params = new JsonObject();
     params.addProperty("timeNumber", time);
-    browserContext.sendMessage("clockSetSystemTime", params);
+    sendMessageWithLogging("clockSetSystemTime", params);
   }
 
   @Override
   public void setSystemTime(String time) {
     JsonObject params = new JsonObject();
     params.addProperty("timeString", time);
-    browserContext.sendMessage("clockSetSystemTime", params);
+    sendMessageWithLogging("clockSetSystemTime", params);
   }
 
   @Override
   public void setSystemTime(Date time) {
     JsonObject params = new JsonObject();
     params.addProperty("timeNumber", time.getTime());
-    browserContext.sendMessage("clockSetSystemTime", params);
+    sendMessageWithLogging("clockSetSystemTime", params);
   }
 
   private static void parseTime(Object time, JsonObject params) {

--- a/playwright/src/main/java/com/microsoft/playwright/impl/ClockImpl.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/ClockImpl.java
@@ -13,21 +13,23 @@ class ClockImpl implements Clock {
   }
 
   private void sendMessageWithLogging(String method, JsonObject params) {
-    browserContext.withLogging("BrowserContext." + method, () -> browserContext.sendMessage(method, params));
+    String capitalizedMethod = method.substring(0, 1).toUpperCase() + method.substring(1);
+    browserContext.withLogging("Clock." + method,
+        () -> browserContext.sendMessage("clock" + capitalizedMethod, params));
   }
 
   @Override
   public void fastForward(long ticks) {
     JsonObject params = new JsonObject();
     params.addProperty("ticksNumber", ticks);
-    sendMessageWithLogging("clockFastForward", params);
+    sendMessageWithLogging("fastForward", params);
   }
 
   @Override
   public void fastForward(String ticks) {
     JsonObject params = new JsonObject();
     params.addProperty("ticksString", ticks);
-    sendMessageWithLogging("clockFastForward", params);
+    sendMessageWithLogging("fastForward", params);
   }
 
   @Override
@@ -36,89 +38,89 @@ class ClockImpl implements Clock {
     if (options != null) {
       parseTime(options.time, params);
     }
-    sendMessageWithLogging("clockInstall", params);
+    sendMessageWithLogging("install", params);
   }
 
   @Override
   public void runFor(long ticks) {
     JsonObject params = new JsonObject();
     params.addProperty("ticksNumber", ticks);
-    sendMessageWithLogging("clockRunFor", params);
+    sendMessageWithLogging("runFor", params);
   }
 
   @Override
   public void runFor(String ticks) {
     JsonObject params = new JsonObject();
     params.addProperty("ticksString", ticks);
-    sendMessageWithLogging("clockRunFor", params);
+    sendMessageWithLogging("runFor", params);
   }
 
   @Override
   public void pauseAt(long time) {
     JsonObject params = new JsonObject();
     params.addProperty("timeNumber", time);
-    sendMessageWithLogging("clockPauseAt", params);
+    sendMessageWithLogging("pauseAt", params);
   }
 
   @Override
   public void pauseAt(String time) {
     JsonObject params = new JsonObject();
     params.addProperty("timeString", time);
-    sendMessageWithLogging("clockPauseAt", params);
+    sendMessageWithLogging("pauseAt", params);
   }
 
   @Override
   public void pauseAt(Date time) {
     JsonObject params = new JsonObject();
     params.addProperty("timeNumber", time.getTime());
-    sendMessageWithLogging("clockPauseAt", params);
+    sendMessageWithLogging("pauseAt", params);
   }
 
   @Override
   public void resume() {
-    sendMessageWithLogging("clockResume", new JsonObject());
+    sendMessageWithLogging("resume", new JsonObject());
   }
 
   @Override
   public void setFixedTime(long time) {
     JsonObject params = new JsonObject();
     params.addProperty("timeNumber", time);
-    sendMessageWithLogging("clockSetFixedTime", params);
+    sendMessageWithLogging("setFixedTime", params);
   }
 
   @Override
   public void setFixedTime(String time) {
     JsonObject params = new JsonObject();
     params.addProperty("timeString", time);
-    sendMessageWithLogging("clockSetFixedTime", params);
+    sendMessageWithLogging("setFixedTime", params);
   }
 
   @Override
   public void setFixedTime(Date time) {
     JsonObject params = new JsonObject();
     params.addProperty("timeNumber", time.getTime());
-    sendMessageWithLogging("clockSetFixedTime", params);
+    sendMessageWithLogging("setFixedTime", params);
   }
 
   @Override
   public void setSystemTime(long time) {
     JsonObject params = new JsonObject();
     params.addProperty("timeNumber", time);
-    sendMessageWithLogging("clockSetSystemTime", params);
+    sendMessageWithLogging("setSystemTime", params);
   }
 
   @Override
   public void setSystemTime(String time) {
     JsonObject params = new JsonObject();
     params.addProperty("timeString", time);
-    sendMessageWithLogging("clockSetSystemTime", params);
+    sendMessageWithLogging("setSystemTime", params);
   }
 
   @Override
   public void setSystemTime(Date time) {
     JsonObject params = new JsonObject();
     params.addProperty("timeNumber", time.getTime());
-    sendMessageWithLogging("clockSetSystemTime", params);
+    sendMessageWithLogging("setSystemTime", params);
   }
 
   private static void parseTime(Object time, JsonObject params) {


### PR DESCRIPTION
Due to the lack of the proper wrapping calls, all `Clock` APIs were not being logged into the recorded trace.

* Trace entries are now properly created
* `Clock` entries are named `Clock.*` matching JS, rather than the previously existing `BrowserContext.clock*`