### PR TITLE
fix(urlMatcher): normalize URLs to align with Node.js parser behavior

### DIFF
--- a/playwright/src/test/java/com/microsoft/playwright/TestRouteWebSocket.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestRouteWebSocket.java
@@ -9,6 +9,8 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.regex.Pattern;
@@ -348,5 +350,45 @@ public class TestRouteWebSocket {
     assertEquals(
       asList("open", "message: data=echo origin=ws://localhost:" + webSocketServer.getPort() + " lastEventId="),
       newPage.evaluate("window.log"));
+  }
+
+  @Test
+  public void shouldWorkWithNoTrailingSlash(Page page) throws Exception {  
+    List<String> log = new ArrayList<>();
+
+    // No trailing slash in the route pattern
+    page.routeWebSocket("ws://localhost:" + webSocketServer.getPort(), ws -> {
+      ws.onMessage(message -> {
+        log.add(message.text());
+        ws.send("response");
+      });
+    });
+
+    page.navigate("about:blank");
+    page.evaluate("({ port }) => {\n" +
+      "    window.log = [];\n" +
+      "    // No trailing slash in WebSocket URL\n" +
+      "    window.ws = new WebSocket('ws://localhost:' + port);\n" +
+      "    window.ws.addEventListener('message', event => window.log.push(event.data));\n" +
+      "}", mapOf("port", webSocketServer.getPort()));
+
+    // Wait for WebSocket to be ready (readyState === 1)
+    page.waitForCondition(() -> {
+      Integer result = (Integer) page.evaluate("() => window.ws.readyState");
+      return result == 1;
+    });
+
+    page.evaluate("() => window.ws.send('query')");
+
+    // Wait and verify server received message
+    page.waitForCondition(() -> log.size() >= 1);
+    assertEquals(asList("query"), log);
+
+    // Wait and verify client received response 
+    page.waitForCondition(() -> {
+      Boolean result = (Boolean) page.evaluate("() => window.log.length >= 1");
+      return result;
+    });
+    assertEquals(asList("response"), page.evaluate("window.log"));
   }
 }


### PR DESCRIPTION
Fixes https://github.com/microsoft/playwright-java/pull/1717
Fixes https://github.com/microsoft/playwright-java/issues/1715

This ports the following upstream change: https://github.com/microsoft/playwright/blob/bc1a8c21912cf82f60d584438cd94c24f9daf8a4/packages/playwright-core/src/utils/isomorphic/urlMatch.ts#L110