### PR TITLE
test: do not send Content-Length header for HEAD requests

### DIFF
--- a/playwright/src/test/java/com/microsoft/playwright/Server.java
+++ b/playwright/src/test/java/com/microsoft/playwright/Server.java
@@ -218,7 +218,7 @@ public class Server implements HttpHandler {
     }
     long contentLength = body.size();
     // -1 means no body, 0 means chunked encoding.
-    exchange.sendResponseHeaders(200, contentLength == 0 ? -1 : contentLength);
+    exchange.sendResponseHeaders(200, (contentLength == 0 || exchange.getRequestMethod().equals("HEAD")) ? -1 : contentLength);
     if (contentLength > 0) {
       exchange.getResponseBody().write(body.toByteArray());
     }

--- a/playwright/src/test/java/com/microsoft/playwright/TestBrowserContextCredentials.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestBrowserContextCredentials.java
@@ -33,7 +33,6 @@ public class TestBrowserContextCredentials extends TestBase {
   @Test
   @DisabledIf(value="isChromiumHeadedLike", disabledReason="fail")
   void shouldFailWithoutCredentials() {
-    System.out.println("channel2 " + getBrowserChannelFromEnv());
     server.setAuth("/empty.html", "user", "pass");
     Response response = page.navigate(server.EMPTY_PAGE);
     assertEquals(401, response.status());

--- a/playwright/src/test/java/com/microsoft/playwright/TestGlobalFetch.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestGlobalFetch.java
@@ -337,7 +337,7 @@ public class TestGlobalFetch extends TestBase {
     for (String method : new String[] {"head", "put", "trace"}) {
       server.setRoute("/empty.html", exchange -> {
         exchange.getResponseHeaders().set("Content-type", "text/plain");
-        exchange.sendResponseHeaders(404, 10);
+        exchange.sendResponseHeaders(404, exchange.getRequestMethod().equals("HEAD") ? -1 : 10);
         try (Writer writer = new OutputStreamWriter(exchange.getResponseBody())) {
           writer.write("Not found.");
         }


### PR DESCRIPTION
Extracted from https://github.com/microsoft/playwright-java/pull/1761.

This fixes:

```
WARNING: sendResponseHeaders: being invoked with a content length for a HEAD request
```