### PR TITLE
devops: trigger publish on new tag

### DIFF
--- a/.azure-pipelines/publish.yml
+++ b/.azure-pipelines/publish.yml
@@ -1,5 +1,9 @@
-trigger: none
 pr: none
+
+trigger:
+  tags:
+    include:
+    - '*'
 
 resources:
   repositories:

--- a/.azure-pipelines/publish.yml
+++ b/.azure-pipelines/publish.yml
@@ -37,8 +37,8 @@ extends:
             artifact: esrp-build
         steps:
         - bash: |
-            if [[ ! "$CURRENT_BRANCH" =~ ^release-.* ]]; then
-              echo "Can only publish from a release branch."
+            if [[ ! "$CURRENT_BRANCH" =~ ^v1\\..* ]]; then
+              echo "Can only publish from a release tag branch (v1.*)."
               echo "Unexpected branch name: $CURRENT_BRANCH"
               exit 1
             fi


### PR DESCRIPTION
We still have [the check](https://github.com/microsoft/playwright-java/blob/01c72ac5d30908016c3a308a1afa445f77e5082b/.azure-pipelines/publish.yml#L31-L34) that the job runs on a `release-*` branch, hopefully it passes and provides extra guarantee that we only publish from release branches..