### PR TITLE
chore: require explicit timeout parameter in sendMessage()

### DIFF
--- a/playwright/src/main/java/com/microsoft/playwright/impl/APIRequestContextImpl.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/APIRequestContextImpl.java
@@ -58,7 +58,7 @@ class APIRequestContextImpl extends ChannelOwner implements APIRequestContext {
     }
     disposeReason = options.reason;
     JsonObject params = gson().toJsonTree(options).getAsJsonObject();
-    sendMessage("dispose", params);
+    sendMessage("dispose", params, NO_TIMEOUT);
   }
 
   @Override
@@ -131,7 +131,6 @@ class APIRequestContextImpl extends ChannelOwner implements APIRequestContext {
     if (options.multipart != null) {
       params.add("multipartData", serializeMultipartData(options.multipart.fields));
     }
-    params.addProperty("timeout", timeoutSettings.timeout(options.timeout));
     if (options.failOnStatusCode != null) {
       params.addProperty("failOnStatusCode", options.failOnStatusCode);
     }
@@ -150,7 +149,7 @@ class APIRequestContextImpl extends ChannelOwner implements APIRequestContext {
       }
       params.addProperty("maxRetries", options.maxRetries);
     }
-    JsonObject json = sendMessage("fetch", params).getAsJsonObject();
+    JsonObject json = sendMessage("fetch", params, timeoutSettings.timeout(options.timeout)).getAsJsonObject();
     return new APIResponseImpl(this, json.getAsJsonObject("response"));
   }
 

--- a/playwright/src/main/java/com/microsoft/playwright/impl/APIRequestImpl.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/APIRequestImpl.java
@@ -27,6 +27,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.List;
 
+import static com.microsoft.playwright.impl.ChannelOwner.NO_TIMEOUT;
 import static com.microsoft.playwright.impl.Serialization.gson;
 import static com.microsoft.playwright.impl.Utils.addToProtocol;
 
@@ -65,7 +66,7 @@ class APIRequestImpl implements APIRequest {
       params.add("storageState", storageState);
     }
     addToProtocol(params, clientCertificateList);
-    JsonObject result = playwright.sendMessage("newRequest", params).getAsJsonObject();
+    JsonObject result = playwright.sendMessage("newRequest", params, options.timeout).getAsJsonObject();
     APIRequestContextImpl context = playwright.connection.getExistingObject(result.getAsJsonObject("request").get("guid").getAsString());
     context.timeoutSettings.setDefaultTimeout(options.timeout);
     return context;

--- a/playwright/src/main/java/com/microsoft/playwright/impl/APIResponseImpl.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/APIResponseImpl.java
@@ -28,6 +28,7 @@ import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 
+import static com.microsoft.playwright.impl.ChannelOwner.NO_TIMEOUT;
 import static com.microsoft.playwright.impl.Serialization.gson;
 import static com.microsoft.playwright.impl.Utils.isSafeCloseError;
 import static java.util.Arrays.asList;
@@ -48,7 +49,7 @@ class APIResponseImpl implements APIResponse {
     try {
       JsonObject params = new JsonObject();
       params.addProperty("fetchUid", fetchUid());
-      JsonObject json = context.sendMessage("fetchResponseBody", params).getAsJsonObject();
+      JsonObject json = context.sendMessage("fetchResponseBody", params, NO_TIMEOUT).getAsJsonObject();
       if (!json.has("binary")) {
         throw new PlaywrightException("Response has been disposed");
       }
@@ -65,7 +66,7 @@ class APIResponseImpl implements APIResponse {
   public void dispose() {
     JsonObject params = new JsonObject();
     params.addProperty("fetchUid", fetchUid());
-    context.sendMessage("disposeAPIResponse", params);
+    context.sendMessage("disposeAPIResponse", params, NO_TIMEOUT);
   }
 
   @Override
@@ -111,7 +112,7 @@ class APIResponseImpl implements APIResponse {
   List<String> fetchLog() {
     JsonObject params = new JsonObject();
     params.addProperty("fetchUid", fetchUid());
-    JsonObject json = context.sendMessage("fetchLog", params).getAsJsonObject();
+    JsonObject json = context.sendMessage("fetchLog", params, NO_TIMEOUT).getAsJsonObject();
     JsonArray log = json.get("log").getAsJsonArray();
     return gson().fromJson(log, new TypeToken<List<String>>() {}.getType());
   }

--- a/playwright/src/main/java/com/microsoft/playwright/impl/ArtifactImpl.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/ArtifactImpl.java
@@ -86,6 +86,6 @@ class ArtifactImpl extends ChannelOwner {
 
     JsonObject params = new JsonObject();
     params.addProperty("path", path.toString());
-    sendMessage("saveAs", params);
+    sendMessage("saveAs", params, NO_TIMEOUT);
   }
 }

--- a/playwright/src/main/java/com/microsoft/playwright/impl/BindingCall.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/BindingCall.java
@@ -78,11 +78,11 @@ class BindingCall extends ChannelOwner {
 
       JsonObject params = new JsonObject();
       params.add("result", gson().toJsonTree(serializeArgument(result)));
-      sendMessage("resolve", params);
+      sendMessage("resolve", params, NO_TIMEOUT);
     } catch (RuntimeException exception) {
       JsonObject params = new JsonObject();
       params.add("error", gson().toJsonTree(serializeError(exception)));
-      sendMessage("reject", params);
+      sendMessage("reject", params, NO_TIMEOUT);
     }
   }
 }

--- a/playwright/src/main/java/com/microsoft/playwright/impl/BrowserImpl.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/BrowserImpl.java
@@ -123,7 +123,7 @@ class BrowserImpl extends ChannelOwner implements Browser {
     options.recordHarPath = null;
     options.recordHarOmitContent = null;
     options.recordHarUrlFilter = null;
-    
+
     if (options.storageStatePath != null) {
       try {
         byte[] bytes = Files.readAllBytes(options.storageStatePath);
@@ -171,7 +171,7 @@ class BrowserImpl extends ChannelOwner implements Browser {
     }
     params.add("selectorEngines", gson().toJsonTree(browserType.playwright.selectors.selectorEngines));
     params.addProperty("testIdAttributeName", browserType.playwright.selectors.testIdAttributeName);
-    JsonElement result = sendMessage("newContext", params);
+    JsonElement result = sendMessage("newContext", params, NO_TIMEOUT);
     BrowserContextImpl context = connection.getExistingObject(result.getAsJsonObject().getAsJsonObject("context").get("guid").getAsString());
     context.initializeHarFromOptions(harOptions);
     return context;
@@ -192,7 +192,7 @@ class BrowserImpl extends ChannelOwner implements Browser {
     if (page != null) {
       params.add("page", ((PageImpl) page).toProtocolRef());
     }
-    sendMessage("startTracing", params);
+    sendMessage("startTracing", params, NO_TIMEOUT);
   }
 
   @Override
@@ -250,7 +250,7 @@ class BrowserImpl extends ChannelOwner implements Browser {
   @Override
   public CDPSession newBrowserCDPSession() {
     JsonObject params = new JsonObject();
-    JsonObject result = sendMessage("newBrowserCDPSession", params).getAsJsonObject();
+    JsonObject result = sendMessage("newBrowserCDPSession", params, NO_TIMEOUT).getAsJsonObject();
     return connection.getExistingObject(result.getAsJsonObject("session").get("guid").getAsString());
   }
 

--- a/playwright/src/main/java/com/microsoft/playwright/impl/ChannelOwner.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/ChannelOwner.java
@@ -36,6 +36,8 @@ class ChannelOwner extends LoggingSupport {
   final JsonObject initializer;
   private boolean wasCollected;
 
+  static Double NO_TIMEOUT = null;
+
   protected ChannelOwner(ChannelOwner parent, String type, String guid, JsonObject initializer) {
     this(parent.connection, parent, type, guid, initializer);
   }
@@ -109,11 +111,16 @@ class ChannelOwner extends LoggingSupport {
   }
 
   JsonElement sendMessage(String method) {
-    return sendMessage(method, new JsonObject());
+    return sendMessage(method, new JsonObject(), NO_TIMEOUT);
   }
 
-  JsonElement sendMessage(String method, JsonObject params) {
+  JsonElement sendMessage(String method, JsonObject params, Double timeout) {
     checkNotCollected();
+    if (timeout != null) {
+      params.addProperty("timeout", timeout);
+    } else if (params.has("timeout")) {
+      throw new PlaywrightException("Internal error: timeout must be passed explicitly.");
+    }
     return connection.sendMessage(guid, method, params);
   }
 

--- a/playwright/src/main/java/com/microsoft/playwright/impl/ClockImpl.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/ClockImpl.java
@@ -5,6 +5,8 @@ import com.microsoft.playwright.Clock;
 
 import java.util.Date;
 
+import static com.microsoft.playwright.impl.ChannelOwner.NO_TIMEOUT;
+
 class ClockImpl implements Clock {
   private final ChannelOwner browserContext;
 
@@ -14,7 +16,7 @@ class ClockImpl implements Clock {
 
   private void sendMessageWithLogging(String method, JsonObject params) {
     String capitalizedMethod = method.substring(0, 1).toUpperCase() + method.substring(1);
-    browserContext.sendMessage("clock" + capitalizedMethod, params);
+    browserContext.sendMessage("clock" + capitalizedMethod, params, NO_TIMEOUT);
   }
 
   @Override

--- a/playwright/src/main/java/com/microsoft/playwright/impl/Connection.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/Connection.java
@@ -83,7 +83,7 @@ public class Connection {
     PlaywrightImpl initialize() {
       JsonObject params = new JsonObject();
       params.addProperty("sdkLanguage", "java");
-      JsonElement result = sendMessage("initialize", params.getAsJsonObject());
+      JsonElement result = sendMessage("initialize", params.getAsJsonObject(), NO_TIMEOUT);
       return this.connection.getExistingObject(result.getAsJsonObject().getAsJsonObject("playwright").get("guid").getAsString());
     }
   }

--- a/playwright/src/main/java/com/microsoft/playwright/impl/DialogImpl.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/DialogImpl.java
@@ -38,7 +38,7 @@ class DialogImpl extends ChannelOwner implements Dialog {
     if (promptText != null) {
       params.addProperty("promptText", promptText);
     }
-    sendMessage("accept", params);
+    sendMessage("accept", params, NO_TIMEOUT);
   }
 
   @Override

--- a/playwright/src/main/java/com/microsoft/playwright/impl/ElementHandleImpl.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/ElementHandleImpl.java
@@ -56,7 +56,7 @@ public class ElementHandleImpl extends JSHandleImpl implements ElementHandle {
   public ElementHandle querySelector(String selector) {
     JsonObject params = new JsonObject();
     params.addProperty("selector", selector);
-    JsonElement json = sendMessage("querySelector", params);
+    JsonElement json = sendMessage("querySelector", params, NO_TIMEOUT);
     JsonObject element = json.getAsJsonObject().getAsJsonObject("element");
     if (element == null) {
       return null;
@@ -68,7 +68,7 @@ public class ElementHandleImpl extends JSHandleImpl implements ElementHandle {
   public List<ElementHandle> querySelectorAll(String selector) {
     JsonObject params = new JsonObject();
     params.addProperty("selector", selector);
-    JsonElement json = sendMessage("querySelectorAll", params);
+    JsonElement json = sendMessage("querySelectorAll", params, NO_TIMEOUT);
     JsonArray elements = json.getAsJsonObject().getAsJsonArray("elements");
     if (elements == null) {
       return null;
@@ -86,7 +86,7 @@ public class ElementHandleImpl extends JSHandleImpl implements ElementHandle {
     params.addProperty("selector", selector);
     params.addProperty("expression", pageFunction);
     params.add("arg", gson().toJsonTree(serializeArgument(arg)));
-    JsonElement json = sendMessage("evalOnSelector", params);
+    JsonElement json = sendMessage("evalOnSelector", params, NO_TIMEOUT);
     SerializedValue value = gson().fromJson(json.getAsJsonObject().get("value"), SerializedValue.class);
     return deserialize(value);
   }
@@ -97,7 +97,7 @@ public class ElementHandleImpl extends JSHandleImpl implements ElementHandle {
     params.addProperty("selector", selector);
     params.addProperty("expression", pageFunction);
     params.add("arg", gson().toJsonTree(serializeArgument(arg)));
-    JsonElement json = sendMessage("evalOnSelectorAll", params);
+    JsonElement json = sendMessage("evalOnSelectorAll", params, NO_TIMEOUT);
     SerializedValue value = gson().fromJson(json.getAsJsonObject().get("value"), SerializedValue.class);
     return deserialize(value);
   }
@@ -116,9 +116,8 @@ public class ElementHandleImpl extends JSHandleImpl implements ElementHandle {
     if (options == null) {
       options = new CheckOptions();
     }
-    options.timeout = frame.timeout(options.timeout);
     JsonObject params = gson().toJsonTree(options).getAsJsonObject();
-    sendMessage("check", params);
+    sendMessage("check", params, frame.timeout(options.timeout));
   }
 
   @Override
@@ -126,9 +125,8 @@ public class ElementHandleImpl extends JSHandleImpl implements ElementHandle {
     if (options == null) {
       options = new ClickOptions();
     }
-    options.timeout = frame.timeout(options.timeout);
     JsonObject params = gson().toJsonTree(options).getAsJsonObject();
-    sendMessage("click", params);
+    sendMessage("click", params, frame.timeout(options.timeout));
   }
 
   @Override
@@ -145,9 +143,8 @@ public class ElementHandleImpl extends JSHandleImpl implements ElementHandle {
     if (options == null) {
       options = new DblclickOptions();
     }
-    options.timeout = frame.timeout(options.timeout);
     JsonObject params = gson().toJsonTree(options).getAsJsonObject();
-    sendMessage("dblclick", params);
+    sendMessage("dblclick", params, frame.timeout(options.timeout));
   }
 
   @Override
@@ -155,7 +152,7 @@ public class ElementHandleImpl extends JSHandleImpl implements ElementHandle {
     JsonObject params = new JsonObject();
     params.addProperty("type", type);
     params.add("eventInit", gson().toJsonTree(serializeArgument(eventInit)));
-    sendMessage("dispatchEvent", params);
+    sendMessage("dispatchEvent", params, NO_TIMEOUT);
   }
 
   @Override
@@ -163,10 +160,9 @@ public class ElementHandleImpl extends JSHandleImpl implements ElementHandle {
     if (options == null) {
       options = new FillOptions();
     }
-    options.timeout = frame.timeout(options.timeout);
     JsonObject params = gson().toJsonTree(options).getAsJsonObject();
     params.addProperty("value", value);
-    sendMessage("fill", params);
+    sendMessage("fill", params, frame.timeout(options.timeout));
   }
 
   @Override
@@ -178,7 +174,7 @@ public class ElementHandleImpl extends JSHandleImpl implements ElementHandle {
   public String getAttribute(String name) {
     JsonObject params = new JsonObject();
     params.addProperty("name", name);
-    JsonObject json = sendMessage("getAttribute", params).getAsJsonObject();
+    JsonObject json = sendMessage("getAttribute", params, NO_TIMEOUT).getAsJsonObject();
     return json.has("value") ? json.get("value").getAsString() : null;
   }
 
@@ -187,9 +183,8 @@ public class ElementHandleImpl extends JSHandleImpl implements ElementHandle {
     if (options == null) {
       options = new HoverOptions();
     }
-    options.timeout = frame.timeout(options.timeout);
     JsonObject params = gson().toJsonTree(options).getAsJsonObject();
-    sendMessage("hover", params);
+    sendMessage("hover", params, frame.timeout(options.timeout));
   }
 
   @Override
@@ -210,7 +205,7 @@ public class ElementHandleImpl extends JSHandleImpl implements ElementHandle {
       options = new InputValueOptions();
     }
     JsonObject params = gson().toJsonTree(options).getAsJsonObject();
-    JsonObject json = sendMessage("inputValue", params).getAsJsonObject();
+    JsonObject json = sendMessage("inputValue", params, NO_TIMEOUT).getAsJsonObject();
     return json.get("value").getAsString();
   }
 
@@ -264,10 +259,9 @@ public class ElementHandleImpl extends JSHandleImpl implements ElementHandle {
     if (options == null) {
       options = new PressOptions();
     }
-    options.timeout = frame.timeout(options.timeout);
     JsonObject params = gson().toJsonTree(options).getAsJsonObject();
     params.addProperty("key", key);
-    sendMessage("press", params);
+    sendMessage("press", params, frame.timeout(options.timeout));
   }
 
   @Override
@@ -275,7 +269,6 @@ public class ElementHandleImpl extends JSHandleImpl implements ElementHandle {
     if (options == null) {
       options = new ScreenshotOptions();
     }
-    options.timeout = frame.timeout(options.timeout);
     if (options.type == null) {
       options.type = PNG;
       if (options.path != null) {
@@ -291,7 +284,7 @@ public class ElementHandleImpl extends JSHandleImpl implements ElementHandle {
     }
     JsonObject params = gson().toJsonTree(options).getAsJsonObject();
     params.remove("path");
-    JsonObject json = sendMessage("screenshot", params).getAsJsonObject();
+    JsonObject json = sendMessage("screenshot", params, frame.timeout(options.timeout)).getAsJsonObject();
 
     byte[] buffer = Base64.getDecoder().decode(json.get("binary").getAsString());
     if (options.path != null) {
@@ -305,9 +298,8 @@ public class ElementHandleImpl extends JSHandleImpl implements ElementHandle {
     if (options == null) {
       options = new ScrollIntoViewIfNeededOptions();
     }
-    options.timeout = frame.timeout(options.timeout);
     JsonObject params = gson().toJsonTree(options).getAsJsonObject();
-    sendMessage("scrollIntoViewIfNeeded", params);
+    sendMessage("scrollIntoViewIfNeeded", params, frame.timeout(options.timeout));
   }
 
   @Override
@@ -327,12 +319,11 @@ public class ElementHandleImpl extends JSHandleImpl implements ElementHandle {
     if (options == null) {
       options = new SelectOptionOptions();
     }
-    options.timeout = frame.timeout(options.timeout);
     JsonObject params = gson().toJsonTree(options).getAsJsonObject();
     if (values != null) {
       params.add("options", toSelectValueOrLabel(values));
     }
-    return selectOption(params);
+    return selectOption(params, options.timeout);
   }
 
   @Override
@@ -351,7 +342,7 @@ public class ElementHandleImpl extends JSHandleImpl implements ElementHandle {
     if (values != null) {
       params.add("options", gson().toJsonTree(values));
     }
-    return selectOption(params);
+    return selectOption(params, options.timeout);
   }
 
   @Override
@@ -363,11 +354,11 @@ public class ElementHandleImpl extends JSHandleImpl implements ElementHandle {
     if (values != null) {
       params.add("elements", Serialization.toProtocol(values));
     }
-    return selectOption(params);
+    return selectOption(params, options.timeout);
   }
 
-  private List<String> selectOption(JsonObject params) {
-    JsonObject json = sendMessage("selectOption", params).getAsJsonObject();
+  private List<String> selectOption(JsonObject params, Double timeout) {
+    JsonObject json = sendMessage("selectOption", params, frame.timeout(timeout)).getAsJsonObject();
     return parseStringList(json.getAsJsonArray("values"));
   }
 
@@ -376,9 +367,8 @@ public class ElementHandleImpl extends JSHandleImpl implements ElementHandle {
     if (options == null) {
       options = new SelectTextOptions();
     }
-    options.timeout = frame.timeout(options.timeout);
     JsonObject params = gson().toJsonTree(options).getAsJsonObject();
-    sendMessage("selectText", params);
+    sendMessage("selectText", params, frame.timeout(options.timeout));
   }
 
   @Override
@@ -405,10 +395,9 @@ public class ElementHandleImpl extends JSHandleImpl implements ElementHandle {
     if (options == null) {
       options = new SetInputFilesOptions();
     }
-    options.timeout = frame.timeout(options.timeout);
     JsonObject params = gson().toJsonTree(options).getAsJsonObject();
     addFilePathUploadParams(files, params, frame.page().context());
-    sendMessage("setInputFiles", params);
+    sendMessage("setInputFiles", params, frame.timeout(options.timeout));
   }
 
   @Override
@@ -422,10 +411,9 @@ public class ElementHandleImpl extends JSHandleImpl implements ElementHandle {
     if (options == null) {
       options = new SetInputFilesOptions();
     }
-    options.timeout = frame.timeout(options.timeout);
     JsonObject params = gson().toJsonTree(options).getAsJsonObject();
     params.add("payloads", Serialization.toJsonArray(files));
-    sendMessage("setInputFiles", params);
+    sendMessage("setInputFiles", params, frame.timeout(options.timeout));
   }
 
   @Override
@@ -433,9 +421,8 @@ public class ElementHandleImpl extends JSHandleImpl implements ElementHandle {
     if (options == null) {
       options = new TapOptions();
     }
-    options.timeout = frame.timeout(options.timeout);
     JsonObject params = gson().toJsonTree(options).getAsJsonObject();
-    sendMessage("tap", params);
+    sendMessage("tap", params, frame.timeout(options.timeout));
   }
 
   @Override
@@ -449,10 +436,9 @@ public class ElementHandleImpl extends JSHandleImpl implements ElementHandle {
     if (options == null) {
       options = new TypeOptions();
     }
-    options.timeout = frame.timeout(options.timeout);
     JsonObject params = gson().toJsonTree(options).getAsJsonObject();
     params.addProperty("text", text);
-    sendMessage("type", params);
+    sendMessage("type", params, frame.timeout(options.timeout));
   }
 
   @Override
@@ -460,9 +446,8 @@ public class ElementHandleImpl extends JSHandleImpl implements ElementHandle {
     if (options == null) {
       options = new UncheckOptions();
     }
-    options.timeout = frame.timeout(options.timeout);
     JsonObject params = gson().toJsonTree(options).getAsJsonObject();
-    sendMessage("uncheck", params);
+    sendMessage("uncheck", params, frame.timeout(options.timeout));
   }
 
   @Override
@@ -470,13 +455,12 @@ public class ElementHandleImpl extends JSHandleImpl implements ElementHandle {
     if (options == null) {
       options = new WaitForElementStateOptions();
     }
-    options.timeout = frame.timeout(options.timeout);
     if (state == null) {
       throw new IllegalArgumentException("State cannot be null");
     }
     JsonObject params = gson().toJsonTree(options).getAsJsonObject();
     params.addProperty("state", toProtocol(state));
-    sendMessage("waitForElementState", params);
+    sendMessage("waitForElementState", params, frame.timeout(options.timeout));
   }
 
   private static String toProtocol(ElementState state) {
@@ -488,10 +472,9 @@ public class ElementHandleImpl extends JSHandleImpl implements ElementHandle {
     if (options == null) {
       options = new WaitForSelectorOptions();
     }
-    options.timeout = frame.timeout(options.timeout);
     JsonObject params = gson().toJsonTree(options).getAsJsonObject();
     params.addProperty("selector", selector);
-    JsonElement json = sendMessage("waitForSelector", params);
+    JsonElement json = sendMessage("waitForSelector", params, frame.timeout(options.timeout)).getAsJsonObject();
     JsonObject element = json.getAsJsonObject().getAsJsonObject("element");
     if (element == null) {
       return null;

--- a/playwright/src/main/java/com/microsoft/playwright/impl/FrameImpl.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/FrameImpl.java
@@ -79,7 +79,7 @@ public class FrameImpl extends ChannelOwner implements Frame {
     }
     JsonObject params = gson().toJsonTree(options).getAsJsonObject();
     params.addProperty("selector", selector);
-    JsonElement json = sendMessage("querySelector", params);
+    JsonElement json = sendMessage("querySelector", params, NO_TIMEOUT);
     JsonObject element = json.getAsJsonObject().getAsJsonObject("element");
     if (element == null) {
       return null;
@@ -91,7 +91,7 @@ public class FrameImpl extends ChannelOwner implements Frame {
   public List<ElementHandle> querySelectorAll(String selector) {
     JsonObject params = new JsonObject();
     params.addProperty("selector", selector);
-    JsonElement json = sendMessage("querySelectorAll", params);
+    JsonElement json = sendMessage("querySelectorAll", params, NO_TIMEOUT);
     JsonArray elements = json.getAsJsonObject().getAsJsonArray("elements");
     if (elements == null) {
       return null;
@@ -140,7 +140,7 @@ public class FrameImpl extends ChannelOwner implements Frame {
     params.addProperty("selector", selector);
     params.addProperty("expression", pageFunction);
     params.add("arg", gson().toJsonTree(serializeArgument(arg)));
-    JsonElement json = sendMessage("evalOnSelector", params);
+    JsonElement json = sendMessage("evalOnSelector", params, NO_TIMEOUT);
     SerializedValue value = gson().fromJson(json.getAsJsonObject().get("value"), SerializedValue.class);
     return deserialize(value);
   }
@@ -155,7 +155,7 @@ public class FrameImpl extends ChannelOwner implements Frame {
     params.addProperty("selector", selector);
     params.addProperty("expression", pageFunction);
     params.add("arg", gson().toJsonTree(serializeArgument(arg)));
-    JsonElement json = sendMessage("evalOnSelectorAll", params);
+    JsonElement json = sendMessage("evalOnSelectorAll", params, NO_TIMEOUT);
     SerializedValue value = gson().fromJson(json.getAsJsonObject().get("value"), SerializedValue.class);
     return deserialize(value);
   }
@@ -182,7 +182,7 @@ public class FrameImpl extends ChannelOwner implements Frame {
       content = addSourceUrlToScript(content, options.path);
       jsonOptions.addProperty("content", content);
     }
-    JsonElement json = sendMessage("addScriptTag", jsonOptions);
+    JsonElement json = sendMessage("addScriptTag", jsonOptions, NO_TIMEOUT);
     return connection.getExistingObject(json.getAsJsonObject().getAsJsonObject("element").get("guid").getAsString());
   }
 
@@ -208,7 +208,7 @@ public class FrameImpl extends ChannelOwner implements Frame {
       content += "/*# sourceURL=" + options.path.toString().replace("\n", "") + "*/";
       jsonOptions.addProperty("content", content);
     }
-    JsonElement json = sendMessage("addStyleTag", jsonOptions);
+    JsonElement json = sendMessage("addStyleTag", jsonOptions, NO_TIMEOUT);
     return connection.getExistingObject(json.getAsJsonObject().getAsJsonObject("element").get("guid").getAsString());
   }
 
@@ -217,10 +217,9 @@ public class FrameImpl extends ChannelOwner implements Frame {
     if (options == null) {
       options = new CheckOptions();
     }
-    options.timeout = timeout(options.timeout);
     JsonObject params = gson().toJsonTree(options).getAsJsonObject();
     params.addProperty("selector", selector);
-    sendMessage("check", params);
+    sendMessage("check", params, timeout(options.timeout));
   }
 
   @Override
@@ -237,10 +236,9 @@ public class FrameImpl extends ChannelOwner implements Frame {
     if (options == null) {
       options = new ClickOptions();
     }
-    options.timeout = timeout(options.timeout);
     JsonObject params = gson().toJsonTree(options).getAsJsonObject();
     params.addProperty("selector", selector);
-    sendMessage("click", params);
+    sendMessage("click", params, timeout(options.timeout));
   }
 
   @Override
@@ -253,10 +251,9 @@ public class FrameImpl extends ChannelOwner implements Frame {
     if (options == null) {
       options = new DblclickOptions();
     }
-    options.timeout = timeout(options.timeout);
     JsonObject params = gson().toJsonTree(options).getAsJsonObject();
     params.addProperty("selector", selector);
-    sendMessage("dblclick", params);
+    sendMessage("dblclick", params, timeout(options.timeout));
   }
 
   @Override
@@ -264,12 +261,11 @@ public class FrameImpl extends ChannelOwner implements Frame {
     if (options == null) {
       options = new DispatchEventOptions();
     }
-    options.timeout = timeout(options.timeout);
     JsonObject params = gson().toJsonTree(options).getAsJsonObject();
     params.addProperty("selector", selector);
     params.addProperty("type", type);
     params.add("eventInit", gson().toJsonTree(serializeArgument(eventInit)));
-    sendMessage("dispatchEvent", params);
+    sendMessage("dispatchEvent", params, timeout(options.timeout));
   }
 
   @Override
@@ -278,7 +274,7 @@ public class FrameImpl extends ChannelOwner implements Frame {
     params.addProperty("expression", expression);
     params.addProperty("world", "main");
     params.add("arg", gson().toJsonTree(serializeArgument(arg)));
-    JsonElement json = sendMessage("evaluateExpression", params);
+    JsonElement json = sendMessage("evaluateExpression", params, NO_TIMEOUT);
     SerializedValue value = gson().fromJson(json.getAsJsonObject().get("value"), SerializedValue.class);
     return deserialize(value);
   }
@@ -289,7 +285,7 @@ public class FrameImpl extends ChannelOwner implements Frame {
     params.addProperty("expression", pageFunction);
     params.addProperty("world", "main");
     params.add("arg", gson().toJsonTree(serializeArgument(arg)));
-    JsonElement json = sendMessage("evaluateExpressionHandle", params);
+    JsonElement json = sendMessage("evaluateExpressionHandle", params, NO_TIMEOUT);
     return connection.getExistingObject(json.getAsJsonObject().getAsJsonObject("handle").get("guid").getAsString());
   }
 
@@ -298,11 +294,10 @@ public class FrameImpl extends ChannelOwner implements Frame {
     if (options == null) {
       options = new FillOptions();
     }
-    options.timeout = timeout(options.timeout);
     JsonObject params = gson().toJsonTree(options).getAsJsonObject();
     params.addProperty("selector", selector);
     params.addProperty("value", value);
-    sendMessage("fill", params);
+    sendMessage("fill", params, timeout(options.timeout));
   }
 
   @Override
@@ -310,10 +305,9 @@ public class FrameImpl extends ChannelOwner implements Frame {
     if (options == null) {
       options = new FocusOptions();
     }
-    options.timeout = timeout(options.timeout);
     JsonObject params = gson().toJsonTree(options).getAsJsonObject();
     params.addProperty("selector", selector);
-    sendMessage("focus", params);
+    sendMessage("focus", params, timeout(options.timeout));
   }
 
   @Override
@@ -401,11 +395,10 @@ public class FrameImpl extends ChannelOwner implements Frame {
     if (options == null) {
       options = new GetAttributeOptions();
     }
-    options.timeout = timeout(options.timeout);
     JsonObject params = gson().toJsonTree(options).getAsJsonObject();
     params.addProperty("selector", selector);
     params.addProperty("name", name);
-    JsonObject json = sendMessage("getAttribute", params).getAsJsonObject();
+    JsonObject json = sendMessage("getAttribute", params, timeout(options.timeout)).getAsJsonObject();
     if (json.has("value")) {
       return json.get("value").getAsString();
     }
@@ -421,10 +414,9 @@ public class FrameImpl extends ChannelOwner implements Frame {
     if (options == null) {
       options = new NavigateOptions();
     }
-    options.timeout = navigationTimeout(options.timeout);
     JsonObject params = gson().toJsonTree(options).getAsJsonObject();
     params.addProperty("url", url);
-    JsonElement result = sendMessage("goto", params);
+    JsonElement result = sendMessage("goto", params, navigationTimeout(options.timeout));
     JsonObject jsonResponse = result.getAsJsonObject().getAsJsonObject("response");
     if (jsonResponse == null) {
       return null;
@@ -441,10 +433,9 @@ public class FrameImpl extends ChannelOwner implements Frame {
     if (options == null) {
       options = new HoverOptions();
     }
-    options.timeout = timeout(options.timeout);
     JsonObject params = gson().toJsonTree(options).getAsJsonObject();
     params.addProperty("selector", selector);
-    sendMessage("hover", params);
+    sendMessage("hover", params, timeout(options.timeout));
   }
 
   @Override
@@ -456,11 +447,10 @@ public class FrameImpl extends ChannelOwner implements Frame {
     if (options == null) {
       options = new DragAndDropOptions();
     }
-    options.timeout = timeout(options.timeout);
     JsonObject params = gson().toJsonTree(options).getAsJsonObject();
     params.addProperty("source", source);
     params.addProperty("target", target);
-    sendMessage("dragAndDrop", params);
+    sendMessage("dragAndDrop", params, timeout(options.timeout));
   }
 
   @Override
@@ -472,10 +462,9 @@ public class FrameImpl extends ChannelOwner implements Frame {
     if (options == null) {
       options = new InnerHTMLOptions();
     }
-    options.timeout = timeout(options.timeout);
     JsonObject params = gson().toJsonTree(options).getAsJsonObject();
     params.addProperty("selector", selector);
-    JsonObject json = sendMessage("innerHTML", params).getAsJsonObject();
+    JsonObject json = sendMessage("innerHTML", params, timeout(options.timeout)).getAsJsonObject();
     return json.get("value").getAsString();
   }
 
@@ -488,10 +477,9 @@ public class FrameImpl extends ChannelOwner implements Frame {
     if (options == null) {
       options = new InnerTextOptions();
     }
-    options.timeout = timeout(options.timeout);
     JsonObject params = gson().toJsonTree(options).getAsJsonObject();
     params.addProperty("selector", selector);
-    JsonObject json = sendMessage("innerText", params).getAsJsonObject();
+    JsonObject json = sendMessage("innerText", params, timeout(options.timeout)).getAsJsonObject();
     return json.get("value").getAsString();
   }
 
@@ -504,10 +492,9 @@ public class FrameImpl extends ChannelOwner implements Frame {
     if (options == null) {
       options = new InputValueOptions();
     }
-    options.timeout = timeout(options.timeout);
     JsonObject params = gson().toJsonTree(options).getAsJsonObject();
     params.addProperty("selector", selector);
-    JsonObject json = sendMessage("inputValue", params).getAsJsonObject();
+    JsonObject json = sendMessage("inputValue", params, timeout(options.timeout)).getAsJsonObject();
     return json.get("value").getAsString();
   }
 
@@ -520,10 +507,9 @@ public class FrameImpl extends ChannelOwner implements Frame {
     if (options == null) {
       options = new IsCheckedOptions();
     }
-    options.timeout = timeout(options.timeout);
     JsonObject params = gson().toJsonTree(options).getAsJsonObject();
     params.addProperty("selector", selector);
-    JsonObject json = sendMessage("isChecked", params).getAsJsonObject();
+    JsonObject json = sendMessage("isChecked", params, timeout(options.timeout)).getAsJsonObject();
     return json.get("value").getAsBoolean();
   }
 
@@ -541,10 +527,9 @@ public class FrameImpl extends ChannelOwner implements Frame {
     if (options == null) {
       options = new IsDisabledOptions();
     }
-    options.timeout = timeout(options.timeout);
     JsonObject params = gson().toJsonTree(options).getAsJsonObject();
     params.addProperty("selector", selector);
-    JsonObject json = sendMessage("isDisabled", params).getAsJsonObject();
+    JsonObject json = sendMessage("isDisabled", params, timeout(options.timeout)).getAsJsonObject();
     return json.get("value").getAsBoolean();
   }
 
@@ -557,10 +542,9 @@ public class FrameImpl extends ChannelOwner implements Frame {
     if (options == null) {
       options = new IsEditableOptions();
     }
-    options.timeout = timeout(options.timeout);
     JsonObject params = gson().toJsonTree(options).getAsJsonObject();
     params.addProperty("selector", selector);
-    JsonObject json = sendMessage("isEditable", params).getAsJsonObject();
+    JsonObject json = sendMessage("isEditable", params, timeout(options.timeout)).getAsJsonObject();
     return json.get("value").getAsBoolean();
   }
 
@@ -573,10 +557,9 @@ public class FrameImpl extends ChannelOwner implements Frame {
     if (options == null) {
       options = new IsEnabledOptions();
     }
-    options.timeout = timeout(options.timeout);
     JsonObject params = gson().toJsonTree(options).getAsJsonObject();
     params.addProperty("selector", selector);
-    JsonObject json = sendMessage("isEnabled", params).getAsJsonObject();
+    JsonObject json = sendMessage("isEnabled", params, timeout(options.timeout)).getAsJsonObject();
     return json.get("value").getAsBoolean();
   }
 
@@ -589,10 +572,9 @@ public class FrameImpl extends ChannelOwner implements Frame {
     if (options == null) {
       options = new IsHiddenOptions();
     }
-    options.timeout = timeout(options.timeout);
     JsonObject params = gson().toJsonTree(options).getAsJsonObject();
     params.addProperty("selector", selector);
-    JsonObject json = sendMessage("isHidden", params).getAsJsonObject();
+    JsonObject json = sendMessage("isHidden", params, timeout(options.timeout)).getAsJsonObject();
     return json.get("value").getAsBoolean();
   }
 
@@ -612,7 +594,7 @@ public class FrameImpl extends ChannelOwner implements Frame {
     }
     JsonObject params = gson().toJsonTree(options).getAsJsonObject();
     params.addProperty("selector", selector);
-    JsonObject json = sendMessage("isVisible", params).getAsJsonObject();
+    JsonObject json = sendMessage("isVisible", params, timeout(options.timeout)).getAsJsonObject();
     return json.get("value").getAsBoolean();
   }
 
@@ -640,13 +622,12 @@ public class FrameImpl extends ChannelOwner implements Frame {
     if (options == null) {
       options = new PressOptions();
     }
-    options.timeout = timeout(options.timeout);
     JsonObject params = gson().toJsonTree(options).getAsJsonObject();
     params.addProperty("selector", selector);
     params.addProperty("key", key);
-    sendMessage("press", params);
+    sendMessage("press", params, timeout(options.timeout));
   }
-
+  
   @Override
   public List<String> selectOption(String selector, SelectOption[] values, SelectOptionOptions options) {
     return selectOptionImpl(selector, values, options);
@@ -656,26 +637,24 @@ public class FrameImpl extends ChannelOwner implements Frame {
     if (options == null) {
       options = new SelectOptionOptions();
     }
-    options.timeout = timeout(options.timeout);
     JsonObject params = gson().toJsonTree(options).getAsJsonObject();
     params.addProperty("selector", selector);
     if (values != null) {
       params.add("options", gson().toJsonTree(values));
     }
-    return selectOption(params);
+    return selectOption(params, options.timeout);
   }
 
   List<String> selectOptionImpl(String selector, String[] values, SelectOptionOptions options) {
     if (options == null) {
       options = new SelectOptionOptions();
     }
-    options.timeout = timeout(options.timeout);
     JsonObject params = gson().toJsonTree(options).getAsJsonObject();
     params.addProperty("selector", selector);
     if (values != null) {
       params.add("options", toSelectValueOrLabel(values));
     }
-    return selectOption(params);
+    return selectOption(params, options.timeout);
   }
 
   @Override
@@ -687,17 +666,16 @@ public class FrameImpl extends ChannelOwner implements Frame {
     if (options == null) {
       options = new SelectOptionOptions();
     }
-    options.timeout = timeout(options.timeout);
     JsonObject params = gson().toJsonTree(options).getAsJsonObject();
     params.addProperty("selector", selector);
     if (values != null) {
       params.add("elements", Serialization.toProtocol(values));
     }
-    return selectOption(params);
+    return selectOption(params, options.timeout);
   }
 
-  private List<String> selectOption(JsonObject params) {
-    JsonObject json = sendMessage("selectOption", params).getAsJsonObject();
+  private List<String> selectOption(JsonObject params, Double timeout) {
+    JsonObject json = sendMessage("selectOption", params, timeout(timeout)).getAsJsonObject();
     return parseStringList(json.getAsJsonArray("values"));
   }
 
@@ -719,10 +697,9 @@ public class FrameImpl extends ChannelOwner implements Frame {
     if (options == null) {
       options = new SetContentOptions();
     }
-    options.timeout = navigationTimeout(options.timeout);
     JsonObject params = gson().toJsonTree(options).getAsJsonObject();
     params.addProperty("html", html);
-    sendMessage("setContent", params);
+    sendMessage("setContent", params, navigationTimeout(options.timeout));
   }
 
   @Override
@@ -739,11 +716,10 @@ public class FrameImpl extends ChannelOwner implements Frame {
     if (options == null) {
       options = new SetInputFilesOptions();
     }
-    options.timeout = timeout(options.timeout);
     JsonObject params = gson().toJsonTree(options).getAsJsonObject();
     addFilePathUploadParams(files, params, page.context());
     params.addProperty("selector", selector);
-    sendMessage("setInputFiles", params);
+    sendMessage("setInputFiles", params, timeout(options.timeout));
   }
 
   @Override
@@ -761,11 +737,10 @@ public class FrameImpl extends ChannelOwner implements Frame {
     if (options == null) {
       options = new SetInputFilesOptions();
     }
-    options.timeout = timeout(options.timeout);
     JsonObject params = gson().toJsonTree(options).getAsJsonObject();
     params.addProperty("selector", selector);
     params.add("payloads", toJsonArray(files));
-    sendMessage("setInputFiles", params);
+    sendMessage("setInputFiles", params, timeout(options.timeout));
   }
 
   @Override
@@ -773,10 +748,9 @@ public class FrameImpl extends ChannelOwner implements Frame {
     if (options == null) {
       options = new TapOptions();
     }
-    options.timeout = timeout(options.timeout);
     JsonObject params = gson().toJsonTree(options).getAsJsonObject();
     params.addProperty("selector", selector);
-    sendMessage("tap", params);
+    sendMessage("tap", params, timeout(options.timeout));
   }
 
   @Override
@@ -784,10 +758,9 @@ public class FrameImpl extends ChannelOwner implements Frame {
     if (options == null) {
       options = new TextContentOptions();
     }
-    options.timeout = timeout(options.timeout);
     JsonObject params = gson().toJsonTree(options).getAsJsonObject();
     params.addProperty("selector", selector);
-    return sendMessage("textContent", params).getAsJsonObject().get("value").getAsString();
+    return sendMessage("textContent", params, timeout(options.timeout)).getAsJsonObject().get("value").getAsString();
   }
 
   @Override
@@ -801,11 +774,10 @@ public class FrameImpl extends ChannelOwner implements Frame {
     if (options == null) {
       options = new TypeOptions();
     }
-    options.timeout = timeout(options.timeout);
     JsonObject params = gson().toJsonTree(options).getAsJsonObject();
     params.addProperty("selector", selector);
     params.addProperty("text", text);
-    sendMessage("type", params);
+    sendMessage("type", params, timeout(options.timeout));
   }
 
   @Override
@@ -813,10 +785,9 @@ public class FrameImpl extends ChannelOwner implements Frame {
     if (options == null) {
       options = new UncheckOptions();
     }
-    options.timeout = timeout(options.timeout);
     JsonObject params = gson().toJsonTree(options).getAsJsonObject();
     params.addProperty("selector", selector);
-    sendMessage("uncheck", params);
+    sendMessage("uncheck", params, timeout(options.timeout));
   }
 
   @Override
@@ -829,11 +800,10 @@ public class FrameImpl extends ChannelOwner implements Frame {
     if (options == null) {
       options = new WaitForFunctionOptions();
     }
-    options.timeout = timeout(options.timeout);
     JsonObject params = gson().toJsonTree(options).getAsJsonObject();
     params.addProperty("expression", pageFunction);
     params.add("arg", gson().toJsonTree(serializeArgument(arg)));
-    JsonElement json = sendMessage("waitForFunction", params);
+    JsonElement json = sendMessage("waitForFunction", params, timeout(options.timeout));
     JsonObject element = json.getAsJsonObject().getAsJsonObject("handle");
     return connection.getExistingObject(element.get("guid").getAsString());
   }
@@ -1009,11 +979,10 @@ public class FrameImpl extends ChannelOwner implements Frame {
     if (options == null) {
       options = new WaitForSelectorOptions();
     }
-    options.timeout = timeout(options.timeout);
     JsonObject params = gson().toJsonTree(options).getAsJsonObject();
     params.addProperty("selector", selector);
     params.addProperty("omitReturnValue", omitReturnValue);
-    JsonElement json = sendMessage("waitForSelector", params);
+    JsonElement json = sendMessage("waitForSelector", params, timeout(options.timeout));
     JsonObject element = json.getAsJsonObject().getAsJsonObject("element");
     if (element == null) {
       return null;
@@ -1024,8 +993,7 @@ public class FrameImpl extends ChannelOwner implements Frame {
   @Override
   public void waitForTimeout(double timeout) {
     JsonObject params = new JsonObject();
-    params.addProperty("timeout", timeout);
-    sendMessage("waitForTimeout", params);
+    sendMessage("waitForTimeout", params, timeout);
   }
 
   @Override
@@ -1065,14 +1033,14 @@ public class FrameImpl extends ChannelOwner implements Frame {
   int queryCount(String selector) {
     JsonObject params = new JsonObject();
     params.addProperty("selector", selector);
-    JsonObject result = sendMessage("queryCount", params).getAsJsonObject();
+    JsonObject result = sendMessage("queryCount", params, NO_TIMEOUT).getAsJsonObject();
     return result.get("value").getAsInt();
   }
 
   void highlightImpl(String selector) {
     JsonObject params = new JsonObject();
     params.addProperty("selector", selector);
-    sendMessage("highlight", params);
+    sendMessage("highlight", params, NO_TIMEOUT);
   }
 
   protected void handleEvent(String event, JsonObject params) {

--- a/playwright/src/main/java/com/microsoft/playwright/impl/HARRouter.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/HARRouter.java
@@ -26,6 +26,7 @@ import java.nio.file.Path;
 import java.util.Base64;
 import java.util.Map;
 
+import static com.microsoft.playwright.impl.ChannelOwner.NO_TIMEOUT;
 import static com.microsoft.playwright.impl.LoggingSupport.*;
 import static com.microsoft.playwright.impl.Serialization.fromNameValues;
 import static com.microsoft.playwright.impl.Serialization.gson;
@@ -41,7 +42,7 @@ public class HARRouter {
 
     JsonObject params = new JsonObject();
     params.addProperty("file", harFile.toString());
-    JsonObject json = localUtils.sendMessage("harOpen", params).getAsJsonObject();
+    JsonObject json = localUtils.sendMessage("harOpen", params, NO_TIMEOUT).getAsJsonObject();
     if (json.has("error")) {
       throw new PlaywrightException(json.get("error").getAsString());
     }
@@ -61,7 +62,7 @@ public class HARRouter {
       params.addProperty("postData", base64);
     }
     params.addProperty("isNavigationRequest", request.isNavigationRequest());
-    JsonObject response = localUtils.sendMessage("harLookup", params).getAsJsonObject();
+    JsonObject response = localUtils.sendMessage("harLookup", params, NO_TIMEOUT).getAsJsonObject();
 
     String action = response.get("action").getAsString();
     if ("redirect".equals(action)) {

--- a/playwright/src/main/java/com/microsoft/playwright/impl/JSHandleImpl.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/JSHandleImpl.java
@@ -53,7 +53,7 @@ public class JSHandleImpl extends ChannelOwner implements JSHandle {
     params.addProperty("expression", pageFunction);
     params.addProperty("world", "main");
     params.add("arg", gson().toJsonTree(serializeArgument(arg)));
-    JsonElement json = sendMessage("evaluateExpression", params);
+    JsonElement json = sendMessage("evaluateExpression", params, NO_TIMEOUT);
     SerializedValue value = gson().fromJson(json.getAsJsonObject().get("value"), SerializedValue.class);
     return deserialize(value);
   }
@@ -64,7 +64,7 @@ public class JSHandleImpl extends ChannelOwner implements JSHandle {
     params.addProperty("expression", pageFunction);
     params.addProperty("world", "main");
     params.add("arg", gson().toJsonTree(serializeArgument(arg)));
-    JsonElement json = sendMessage("evaluateExpressionHandle", params);
+    JsonElement json = sendMessage("evaluateExpressionHandle", params, NO_TIMEOUT);
     return connection.getExistingObject(json.getAsJsonObject().getAsJsonObject("handle").get("guid").getAsString());
   }
 
@@ -84,7 +84,7 @@ public class JSHandleImpl extends ChannelOwner implements JSHandle {
   public JSHandle getProperty(String propertyName) {
     JsonObject params = new JsonObject();
     params.addProperty("name", propertyName);
-    JsonObject json = sendMessage("getProperty", params).getAsJsonObject();
+    JsonObject json = sendMessage("getProperty", params, NO_TIMEOUT).getAsJsonObject();
     return connection.getExistingObject(json.getAsJsonObject("handle").get("guid").getAsString());
   }
 

--- a/playwright/src/main/java/com/microsoft/playwright/impl/JsonPipe.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/JsonPipe.java
@@ -44,7 +44,7 @@ class JsonPipe extends ChannelOwner implements Transport {
     checkIfClosed();
     JsonObject params = new JsonObject();
     params.add("message", message);
-    sendMessage("send", params);
+    sendMessage("send", params, NO_TIMEOUT);
   }
 
   @Override

--- a/playwright/src/main/java/com/microsoft/playwright/impl/KeyboardImpl.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/KeyboardImpl.java
@@ -19,6 +19,7 @@ package com.microsoft.playwright.impl;
 import com.google.gson.JsonObject;
 import com.microsoft.playwright.Keyboard;
 
+import static com.microsoft.playwright.impl.ChannelOwner.NO_TIMEOUT;
 import static com.microsoft.playwright.impl.Serialization.gson;
 
 class KeyboardImpl implements Keyboard {
@@ -32,14 +33,14 @@ class KeyboardImpl implements Keyboard {
   public void down(String key) {
     JsonObject params = new JsonObject();
     params.addProperty("key", key);
-    page.sendMessage("keyboardDown", params);
+    page.sendMessage("keyboardDown", params, NO_TIMEOUT);
   }
 
   @Override
   public void insertText(String text) {
     JsonObject params = new JsonObject();
     params.addProperty("text", text);
-    page.sendMessage("keyboardInsertText", params);
+    page.sendMessage("keyboardInsertText", params, NO_TIMEOUT);
   }
 
   @Override
@@ -53,7 +54,7 @@ class KeyboardImpl implements Keyboard {
     }
     JsonObject params = gson().toJsonTree(options).getAsJsonObject();
     params.addProperty("key", key);
-    page.sendMessage("keyboardPress", params);
+    page.sendMessage("keyboardPress", params, NO_TIMEOUT);
   }
 
     @Override
@@ -67,13 +68,13 @@ class KeyboardImpl implements Keyboard {
     }
     JsonObject params = gson().toJsonTree(options).getAsJsonObject();
     params.addProperty("text", text);
-    page.sendMessage("keyboardType", params);
+    page.sendMessage("keyboardType", params, NO_TIMEOUT);
   }
 
   @Override
   public void up(String key) {
     JsonObject params = new JsonObject();
     params.addProperty("key", key);
-    page.sendMessage("keyboardUp", params);
+    page.sendMessage("keyboardUp", params, NO_TIMEOUT);
   }
 }

--- a/playwright/src/main/java/com/microsoft/playwright/impl/LocalUtils.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/LocalUtils.java
@@ -41,13 +41,13 @@ public class LocalUtils extends ChannelOwner {
     params.addProperty("mode", appendMode ? "append" : "write");
     params.addProperty("stacksId", stacksId);
     params.addProperty("includeSources", includeSources);
-    sendMessage("zip", params);
+    sendMessage("zip", params, NO_TIMEOUT);
   }
 
   void traceDiscarded(String stacksId) {
     JsonObject params = new JsonObject();
     params.addProperty("stacksId", stacksId);
-    sendMessage("traceDiscarded", params);
+    sendMessage("traceDiscarded", params, NO_TIMEOUT);
   }
 
   String tracingStarted(String tracesDir, String traceName) {
@@ -56,7 +56,7 @@ public class LocalUtils extends ChannelOwner {
       params.addProperty("tracesDir", "");
     }
     params.addProperty("traceName", traceName);
-    JsonObject json = connection.localUtils().sendMessage("tracingStarted", params).getAsJsonObject();
+    JsonObject json = connection.localUtils().sendMessage("tracingStarted", params, NO_TIMEOUT).getAsJsonObject();
     return json.get("stacksId").getAsString();
   }
 
@@ -67,7 +67,7 @@ public class LocalUtils extends ChannelOwner {
       params.addProperty("baseURL", baseURL);
     }
     params.addProperty("webSocketUrl", webSocketUrl);
-    JsonObject json = connection.localUtils().sendMessage("globToRegex", params).getAsJsonObject();
+    JsonObject json = connection.localUtils().sendMessage("globToRegex", params, NO_TIMEOUT).getAsJsonObject();
     String regex = json.get("regex").getAsString();
     return Pattern.compile(regex);
   }

--- a/playwright/src/main/java/com/microsoft/playwright/impl/LocatorImpl.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/LocatorImpl.java
@@ -121,10 +121,9 @@ class LocatorImpl implements Locator {
     if (options == null) {
       options = new AriaSnapshotOptions();
     }
-    options.timeout = frame.timeout(options.timeout);
     JsonObject params = gson().toJsonTree(options).getAsJsonObject();
     params.addProperty("selector", selector);
-    JsonObject result = frame.sendMessage("ariaSnapshot", params).getAsJsonObject();
+    JsonObject result = frame.sendMessage("ariaSnapshot", params, frame.timeout(options.timeout)).getAsJsonObject();
     return result.get("snapshot").getAsString();
   }
 
@@ -133,11 +132,10 @@ class LocatorImpl implements Locator {
     if (options == null) {
       options = new BlurOptions();
     }
-    options.timeout = frame.timeout(options.timeout);
     JsonObject params = gson().toJsonTree(options).getAsJsonObject();
     params.addProperty("selector", selector);
     params.addProperty("strict", true);
-    frame.sendMessage("blur", params);
+    frame.sendMessage("blur", params, frame.timeout(options.timeout));
   }
 
   @Override
@@ -661,7 +659,7 @@ class LocatorImpl implements Locator {
     JsonObject params = gson().toJsonTree(options).getAsJsonObject();
     params.addProperty("selector", selector);
     params.addProperty("expression", expression);
-    JsonElement json = frame.sendMessage("expect", params);
+    JsonElement json = frame.sendMessage("expect", params, options.timeout);
     FrameExpectResult result = gson().fromJson(json, FrameExpectResult.class);
     return result;
   }

--- a/playwright/src/main/java/com/microsoft/playwright/impl/MouseImpl.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/MouseImpl.java
@@ -19,6 +19,7 @@ package com.microsoft.playwright.impl;
 import com.google.gson.JsonObject;
 import com.microsoft.playwright.Mouse;
 
+import static com.microsoft.playwright.impl.ChannelOwner.NO_TIMEOUT;
 import static com.microsoft.playwright.impl.Serialization.gson;
 import static com.microsoft.playwright.impl.Utils.convertType;
 
@@ -37,7 +38,7 @@ class MouseImpl implements Mouse {
     JsonObject params = gson().toJsonTree(options).getAsJsonObject();
     params.addProperty("x", x);
     params.addProperty("y", y);
-    page.sendMessage("mouseClick", params);
+    page.sendMessage("mouseClick", params, NO_TIMEOUT);
   }
 
   @Override
@@ -62,7 +63,7 @@ class MouseImpl implements Mouse {
       options = new DownOptions();
     }
     JsonObject params = gson().toJsonTree(options).getAsJsonObject();
-    page.sendMessage("mouseDown", params);
+    page.sendMessage("mouseDown", params, NO_TIMEOUT);
   }
 
   @Override
@@ -73,7 +74,7 @@ class MouseImpl implements Mouse {
     JsonObject params = gson().toJsonTree(options).getAsJsonObject();
     params.addProperty("x", x);
     params.addProperty("y", y);
-    page.sendMessage("mouseMove", params);
+    page.sendMessage("mouseMove", params, NO_TIMEOUT);
   }
 
   @Override
@@ -82,7 +83,7 @@ class MouseImpl implements Mouse {
       options = new UpOptions();
     }
     JsonObject params = gson().toJsonTree(options).getAsJsonObject();
-    page.sendMessage("mouseUp", params);
+    page.sendMessage("mouseUp", params, NO_TIMEOUT);
   }
 
   @Override
@@ -90,6 +91,6 @@ class MouseImpl implements Mouse {
     JsonObject params = new JsonObject();
     params.addProperty("deltaX", deltaX);
     params.addProperty("deltaY", deltaY);
-    page.sendMessage("mouseWheel", params);
+    page.sendMessage("mouseWheel", params, NO_TIMEOUT);
   }
 }

--- a/playwright/src/main/java/com/microsoft/playwright/impl/PageImpl.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/PageImpl.java
@@ -546,7 +546,7 @@ public class PageImpl extends ChannelOwner implements Page {
         ownedContext.close();
       } else {
         JsonObject params = gson().toJsonTree(options).getAsJsonObject();
-        sendMessage("close", params);
+        sendMessage("close", params, NO_TIMEOUT);
       }
     } catch (PlaywrightException exception) {
       if (isSafeCloseError(exception) && (options.runBeforeUnload == null || !options.runBeforeUnload)) {
@@ -586,7 +586,7 @@ public class PageImpl extends ChannelOwner implements Page {
       params.addProperty("noWaitAfter", true);
     }
     params.addProperty("selector", locatorImpl.selector);
-    JsonObject json = (JsonObject) sendMessage("registerLocatorHandler", params);
+    JsonObject json = (JsonObject) sendMessage("registerLocatorHandler", params, NO_TIMEOUT);
     int uid = json.get("uid").getAsInt();
     locatorHandlers.put(uid, new LocatorHandler(locator, handler, finalOptions.times));
   }
@@ -599,7 +599,7 @@ public class PageImpl extends ChannelOwner implements Page {
         JsonObject params = new JsonObject();
         params.addProperty("uid", entry.getKey());
         try {
-          sendMessage("unregisterLocatorHandler", params);
+          sendMessage("unregisterLocatorHandler", params, NO_TIMEOUT);
         } catch (PlaywrightException e) {
         }
       }
@@ -652,7 +652,7 @@ public class PageImpl extends ChannelOwner implements Page {
   private void addInitScriptImpl(String script) {
     JsonObject params = new JsonObject();
     params.addProperty("source", script);
-    sendMessage("addInitScript", params);
+    sendMessage("addInitScript", params, NO_TIMEOUT);
   }
 
   @Override
@@ -710,7 +710,7 @@ public class PageImpl extends ChannelOwner implements Page {
       options = new EmulateMediaOptions();
     }
     JsonObject params = gson().toJsonTree(options).getAsJsonObject();
-    sendMessage("emulateMedia", params);
+    sendMessage("emulateMedia", params, NO_TIMEOUT);
   }
 
   @Override
@@ -742,7 +742,7 @@ public class PageImpl extends ChannelOwner implements Page {
     if (options != null && options.handle != null && options.handle) {
       params.addProperty("needsHandle", true);
     }
-    sendMessage("exposeBinding", params);
+    sendMessage("exposeBinding", params, NO_TIMEOUT);
   }
 
   @Override
@@ -883,9 +883,8 @@ public class PageImpl extends ChannelOwner implements Page {
     if (options == null) {
       options = new GoBackOptions();
     }
-    options.timeout = timeoutSettings.navigationTimeout(options.timeout);
     JsonObject params = gson().toJsonTree(options).getAsJsonObject();
-    JsonObject json = sendMessage("goBack", params).getAsJsonObject();
+    JsonObject json = sendMessage("goBack", params, timeoutSettings.navigationTimeout(options.timeout)).getAsJsonObject();
     if (json.has("response")) {
       return connection.getExistingObject(json.getAsJsonObject("response").get("guid").getAsString());
     }
@@ -901,9 +900,8 @@ public class PageImpl extends ChannelOwner implements Page {
     if (options == null) {
       options = new GoForwardOptions();
     }
-    options.timeout = timeoutSettings.navigationTimeout(options.timeout);
     JsonObject params = gson().toJsonTree(options).getAsJsonObject();
-    JsonObject json = sendMessage("goForward", params).getAsJsonObject();
+    JsonObject json = sendMessage("goForward", params, timeoutSettings.navigationTimeout(options.timeout)).getAsJsonObject();
     if (json.has("response")) {
       return connection.getExistingObject(json.getAsJsonObject("response").get("guid").getAsString());
     }
@@ -1033,7 +1031,7 @@ public class PageImpl extends ChannelOwner implements Page {
     }
     JsonObject params = gson().toJsonTree(options).getAsJsonObject();
     params.remove("path");
-    JsonObject json = sendMessage("pdf", params).getAsJsonObject();
+    JsonObject json = sendMessage("pdf", params, NO_TIMEOUT).getAsJsonObject();
     byte[] buffer = Base64.getDecoder().decode(json.get("pdf").getAsString());
     if (options.path != null) {
       Utils.writeToFile(buffer, options.path);
@@ -1060,9 +1058,8 @@ public class PageImpl extends ChannelOwner implements Page {
     if (options == null) {
       options = new ReloadOptions();
     }
-    options.timeout = timeoutSettings.navigationTimeout(options.timeout);
     JsonObject params = gson().toJsonTree(options).getAsJsonObject();
-    JsonObject json = sendMessage("reload", params).getAsJsonObject();
+    JsonObject json = sendMessage("reload", params, timeoutSettings.navigationTimeout(options.timeout)).getAsJsonObject();
     if (json.has("response")) {
       return connection.getExistingObject(json.getAsJsonObject("response").get("guid").getAsString());
     }
@@ -1156,7 +1153,6 @@ public class PageImpl extends ChannelOwner implements Page {
     if (options == null) {
       options = new ScreenshotOptions();
     }
-    options.timeout = timeoutSettings.timeout(options.timeout);
     if (options.type == null) {
       options.type = PNG;
       if (options.path != null) {
@@ -1182,7 +1178,7 @@ public class PageImpl extends ChannelOwner implements Page {
       }
       params.add("mask", maskArray);
     }
-    JsonObject json = sendMessage("screenshot", params).getAsJsonObject();
+    JsonObject json = sendMessage("screenshot", params, timeoutSettings.timeout(options.timeout)).getAsJsonObject();
 
     byte[] buffer = Base64.getDecoder().decode(json.get("binary").getAsString());
     if (options.path != null) {
@@ -1232,7 +1228,7 @@ public class PageImpl extends ChannelOwner implements Page {
       jsonHeaders.add(header);
     }
     params.add("headers", jsonHeaders);
-    sendMessage("setExtraHTTPHeaders", params);
+    sendMessage("setExtraHTTPHeaders", params, NO_TIMEOUT);
   }
 
   @Override
@@ -1260,7 +1256,7 @@ public class PageImpl extends ChannelOwner implements Page {
     viewport = new ViewportSize(width, height);
     JsonObject params = new JsonObject();
     params.add("viewportSize", gson().toJsonTree(viewport));
-    sendMessage("setViewportSize", params);
+    sendMessage("setViewportSize", params, NO_TIMEOUT);
   }
 
   @Override
@@ -1320,11 +1316,11 @@ public class PageImpl extends ChannelOwner implements Page {
   }
 
   private void updateInterceptionPatterns() {
-    sendMessage("setNetworkInterceptionPatterns", routes.interceptionPatterns());
+    sendMessage("setNetworkInterceptionPatterns", routes.interceptionPatterns(), NO_TIMEOUT);
   }
 
   private void updateWebSocketInterceptionPatterns() {
-    sendMessage("setWebSocketInterceptionPatterns", webSocketRoutes.interceptionPatterns());
+    sendMessage("setWebSocketInterceptionPatterns", webSocketRoutes.interceptionPatterns(), NO_TIMEOUT);
   }
 
   @Override

--- a/playwright/src/main/java/com/microsoft/playwright/impl/SelectorsImpl.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/SelectorsImpl.java
@@ -26,6 +26,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 
+import static com.microsoft.playwright.impl.ChannelOwner.NO_TIMEOUT;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 public class SelectorsImpl extends LoggingSupport implements Selectors {
@@ -45,7 +46,7 @@ public class SelectorsImpl extends LoggingSupport implements Selectors {
         JsonObject params = new JsonObject();
         params.addProperty("testIdAttributeName", attributeName);
         context.sendMessageAsync("setTestIdAttributeName", params);
-      } catch (PlaywrightException e) {  
+      } catch (PlaywrightException e) {
       }
     }
   }
@@ -76,7 +77,7 @@ public class SelectorsImpl extends LoggingSupport implements Selectors {
     for (BrowserContextImpl context : contextsForSelectors) {
       JsonObject params = new JsonObject();
       params.add("selectorEngine", engine);
-      context.sendMessage("registerSelectorEngine", params);
+      context.sendMessage("registerSelectorEngine", params, NO_TIMEOUT);
     }
     selectorEngines.add(engine);
   }

--- a/playwright/src/main/java/com/microsoft/playwright/impl/Stream.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/Stream.java
@@ -50,7 +50,7 @@ public class Stream extends ChannelOwner {
       }
       JsonObject params = new JsonObject();
       params.addProperty("size", len);
-      JsonObject json = sendMessage("read", params).getAsJsonObject();
+      JsonObject json = sendMessage("read", params, NO_TIMEOUT).getAsJsonObject();
       String encoded = json.get("binary").getAsString();
       if (encoded.isEmpty()) {
         return -1;

--- a/playwright/src/main/java/com/microsoft/playwright/impl/TouchscreenImpl.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/TouchscreenImpl.java
@@ -19,6 +19,8 @@ package com.microsoft.playwright.impl;
 import com.google.gson.JsonObject;
 import com.microsoft.playwright.Touchscreen;
 
+import static com.microsoft.playwright.impl.ChannelOwner.NO_TIMEOUT;
+
 class TouchscreenImpl implements Touchscreen {
   private final PageImpl page;
 
@@ -31,6 +33,6 @@ class TouchscreenImpl implements Touchscreen {
     JsonObject params = new JsonObject();
     params.addProperty("x", x);
     params.addProperty("y", y);
-    page.sendMessage("touchscreenTap", params);
+    page.sendMessage("touchscreenTap", params, NO_TIMEOUT);
   }
 }

--- a/playwright/src/main/java/com/microsoft/playwright/impl/TracingImpl.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/TracingImpl.java
@@ -45,7 +45,7 @@ class TracingImpl extends ChannelOwner implements Tracing {
     // Not interested in artifacts.
     if (path == null) {
       params.addProperty("mode", "discard");
-      sendMessage("tracingStopChunk", params);
+      sendMessage("tracingStopChunk", params, NO_TIMEOUT);
       if (stacksId != null) {
         connection.localUtils().traceDiscarded(stacksId);
       }
@@ -55,14 +55,14 @@ class TracingImpl extends ChannelOwner implements Tracing {
     boolean isLocal = !connection.isRemote;
     if (isLocal) {
       params.addProperty("mode", "entries");
-      JsonObject json = sendMessage("tracingStopChunk", params).getAsJsonObject();
+      JsonObject json = sendMessage("tracingStopChunk", params, NO_TIMEOUT).getAsJsonObject();
       JsonArray entries = json.getAsJsonArray("entries");
       connection.localUtils.zip(path, entries, stacksId, false, includeSources);
       return;
     }
 
     params.addProperty("mode", "archive");
-    JsonObject json = sendMessage("tracingStopChunk", params).getAsJsonObject();
+    JsonObject json = sendMessage("tracingStopChunk", params, NO_TIMEOUT).getAsJsonObject();
     // The artifact may be missing if the browser closed while stopping tracing.
     if (!json.has("artifact")) {
       if (stacksId != null) {
@@ -96,7 +96,7 @@ class TracingImpl extends ChannelOwner implements Tracing {
     }
     JsonObject params = gson().toJsonTree(options).getAsJsonObject();
     params.addProperty("name", name);
-    sendMessage("tracingGroup", params);
+    sendMessage("tracingGroup", params, NO_TIMEOUT);
   }
 
   @Override
@@ -112,7 +112,7 @@ class TracingImpl extends ChannelOwner implements Tracing {
     if (title != null) {
       params.addProperty("title", title);
     }
-    JsonObject result = sendMessage("tracingStartChunk", params).getAsJsonObject();
+    JsonObject result = sendMessage("tracingStartChunk", params, NO_TIMEOUT).getAsJsonObject();
     startCollectingStacks(result.get("traceName").getAsString());
   }
 
@@ -134,7 +134,7 @@ class TracingImpl extends ChannelOwner implements Tracing {
     if (includeSources) {
       params.addProperty("sources", true);
     }
-    sendMessage("tracingStart", params);
+    sendMessage("tracingStart", params, NO_TIMEOUT);
     tracingStartChunk(options.name, options.title);
   }
 

--- a/playwright/src/main/java/com/microsoft/playwright/impl/Utils.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/Utils.java
@@ -35,6 +35,7 @@ import java.util.*;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import static com.microsoft.playwright.impl.ChannelOwner.NO_TIMEOUT;
 import static com.microsoft.playwright.impl.Serialization.toJsonArray;
 import static java.nio.file.Files.readAllBytes;
 
@@ -200,7 +201,7 @@ public class Utils {
       items.add(item);
     }
     tempFilesParams.add("items", items);
-    return context.sendMessage("createTempFiles", tempFilesParams).getAsJsonObject();
+    return context.sendMessage("createTempFiles", tempFilesParams, NO_TIMEOUT).getAsJsonObject();
   }
 
   static void checkFilePayloadSize(FilePayload[] files) {

--- a/playwright/src/main/java/com/microsoft/playwright/impl/WorkerImpl.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/WorkerImpl.java
@@ -74,7 +74,7 @@ class WorkerImpl extends ChannelOwner implements Worker {
     JsonObject params = new JsonObject();
     params.addProperty("expression", pageFunction);
     params.add("arg", gson().toJsonTree(serializeArgument(arg)));
-    JsonElement json = sendMessage("evaluateExpression", params);
+    JsonElement json = sendMessage("evaluateExpression", params, NO_TIMEOUT);
     SerializedValue value = gson().fromJson(json.getAsJsonObject().get("value"), SerializedValue.class);
     return deserialize(value);
   }
@@ -84,7 +84,7 @@ class WorkerImpl extends ChannelOwner implements Worker {
     JsonObject params = new JsonObject();
     params.addProperty("expression", pageFunction);
     params.add("arg", gson().toJsonTree(serializeArgument(arg)));
-    JsonElement json = sendMessage("evaluateExpressionHandle", params);
+    JsonElement json = sendMessage("evaluateExpressionHandle", params, NO_TIMEOUT);
     return connection.getExistingObject(json.getAsJsonObject().getAsJsonObject("handle").get("guid").getAsString());
   }
 

--- a/playwright/src/main/java/com/microsoft/playwright/impl/WritableStream.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/WritableStream.java
@@ -42,7 +42,7 @@ class WritableStream extends ChannelOwner {
         ByteBuffer buffer = ByteBuffer.wrap(b, off, len);
         ByteBuffer encoded = Base64.getEncoder().encode(buffer);
         params.addProperty("binary", new String(encoded.array(), StandardCharsets.UTF_8));
-        sendMessage("write", params);
+        sendMessage("write", params, NO_TIMEOUT);
       }
 
       @Override


### PR DESCRIPTION
Either `NO_TIMEOUT` or computed timeout must be provided for each call to `sendMessage(method, params, timeout)`, so that we can leverage compiler support.