### PR TITLE
devops: fix release branch name check

### DIFF
--- a/.azure-pipelines/publish.yml
+++ b/.azure-pipelines/publish.yml
@@ -37,7 +37,7 @@ extends:
             artifact: esrp-build
         steps:
         - bash: |
-            if [[ ! "$CURRENT_BRANCH" =~ ^v1\\..* ]]; then
+            if [[ ! "$CURRENT_BRANCH" =~ ^v1\..* ]]; then
               echo "Can only publish from a release tag branch (v1.*)."
               echo "Unexpected branch name: $CURRENT_BRANCH"
               exit 1


### PR DESCRIPTION
Bash doesn't support [[ ... =~ ... ]] with double backslashes for escaping . in regex the same way Zsh does.
- `\.` is sufficient in Bash (not `\\.`).
- The double backslash `\\.` is interpreted literally as `\.` in the regex, which doesn’t behave as intended in Bash.

Fixes the following error:

```
Starting: Check the branch is a release branch
==============================================================================
Task         : Bash
Description  : Run a Bash script on macOS, Linux, or Windows
Version      : 3.250.1
Author       : Microsoft Corporation
Help         : https://docs.microsoft.com/azure/devops/pipelines/tasks/utility/bash
==============================================================================
Generating script.
========================== Starting Command Output ===========================
/usr/bin/bash /mnt/vss/_work/_temp/95dbd6e7-36d9-4830-a31d-e46e74274323.sh
Can only publish from a release tag branch (v1.*).
Unexpected branch name: v1.53.0

##[error]Bash exited with code '1'.
Finishing: Check the branch is a release branch

```