### PR TITLE
fix: Fix masking in single element screenshots.

### DIFF
--- a/playwright/src/main/java/com/microsoft/playwright/impl/PageImpl.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/PageImpl.java
@@ -1166,18 +1166,8 @@ public class PageImpl extends ChannelOwner implements Page {
         }
       }
     }
-    List<Locator> mask = options.mask;
-    options.mask = null;
     JsonObject params = gson().toJsonTree(options).getAsJsonObject();
-    options.mask = mask;
     params.remove("path");
-    if (mask != null) {
-      JsonArray maskArray = new JsonArray();
-      for (Locator locator: mask) {
-        maskArray.add(((LocatorImpl) locator).toProtocol());
-      }
-      params.add("mask", maskArray);
-    }
     JsonObject json = sendMessage("screenshot", params, timeoutSettings.timeout(options.timeout)).getAsJsonObject();
 
     byte[] buffer = Base64.getDecoder().decode(json.get("binary").getAsString());

--- a/playwright/src/main/java/com/microsoft/playwright/impl/Serialization.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/Serialization.java
@@ -66,6 +66,7 @@ class Serialization {
     .registerTypeHierarchyAdapter(JSHandleImpl.class, new HandleSerializer())
     .registerTypeAdapter((new TypeToken<Map<String, String>>(){}).getType(), new StringMapSerializer())
     .registerTypeAdapter((new TypeToken<Map<String, Object>>(){}).getType(), new FirefoxUserPrefsSerializer())
+    .registerTypeAdapter(LocatorImpl.class, new LocatorImplSerializer())
     .registerTypeHierarchyAdapter(Path.class, new PathSerializer()).create();
 
   static Gson gson() {
@@ -487,6 +488,13 @@ class Serialization {
     @Override
     public JsonElement serialize(E src, Type typeOfSrc, JsonSerializationContext context) {
       return new JsonPrimitive(src.toString().toLowerCase());
+    }
+  }
+
+  private static class LocatorImplSerializer implements JsonSerializer<LocatorImpl> {
+    @Override
+    public JsonElement serialize(LocatorImpl src, Type typeOfSrc, JsonSerializationContext context) {
+      return src.toProtocol();
     }
   }
 

--- a/playwright/src/test/java/com/microsoft/playwright/TestPageScreenshot.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestPageScreenshot.java
@@ -136,13 +136,24 @@ public class TestPageScreenshot extends TestBase {
   }
 
   @Test
-  void maskShouldWork() {
+  void maskShouldWorkForPage() {
     page.setViewportSize(500, 500);
     page.navigate(server.PREFIX + "/grid.html");
     byte[] screenshot = page.screenshot(new Page.ScreenshotOptions()
       .setMask(asList(page.locator("div").nth(5))));
     // TODO: toMatchSnapshot is not present in java, so we only checks that masked screenshot is different.
     byte[] originalScreenshot = page.screenshot();
+    assertThrows(AssertionFailedError.class, () -> assertArrayEquals(screenshot, originalScreenshot));
+  }
+
+  @Test
+  void maskShouldWorkForLocator() {
+    page.navigate(server.PREFIX + "/grid.html");
+    Locator locatorToScreenshot = page.locator("div").first();
+    byte[] screenshot = locatorToScreenshot.screenshot(new Locator.ScreenshotOptions()
+      .setMask(asList(page.locator("img"))));
+    // TODO: toMatchSnapshot is not present in java, so we only checks that masked screenshot is different.
+    byte[] originalScreenshot = locatorToScreenshot.screenshot();
     assertThrows(AssertionFailedError.class, () -> assertArrayEquals(screenshot, originalScreenshot));
   }
 


### PR DESCRIPTION
Using masks in single element screenshots (`Locator.screenshot()`) never worked, because the mask option failed to be serialized.

When a mask is provided as an option, serialize it manually. This is the same implementation as in `PageImpl.screenshot()`.

Fixes #1790