### PR TITLE
chore: fix Maven test commands

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,9 +32,9 @@ scripts/download_driver.sh
 mvn compile
 mvn test
 # Executing a single test
-BROWSER=chromium mvn test --projects=playwright -Dtest=TestPageNetworkSizes#shouldHaveTheCorrectResponseBodySize
+BROWSER=chromium mvn test -Dtest=TestPageNetworkSizes#shouldHaveTheCorrectResponseBodySize
 # Executing a single test class
-BROWSER=chromium mvn test --projects=playwright -Dtest=TestPageNetworkSizes
+BROWSER=chromium mvn test -Dtest=TestPageNetworkSizes
 ```
 
 ### Generating API

--- a/pom.xml
+++ b/pom.xml
@@ -170,6 +170,7 @@
                 junit.jupiter.execution.parallel.config.dynamic.factor=0.5
               </configurationParameters>
             </properties>
+            <failIfNoSpecifiedTests>false</failIfNoSpecifiedTests>
             <failIfNoTests>false</failIfNoTests>
             <rerunFailingTestsCount>${env.PW_MAX_RETRIES}</rerunFailingTestsCount>
             <!-- Activate the use of TCP to transmit events to the plugin and avoid


### PR DESCRIPTION
Previously they were filtering by project `playwright` which e.g. not included rebuilding the driver. This reverts what was added in https://github.com/microsoft/playwright-java/pull/1484 and adds the ignore flag.