### PR TITLE
devops: enable retries in Docker tests

### DIFF
--- a/.github/workflows/test_docker.yml
+++ b/.github/workflows/test_docker.yml
@@ -21,6 +21,8 @@ jobs:
     name: Test
     timeout-minutes: 120
     runs-on: ${{ matrix.runs-on }}
+    env:
+      PW_MAX_RETRIES: 3
     strategy:
       fail-fast: false
       matrix:
@@ -34,7 +36,7 @@ jobs:
           bash utils/docker/build.sh --$ARCH ${{ matrix.flavor }} playwright-java:localbuild-${{ matrix.flavor }}
       - name: Start container
         run: |
-            CONTAINER_ID=$(docker run --rm -e CI --ipc=host -v "$(pwd)":/root/playwright --name playwright-docker-test -d -t playwright-java:localbuild-${{ matrix.flavor }} /bin/bash)
+            CONTAINER_ID=$(docker run --rm -e CI -e PW_MAX_RETRIES --ipc=host -v "$(pwd)":/root/playwright --name playwright-docker-test -d -t playwright-java:localbuild-${{ matrix.flavor }} /bin/bash)
             echo "CONTAINER_ID=$CONTAINER_ID" >> $GITHUB_ENV
 
       - name: Run test in container

--- a/tools/test-local-installation/pom.xml
+++ b/tools/test-local-installation/pom.xml
@@ -64,7 +64,15 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.2.5</version>
+        <version>3.5.3</version>
+        <configuration>
+          <failIfNoSpecifiedTests>false</failIfNoSpecifiedTests>
+          <failIfNoTests>false</failIfNoTests>
+          <rerunFailingTestsCount>${env.PW_MAX_RETRIES}</rerunFailingTestsCount>
+          <!-- Activate the use of TCP to transmit events to the plugin and avoid
+          [WARNING] Corrupted STDOUT by directly writing to native stream in forked JVM -->
+          <forkNode implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory"/>
+        </configuration>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
Enabled retries required us to add the env var and mirror the configuration from the root `pom.xml` into the `tools/test-local-installation/pom.xml`.