### PR TITLE
feat(api): add launchOptions support to ConnectOptions

### DIFF
--- a/playwright/src/main/java/com/microsoft/playwright/BrowserType.java
+++ b/playwright/src/main/java/com/microsoft/playwright/BrowserType.java
@@ -68,6 +68,23 @@ public interface BrowserType {
      */
     public Map<String, String> headers;
     /**
+     * Launch options to be passed to the browser being connected to. These options will be automatically
+     * serialized and sent via the {@code x-playwright-launch-options} header.
+     *
+     * <p> This is particularly useful when connecting to a browser with specific requirements, such as using
+     * a specific browser channel (e.g., "msedge" for Microsoft Edge).
+     *
+     * <p> Example:
+     * <pre>{@code
+     * BrowserType.LaunchOptions launchOptions = new BrowserType.LaunchOptions()
+     *   .setChannel("msedge");
+     * BrowserType.ConnectOptions connectOptions = new BrowserType.ConnectOptions()
+     *   .setLaunchOptions(launchOptions);
+     * Browser browser = browserType.connect(wsEndpoint, connectOptions);
+     * }</pre>
+     */
+    public LaunchOptions launchOptions;
+    /**
      * Slows down Playwright operations by the specified amount of milliseconds. Useful so that you can see what is going on.
      * Defaults to 0.
      */
@@ -105,6 +122,26 @@ public interface BrowserType {
      */
     public ConnectOptions setHeaders(Map<String, String> headers) {
       this.headers = headers;
+      return this;
+    }
+    /**
+     * Launch options to be passed to the browser being connected to. These options will be automatically
+     * serialized and sent via the {@code x-playwright-launch-options} header.
+     *
+     * <p> This is particularly useful when connecting to a browser with specific requirements, such as using
+     * a specific browser channel (e.g., "msedge" for Microsoft Edge).
+     *
+     * <p> Example:
+     * <pre>{@code
+     * BrowserType.LaunchOptions launchOptions = new BrowserType.LaunchOptions()
+     *   .setChannel("msedge");
+     * BrowserType.ConnectOptions connectOptions = new BrowserType.ConnectOptions()
+     *   .setLaunchOptions(launchOptions);
+     * Browser browser = browserType.connect(wsEndpoint, connectOptions);
+     * }</pre>
+     */
+    public ConnectOptions setLaunchOptions(LaunchOptions launchOptions) {
+      this.launchOptions = launchOptions;
       return this;
     }
     /**

--- a/playwright/src/main/java/com/microsoft/playwright/impl/BrowserTypeImpl.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/BrowserTypeImpl.java
@@ -76,6 +76,11 @@ class BrowserTypeImpl extends ChannelOwner implements BrowserType {
       headers.addProperty("x-playwright-browser", name());
     }
 
+    if (options.launchOptions != null && !headers.has("x-playwright-launch-options")) {
+      String launchOptionsJson = new Gson().toJsonTree(options.launchOptions).toString();
+      headers.addProperty("x-playwright-launch-options", launchOptionsJson);
+    }
+
     Double timeout = options.timeout;
     if (timeout == null) {
       timeout = 0.0;

--- a/playwright/src/test/java/com/microsoft/playwright/TestBrowserTypeConnect.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestBrowserTypeConnect.java
@@ -175,6 +175,22 @@ public class TestBrowserTypeConnect extends TestBase {
   }
 
   @Test
+  void shouldSendLaunchOptionsViaConnectOptions() throws Exception {
+    try (WebSocketServerImpl webSocketServer = WebSocketServerImpl.create()) {
+      try {
+        browserType.connect("ws://localhost:" + webSocketServer.getPort() + "/ws",
+          new BrowserType.ConnectOptions().setLaunchOptions(
+            new BrowserType.LaunchOptions().setChannel("msedge")));
+      } catch (Exception e) {
+      }
+      assertNotNull(webSocketServer.lastClientHandshake);
+      String headerValue = webSocketServer.lastClientHandshake.getFieldValue("x-playwright-launch-options");
+      assertNotNull(headerValue);
+      assertTrue(headerValue.contains("\"channel\":\"msedge\""));
+    }
+  }
+
+  @Test
   void disconnectedEventShouldBeEmittedWhenBrowserIsClosedOrServerIsClosed() throws InterruptedException {
     // Launch another server to not affect other tests.
     BrowserServer remote = launchBrowserServer(browserType);


### PR DESCRIPTION
Add ability to pass LaunchOptions directly via ConnectOptions instead of manually constructing JSON headers. 

The implementation automatically serializes launchOptions to the x-playwright-launch-options header when provided.

Motivation / Use case

When running the browser inside a container and connecting remotely (see [Playwright docs: Remote connection with Docker](https://playwright.dev/docs/docker#remote-connection)), it’s currently cumbersome to specify the browser channel.

current:
`connectOptions.headers.put("x-playwright-launch-options", "{\"channel\":\"msedge\"}");` 
which you have to discover first

Proposed API (Java)

```
browserType.connect("ws://localhost:3000/ws",
          new BrowserType.ConnectOptions().setLaunchOptions(
            new BrowserType.LaunchOptions().setChannel("msedge")));
```