### PR TITLE
chore(deps): bump junit.version from 5.13.4 to 5.14.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
     <maven.compiler.target>8</maven.compiler.target>
     <maven.compiler.parameters>true</maven.compiler.parameters>
     <gson.version>2.13.2</gson.version>
-    <junit.version>5.14.0</junit.version>
+    <junit.version>5.14.1</junit.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <websocket.version>1.6.0</websocket.version>
     <slf4j.version>2.0.17</slf4j.version>


### PR DESCRIPTION
Bumps junit.version from 5.13.4 to 5.14.1.

- replaces #1863

https://docs.junit.org/5.14.1/release-notes/

<details>
5.14.1
Date of Release: October 31, 2025

Scope: Bug fixes and enhancements since 5.14.0

For a complete list of all closed issues and pull requests for this release, consult the [5.14.1](https://github.com/junit-team/junit-framework/milestone/111?closed=1) milestone page in the JUnit repository on GitHub.

JUnit Platform
No changes.

JUnit Jupiter
Bug Fixes
Fix support for test methods with the same signature as a package-private methods declared in super classes in different packages.

New Features and Improvements
Improve error message when using @ParameterizedClass with field injection and not providing enough arguments.

JUnit Vintage
No changes.

Deprecations and Breaking Changes
Deprecate OutputDirectoryProvider interface in favor of the new OutputDirectoryCreator interface to resolve a cyclic package dependency along with the following APIs (which all have replacements working with OutputDirectoryCreator):

EngineDiscoveryRequest.getOutputDirectoryProvider()

ExecutionRequest.getOutputDirectoryProvider()

LauncherDiscoveryRequestBuilder.outputDirectoryProvider(OutputDirectoryProvider)

TestPlan.getOutputDirectoryProvider()

EngineTestKit.Builder.outputDirectoryProvider(OutputDirectoryProvider)

Deprecate org.junit.platform.commons.support.Resource interface in favor of the new org.junit.platform.commons.io.Resource interface.

Deprecate Resource-related methods in ReflectionSupport in favor of corresponding methods in the new ResourceSupport class:

findAllResourcesInClasspathRoot(URI, Predicate)

findAllResourcesInModule(String, Predicate)

findAllResourcesInPackage(String, Predicate)

streamAllResourcesInClasspathRoot(URI, Predicate)

streamAllResourcesInModule(String, Predicate)

streamAllResourcesInPackage(String, Predicate)

tryToGetResources(String)

tryToGetResources(String, ClassLoader)

Deprecate DiscoverySelectors.selectClasspathResource(Set) method in favor of selectClasspathResourceByName(Set).

Deprecate ClasspathResourceSelector.getClasspathResources() method in favor of getResources().

Deprecate the EngineDiscoveryRequestResolver.Builder.addResourceContainerSelectorResolver(Predicate) method in favor of addResourceContainerSelectorResolver(ResourceFilter).

Deprecate Resource-related methods in ClasspathScanner in favor of new methods using org.junit.platform.commons.io.Resource and ResourceFilter:

scanForResourcesInPackage(String, Predicate)

scanForResourcesInClasspathRoot(URI, Predicate)

New Features and Improvements
Emit discovery warning when @SuiteDisplayName is used with a blank string.

To help diagnosing potentially invalid invocations, the Console Launcher now logs warnings for nonexistent classpath roots added via --classpath or --scan-classpath rather than silently ignoring them.

New classpath resource abstraction in org.junit.platform.commons.io.Resource with support for loading resources or finding them on the classpath via static utility methods in the new org.junit.platform.commons.support.ResourceSupport class.

New Resource.of(String, URI) static factory method for creating an org.junit.platform.commons.support.Resource.

New FileSource.withPosition(FilePosition) method to avoid the overhead of redundant canonicalization of files when using FileSource.from(File, FilePosition) with many different FilePosition instances for the same File.

New classpath resource abstraction in org.junit.platform.commons.io.Resource with support for loading resources or finding them on the classpath via static utility methods in the new org.junit.platform.commons.support.ResourceSupport class.
</details>