### PR TITLE
Migrate ExtensionContext.Store.CloseableResource to AutoCloseable

### DIFF
--- a/playwright/src/main/java/com/microsoft/playwright/impl/junit/PlaywrightExtension.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/junit/PlaywrightExtension.java
@@ -36,7 +36,7 @@ public class PlaywrightExtension implements ParameterResolver {
   // There should be at most one instance of PlaywrightRegistry per test run, it keeps
   // track of all created Playwright instances and calls `close()` on each of them after
   // the tests finished.
-  static class PlaywrightRegistry implements ExtensionContext.Store.CloseableResource {
+  static class PlaywrightRegistry implements AutoCloseable {
     private final List<Playwright> playwrightList = Collections.synchronizedList(new ArrayList<>());
 
     static synchronized PlaywrightRegistry getOrCreateFor(ExtensionContext extensionContext) {
@@ -59,7 +59,7 @@ public class PlaywrightExtension implements ParameterResolver {
     // This is a workaround for JUnit's lack of an "AfterTestRun" hook
     // This will be called once after all tests have completed.
     @Override
-    public void close() throws Throwable {
+    public void close() {
       for (Playwright playwright : playwrightList) {
         playwright.close();
       }


### PR DESCRIPTION
Migrate ExtensionContext.Store.CloseableResource to AutoCloseable
- closes #1864

### background

ExtensionContext.Store.CloseableResource is deprecated since 5.13

see:
https://docs.junit.org/5.14.0/user-guide/#extensions-keeping-state

> Resource management via AutoCloseable
An extension context store is bound to its extension context lifecycle. When an extension context lifecycle ends it closes its associated store. As of JUnit 5.13, all stored values that are instances of AutoCloseable are notified by an invocation of their close() method in the inverse order they were added in (unless the junit.jupiter.extensions.store.close.autocloseable.enabled [configuration parameter](https://docs.junit.org/5.14.0/user-guide/#running-tests-config-params) is set to false). Older versions only supported CloseableResource, which is deprecated but still available for backward compatibility.



https://docs.junit.org/5.14.0/api/org.junit.jupiter.api/org/junit/jupiter/api/extension/ExtensionContext.Store.CloseableResource.html

```
Deprecated.
Please extend AutoCloseable directly.
```