### PR TITLE
Fix document typo - setContextOptions

### DIFF
--- a/playwright/src/main/java/com/microsoft/playwright/junit/OptionsFactory.java
+++ b/playwright/src/main/java/com/microsoft/playwright/junit/OptionsFactory.java
@@ -36,7 +36,7 @@ package com.microsoft.playwright.junit;
  *     public Options getOptions() {
  *       return new Options()
  *           .setHeadless(false)
- *           .setContextOption(new Browser.NewContextOptions()
+ *           .setContextOptions(new Browser.NewContextOptions()
  *               .setBaseURL("https://github.com"))
  *           .setApiRequestOptions(new APIRequest.NewContextOptions()
  *               .setBaseURL("https://playwright.dev"));


### PR DESCRIPTION
current document is `setContextOption`

https://github.com/microsoft/playwright-java/blob/059667e3115250a9d9c6bb4b697581d5a1988e9e/playwright/src/main/java/com/microsoft/playwright/junit/OptionsFactory.java#L36-L42

but, actual is `setContextOptions`

https://github.com/microsoft/playwright-java/blob/059667e3115250a9d9c6bb4b697581d5a1988e9e/playwright/src/test/java/com/microsoft/playwright/junit/TestFixtureContextOptions.java#L35-L39