### PR TITLE
chore: use langAliases from api.json in api generator

### DIFF
--- a/playwright/src/main/java/com/microsoft/playwright/Browser.java
+++ b/playwright/src/main/java/com/microsoft/playwright/Browser.java
@@ -1448,7 +1448,7 @@ public interface Browser extends AutoCloseable {
    * @param title Title of the browser server, used for identification.
    * @since v1.59
    */
-  default Bind bind(String title) {
+  default BindResult bind(String title) {
     return bind(title, null);
   }
   /**
@@ -1457,7 +1457,7 @@ public interface Browser extends AutoCloseable {
    * @param title Title of the browser server, used for identification.
    * @since v1.59
    */
-  Bind bind(String title, BindOptions options);
+  BindResult bind(String title, BindOptions options);
   /**
    * <strong>NOTE:</strong> This API controls <a href="https://www.chromium.org/developers/how-tos/trace-event-profiling-tool">Chromium Tracing</a>
    * which is a low-level chromium-specific debugging tool. API to control <a

--- a/playwright/src/main/java/com/microsoft/playwright/Debugger.java
+++ b/playwright/src/main/java/com/microsoft/playwright/Debugger.java
@@ -39,7 +39,7 @@ public interface Debugger {
    *
    * @since v1.59
    */
-  PausedDetails pausedDetails();
+  DebuggerPausedDetails pausedDetails();
   /**
    * Configures the debugger to pause before the next action is executed.
    *

--- a/playwright/src/main/java/com/microsoft/playwright/impl/BrowserImpl.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/BrowserImpl.java
@@ -20,7 +20,7 @@ import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.microsoft.playwright.*;
-import com.microsoft.playwright.options.Bind;
+import com.microsoft.playwright.options.BindResult;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -197,7 +197,7 @@ class BrowserImpl extends ChannelOwner implements Browser {
   }
 
   @Override
-  public Bind bind(String title, BindOptions options) {
+  public BindResult bind(String title, BindOptions options) {
     JsonObject params = new JsonObject();
     params.addProperty("title", title);
     if (options != null) {
@@ -212,9 +212,9 @@ class BrowserImpl extends ChannelOwner implements Browser {
       }
     }
     JsonObject result = sendMessage("startServer", params, NO_TIMEOUT).getAsJsonObject();
-    Bind bind = new Bind();
-    bind.endpoint = result.get("endpoint").getAsString();
-    return bind;
+    BindResult bindResult = new BindResult();
+    bindResult.endpoint = result.get("endpoint").getAsString();
+    return bindResult;
   }
 
   @Override

--- a/playwright/src/main/java/com/microsoft/playwright/impl/DebuggerImpl.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/DebuggerImpl.java
@@ -19,7 +19,7 @@ package com.microsoft.playwright.impl;
 import com.google.gson.JsonObject;
 import com.microsoft.playwright.Debugger;
 import com.microsoft.playwright.options.Location;
-import com.microsoft.playwright.options.PausedDetails;
+import com.microsoft.playwright.options.DebuggerPausedDetails;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -28,7 +28,7 @@ import static com.microsoft.playwright.impl.Serialization.gson;
 
 class DebuggerImpl extends ChannelOwner implements Debugger {
   private final List<Runnable> pausedStateChangedHandlers = new ArrayList<>();
-  private PausedDetails pausedDetails;
+  private DebuggerPausedDetails pausedDetails;
 
   DebuggerImpl(ChannelOwner parent, String type, String guid, JsonObject initializer) {
     super(parent, type, guid, initializer);
@@ -38,7 +38,7 @@ class DebuggerImpl extends ChannelOwner implements Debugger {
   protected void handleEvent(String event, JsonObject params) {
     if ("pausedStateChanged".equals(event)) {
       if (params.has("pausedDetails") && !params.get("pausedDetails").isJsonNull()) {
-        pausedDetails = gson().fromJson(params.get("pausedDetails"), PausedDetails.class);
+        pausedDetails = gson().fromJson(params.get("pausedDetails"), DebuggerPausedDetails.class);
       } else {
         pausedDetails = null;
       }
@@ -59,7 +59,7 @@ class DebuggerImpl extends ChannelOwner implements Debugger {
   }
 
   @Override
-  public PausedDetails pausedDetails() {
+  public DebuggerPausedDetails pausedDetails() {
     return pausedDetails;
   }
 

--- a/playwright/src/main/java/com/microsoft/playwright/options/BindResult.java
+++ b/playwright/src/main/java/com/microsoft/playwright/options/BindResult.java
@@ -16,8 +16,7 @@
 
 package com.microsoft.playwright.options;
 
-public class PausedDetails {
-  public Location location;
-  public String title;
+public class BindResult {
+  public String endpoint;
 
 }

--- a/playwright/src/main/java/com/microsoft/playwright/options/DebuggerPausedDetails.java
+++ b/playwright/src/main/java/com/microsoft/playwright/options/DebuggerPausedDetails.java
@@ -16,7 +16,8 @@
 
 package com.microsoft.playwright.options;
 
-public class Bind {
-  public String endpoint;
+public class DebuggerPausedDetails {
+  public Location location;
+  public String title;
 
 }

--- a/playwright/src/test/java/com/microsoft/playwright/TestBrowserBind.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestBrowserBind.java
@@ -16,7 +16,7 @@
 
 package com.microsoft.playwright;
 
-import com.microsoft.playwright.options.Bind;
+import com.microsoft.playwright.options.BindResult;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -24,7 +24,7 @@ import static org.junit.jupiter.api.Assertions.*;
 public class TestBrowserBind extends TestBase {
   @Test
   void shouldBindAndUnbindBrowser() {
-    Bind serverInfo = browser.bind("default");
+    BindResult serverInfo = browser.bind("default");
     try {
       assertNotNull(serverInfo);
       assertNotNull(serverInfo.endpoint);
@@ -36,7 +36,7 @@ public class TestBrowserBind extends TestBase {
 
   @Test
   void shouldBindWithCustomTitleAndOptions() {
-    Bind serverInfo = browser.bind("my-title",
+    BindResult serverInfo = browser.bind("my-title",
       new Browser.BindOptions().setHost("127.0.0.1").setPort(0));
     try {
       assertNotNull(serverInfo);

--- a/playwright/src/test/java/com/microsoft/playwright/TestDebugger.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestDebugger.java
@@ -16,7 +16,7 @@
 
 package com.microsoft.playwright;
 
-import com.microsoft.playwright.options.PausedDetails;
+import com.microsoft.playwright.options.DebuggerPausedDetails;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -40,7 +40,7 @@ public class TestDebugger extends TestBase {
     dbg.onPausedStateChanged(() -> {
       if (!paused[0]) {
         paused[0] = true;
-        PausedDetails details = dbg.pausedDetails();
+        DebuggerPausedDetails details = dbg.pausedDetails();
         assertNotNull(details);
         assertTrue(details.title.contains("Click"), "title: " + details.title);
         dbg.resume();
@@ -63,7 +63,7 @@ public class TestDebugger extends TestBase {
     dbg.onPausedStateChanged(() -> {
       if (!paused[0]) {
         paused[0] = true;
-        PausedDetails details = dbg.pausedDetails();
+        DebuggerPausedDetails details = dbg.pausedDetails();
         assertNotNull(details);
         assertTrue(details.title.contains("Click"), "title: " + details.title);
         dbg.next();
@@ -88,7 +88,7 @@ public class TestDebugger extends TestBase {
     dbg.onPausedStateChanged(() -> {
       if (!paused[0]) {
         paused[0] = true;
-        PausedDetails details = dbg.pausedDetails();
+        DebuggerPausedDetails details = dbg.pausedDetails();
         assertNotNull(details);
         assertTrue(details.title.contains("Pause"), "title: " + details.title);
         dbg.resume();

--- a/tools/api-generator/src/main/java/com/microsoft/playwright/tools/ApiGenerator.java
+++ b/tools/api-generator/src/main/java/com/microsoft/playwright/tools/ApiGenerator.java
@@ -283,40 +283,20 @@ abstract class Element {
 class TypeRef extends Element {
   String customType;
 
-  private static final Map<String, String> customTypeNames = new HashMap<>();
-  static {
-    customTypeNames.put("APIRequest.newContext.options.clientCertificates", "ClientCertificate");
-    customTypeNames.put("Browser.newContext.options.clientCertificates", "ClientCertificate");
-    customTypeNames.put("Browser.newPage.options.clientCertificates", "ClientCertificate");
-    customTypeNames.put("BrowserType.launchPersistentContext.options.clientCertificates", "ClientCertificate");
-
-    customTypeNames.put("BrowserContext.addCookies.cookies", "Cookie");
-    customTypeNames.put("BrowserContext.cookies", "Cookie");
-
-    customTypeNames.put("Request.headersArray", "HttpHeader");
-    customTypeNames.put("Response.headersArray", "HttpHeader");
-    customTypeNames.put("APIResponse.headersArray", "HttpHeader");
-
-    customTypeNames.put("Locator.selectOption.values", "SelectOption");
-    customTypeNames.put("ElementHandle.selectOption.values", "SelectOption");
-    customTypeNames.put("Frame.selectOption.values", "SelectOption");
-    customTypeNames.put("Page.selectOption.values", "SelectOption");
-
-    customTypeNames.put("Locator.setInputFiles.files", "FilePayload");
-    customTypeNames.put("ElementHandle.setInputFiles.files", "FilePayload");
-    customTypeNames.put("FileChooser.setFiles.files", "FilePayload");
-    customTypeNames.put("Frame.setInputFiles.files", "FilePayload");
-    customTypeNames.put("Page.setInputFiles.files", "FilePayload");
-    customTypeNames.put("Page.setInputFiles.files", "FilePayload");
-    customTypeNames.put("FormData.append.value", "FilePayload");
-    customTypeNames.put("FormData.set.value", "FilePayload");
-
-    customTypeNames.put("Locator.dragTo.options.sourcePosition", "Position");
-    customTypeNames.put("Page.dragAndDrop.options.sourcePosition", "Position");
-    customTypeNames.put("Frame.dragAndDrop.options.sourcePosition", "Position");
-    customTypeNames.put("Locator.dragTo.options.targetPosition", "Position");
-    customTypeNames.put("Page.dragAndDrop.options.targetPosition", "Position");
-    customTypeNames.put("Frame.dragAndDrop.options.targetPosition", "Position");
+  // Returns the Java-specific type alias declared in the api docs (e.g. `alias-java: Cookie`),
+  // falling back to the language-agnostic `alias` if no Java-specific override is provided.
+  private static String javaAlias(JsonObject jsonType) {
+    if (!jsonType.has("langAliases")) {
+      return null;
+    }
+    JsonObject langAliases = jsonType.getAsJsonObject("langAliases");
+    if (langAliases.has("java")) {
+      return langAliases.get("java").getAsString();
+    }
+    if (langAliases.has("default")) {
+      return langAliases.get("default").getAsString();
+    }
+    return null;
   }
 
   TypeRef(Element parent, JsonElement jsonElement) {
@@ -355,8 +335,9 @@ class TypeRef extends Element {
         customType = toTitle(parent.parent.jsonName) + toTitle(parent.jsonName);
         typeScope().createNestedClass(customType, this, jsonObject);
       } else {
-        if (customTypeNames.containsKey(jsonPath)) {
-          customType = customTypeNames.get(jsonPath);
+        String alias = javaAlias(jsonObject);
+        if (alias != null) {
+          customType = alias;
         } else {
           customType = toTitle(parent.jsonName);
         }
@@ -534,15 +515,12 @@ class TypeRef extends Element {
       return convertTemplateParams(jsonType);
     }
     if ("function".equals(name)) {
+      String alias = javaAlias(jsonType);
+      if (alias != null) {
+        return alias;
+      }
       if (!jsonType.has("args")) {
-        switch (jsonPath) {
-          case "BrowserContext.exposeBinding.callback": return "BindingCallback";
-          case "BrowserContext.exposeFunction.callback": return "FunctionCallback";
-          case "Page.exposeBinding.callback": return "BindingCallback";
-          case "Page.exposeFunction.callback": return "FunctionCallback";
-          default:
-            throw new RuntimeException("Missing mapping for " + jsonPath);
-        }
+        throw new RuntimeException("Missing mapping for " + jsonPath);
       }
       if ("WebSocketRoute.onClose.handler".equals(jsonPath)) {
         return "BiConsumer<Integer, String>";


### PR DESCRIPTION
## Summary
- Read `langAliases.java` (with fallback to the language-agnostic `default`) from `api.json` in `ApiGenerator` to drive Java type names for `Object` and `function` types.
- Drop the hand-maintained `customTypeNames` map (28 entries: `ClientCertificate`, `Cookie`, `HttpHeader`, `SelectOption`, `FilePayload`, `Position`) and the hardcoded `BindingCallback`/`FunctionCallback` switch — these are all expressed as aliases in api.json now.
- Two classes are renamed because the upstream docs only declare a language-agnostic `alias:` for them: `Bind` -> `BindResult`, `PausedDetails` -> `DebuggerPausedDetails`. Impl and test references are updated accordingly.

This follows the upstream playwright change that introduced the alias bullets (microsoft/playwright#40122).
