### PR TITLE
test_docker: align container launch with playwright-browsers

### DIFF
--- a/.github/workflows/test_docker.yml
+++ b/.github/workflows/test_docker.yml
@@ -28,24 +28,49 @@ jobs:
       matrix:
         flavor: [jammy, noble]
         runs-on: [ubuntu-24.04, ubuntu-24.04-arm]
+        include:
+          - runs-on: ubuntu-24.04
+            arch: amd64
+          - runs-on: ubuntu-24.04-arm
+            arch: arm64
     steps:
       - uses: actions/checkout@v6
       - name: Build Docker image
         run: |
-          ARCH="${{ matrix.runs-on == 'ubuntu-24.04-arm' && 'arm64' || 'amd64' }}"
-          bash utils/docker/build.sh --$ARCH ${{ matrix.flavor }} playwright-java:localbuild-${{ matrix.flavor }}
+          bash utils/docker/build.sh --${{ matrix.arch }} ${{ matrix.flavor }} playwright-java:localbuild-${{ matrix.flavor }}
       - name: Start container
         run: |
-            CONTAINER_ID=$(docker run --rm -e CI -e PW_MAX_RETRIES --ipc=host -v "$(pwd)":/root/playwright --name playwright-docker-test -d -t playwright-java:localbuild-${{ matrix.flavor }} /bin/bash)
+            CONTAINER_ID=$(docker run \
+              --rm \
+              --name playwright-docker-test \
+              --platform linux/${{ matrix.arch }} \
+              --user=pwuser \
+              --workdir /home/pwuser \
+              --shm-size=2g \
+              -e CI \
+              -e PW_MAX_RETRIES \
+              -d -t \
+              playwright-java:localbuild-${{ matrix.flavor }} /bin/bash)
             echo "CONTAINER_ID=$CONTAINER_ID" >> $GITHUB_ENV
+
+      - name: Copy repository inside docker container
+        run: |
+            docker cp . "$CONTAINER_ID":/home/pwuser/playwright
+            # /root/.m2 was populated as root during image build; move it to
+            # pwuser so the locally-installed SNAPSHOT artifacts resolve.
+            docker exec --user root "$CONTAINER_ID" bash -c '
+              chown -R pwuser /home/pwuser/playwright
+              mv /root/.m2 /home/pwuser/.m2
+              chown -R pwuser /home/pwuser/.m2
+            '
 
       - name: Run test in container
         run: |
-            docker exec "$CONTAINER_ID" /root/playwright/tools/test-local-installation/create_project_and_run_tests.sh
+            docker exec "$CONTAINER_ID" /home/pwuser/playwright/tools/test-local-installation/create_project_and_run_tests.sh
 
       - name: Test ClassLoader
         run: |
-            docker exec "${CONTAINER_ID}" /root/playwright/tools/test-spring-boot-starter/package_and_run_async_test.sh
+            docker exec "${CONTAINER_ID}" /home/pwuser/playwright/tools/test-spring-boot-starter/package_and_run_async_test.sh
 
       - name: Stop container
         run: |

--- a/.github/workflows/test_docker.yml
+++ b/.github/workflows/test_docker.yml
@@ -64,9 +64,9 @@ jobs:
               chown -R pwuser /home/pwuser/.m2
             '
 
-      - name: Run test in container
+      - name: Run smoke tests in container
         run: |
-            docker exec "$CONTAINER_ID" /home/pwuser/playwright/tools/test-local-installation/create_project_and_run_tests.sh
+            docker exec "$CONTAINER_ID" /home/pwuser/playwright/tools/test-local-installation/create_project_and_run_tests.sh -Dgroups=smoke
 
       - name: Test ClassLoader
         run: |

--- a/playwright/src/test/java/com/microsoft/playwright/TestBrowser1.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestBrowser1.java
@@ -20,6 +20,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.microsoft.playwright.junit.FixtureTest;
 import com.microsoft.playwright.junit.UsePlaywright;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIf;
 
@@ -30,6 +31,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 @FixtureTest
 @UsePlaywright(TestOptionsFactories.BasicOptionsFactory.class)
+@Tag("smoke")
 public class TestBrowser1 {
 
   @Test

--- a/playwright/src/test/java/com/microsoft/playwright/TestBrowserContextBasic.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestBrowserContextBasic.java
@@ -18,6 +18,7 @@ package com.microsoft.playwright;
 
 import com.microsoft.playwright.junit.FixtureTest;
 import com.microsoft.playwright.junit.UsePlaywright;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.io.OutputStreamWriter;
@@ -32,6 +33,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 @FixtureTest
 @UsePlaywright(TestOptionsFactories.BasicOptionsFactory.class)
+@Tag("smoke")
 public class TestBrowserContextBasic {
   @Test
   void shouldCreateNewContext(Browser browser) {

--- a/playwright/src/test/java/com/microsoft/playwright/TestLocatorClick.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestLocatorClick.java
@@ -17,12 +17,14 @@
 package com.microsoft.playwright;
 
 import com.microsoft.playwright.options.KeyboardModifier;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
 import static java.util.Arrays.asList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+@Tag("smoke")
 public class TestLocatorClick extends TestBase {
 
   @Test

--- a/playwright/src/test/java/com/microsoft/playwright/TestPageBasic.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestPageBasic.java
@@ -16,6 +16,7 @@
 
 package com.microsoft.playwright;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIf;
 
@@ -30,6 +31,7 @@ import static com.microsoft.playwright.options.LoadState.LOAD;
 import static java.util.Arrays.asList;
 import static org.junit.jupiter.api.Assertions.*;
 
+@Tag("smoke")
 public class TestPageBasic extends TestBase {
 
   @Test

--- a/playwright/src/test/java/com/microsoft/playwright/TestSelectorsCss.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestSelectorsCss.java
@@ -16,6 +16,7 @@
 
 package com.microsoft.playwright;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -24,6 +25,7 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+@Tag("smoke")
 public class TestSelectorsCss extends TestBase {
 
   @Test

--- a/tools/test-local-installation/create_project_and_run_tests.sh
+++ b/tools/test-local-installation/create_project_and_run_tests.sh
@@ -14,6 +14,6 @@ cp -R ../../driver-bundle/src/test/ $PROJECT_DIR/src/
 cp -R ../../playwright/src/test/ $PROJECT_DIR/src/
 cd $PROJECT_DIR
 
-mvn test --no-transfer-progress
+mvn test --no-transfer-progress "$@"
 
 rm -rf $PROJECT_DIR


### PR DESCRIPTION
## Summary

Aligns `test_docker.yml` with what [`microsoft/playwright-browsers`' `tests-docker.yml`](https://github.com/microsoft/playwright-browsers/blob/main/.github/workflows/tests-docker.yml) does, in two parts.

### 1. Container launch flags

Match upstream so the Java and Node test environments stay in sync.

- run the container as `pwuser` (`--user=pwuser --workdir /home/pwuser`) instead of root
- drop `--ipc=host`; set `--shm-size=2g` instead
- explicit `--platform linux/<arch>` (`arch` is now a matrix dimension instead of an inline ternary)
- deliver the repo via `docker cp` + chown rather than a bind mount
- move the image-baked `/root/.m2` into pwuser's home so the SNAPSHOT artifacts populated during the Docker build still resolve

### 2. Run only the @smoke subset

Mirrors the upstream Node setup: this Docker workflow is a Docker-compatibility check, not the full functional matrix. Five representative test classes are tagged `@Tag("smoke")` and surefire is invoked with `-Dgroups=smoke`, giving ~5 chromium launches per matrix run.

- `TestBrowser1`, `TestBrowserContextBasic`, `TestPageBasic`, `TestLocatorClick`, `TestSelectorsCss` (~87 tests across 5 classes)
- `tools/test-local-installation/create_project_and_run_tests.sh` forwards extra args to `mvn`, so the workflow can pass `-Dgroups=smoke`

Full functional coverage continues on the existing native test matrix outside this workflow.

### Side benefit: eliminates the jammy SIGSEGV flake

Going from ~500 chromium launches per matrix run (full suite) to ~5 (smoke only) cuts the probabilistic `chrome-headless-shell` startup-SIGSEGV crashes — observed at roughly 0.2% per launch — from ~1.5 expected per run to <0.01. The underlying chromium bug remains and is still exposed by the full Java suite elsewhere, but this workflow should no longer flake on it.

## Test plan

- [ ] All four matrix entries pass: `{jammy, noble} × {amd64, arm64}`
- [ ] The smoke step exercises the 5 tagged classes and `Test ClassLoader` runs the Spring Boot starter