### PR TITLE
fix(docker): assemble driver on the host for docker builds

### DIFF
--- a/scripts/download_driver.sh
+++ b/scripts/download_driver.sh
@@ -37,22 +37,16 @@ download() {
 DRIVER_VERSION=$(head -1 ./DRIVER_VERSION)
 
 # Resolve the exact upstream commit that produced this driver version, so that the
-# bundled Node.js version matches the driver exactly. Query the npm registry over
-# HTTP instead of the npm CLI which is not available in the docker image build.
-VERSION_MANIFEST=$(mktemp)
-download "https://registry.npmjs.org/playwright/$DRIVER_VERSION" "$VERSION_MANIFEST"
-GIT_HEAD=$(grep -o '"gitHead"[[:space:]]*:[[:space:]]*"[0-9a-f]\{40\}"' "$VERSION_MANIFEST" | head -1 | grep -o '[0-9a-f]\{40\}')
-rm -f "$VERSION_MANIFEST"
+# bundled Node.js version matches the driver exactly.
+GIT_HEAD=$(npm view playwright@"$DRIVER_VERSION" gitHead)
 if [[ -z "$GIT_HEAD" ]]; then
   echo "Failed to resolve upstream commit (gitHead) for playwright@$DRIVER_VERSION"
   exit 1
 fi
 
 # The Node.js version is kept in sync with the driver version in the upstream build script.
-BUILD_SCRIPT=$(mktemp)
-download "https://raw.githubusercontent.com/microsoft/playwright/$GIT_HEAD/utils/build/build-playwright-driver.sh" "$BUILD_SCRIPT"
-NODE_VERSION=$(sed -n 's/^NODE_VERSION="\([^"]*\)".*/\1/p' "$BUILD_SCRIPT")
-rm -f "$BUILD_SCRIPT"
+NODE_VERSION=$(curl -fsSL "https://raw.githubusercontent.com/microsoft/playwright/$GIT_HEAD/utils/build/build-playwright-driver.sh" \
+  | sed -n 's/^NODE_VERSION="\([^"]*\)".*/\1/p')
 if [[ -z "$NODE_VERSION" ]]; then
   echo "Failed to determine Node.js version for playwright@$DRIVER_VERSION ($GIT_HEAD)"
   exit 1

--- a/scripts/download_driver.sh
+++ b/scripts/download_driver.sh
@@ -37,16 +37,22 @@ download() {
 DRIVER_VERSION=$(head -1 ./DRIVER_VERSION)
 
 # Resolve the exact upstream commit that produced this driver version, so that the
-# bundled Node.js version matches the driver exactly.
-GIT_HEAD=$(npm view playwright@"$DRIVER_VERSION" gitHead)
+# bundled Node.js version matches the driver exactly. Query the npm registry over
+# HTTP instead of the npm CLI which is not available in the docker image build.
+VERSION_MANIFEST=$(mktemp)
+download "https://registry.npmjs.org/playwright/$DRIVER_VERSION" "$VERSION_MANIFEST"
+GIT_HEAD=$(grep -o '"gitHead"[[:space:]]*:[[:space:]]*"[0-9a-f]\{40\}"' "$VERSION_MANIFEST" | head -1 | grep -o '[0-9a-f]\{40\}')
+rm -f "$VERSION_MANIFEST"
 if [[ -z "$GIT_HEAD" ]]; then
   echo "Failed to resolve upstream commit (gitHead) for playwright@$DRIVER_VERSION"
   exit 1
 fi
 
 # The Node.js version is kept in sync with the driver version in the upstream build script.
-NODE_VERSION=$(curl -fsSL "https://raw.githubusercontent.com/microsoft/playwright/$GIT_HEAD/utils/build/build-playwright-driver.sh" \
-  | sed -n 's/^NODE_VERSION="\([^"]*\)".*/\1/p')
+BUILD_SCRIPT=$(mktemp)
+download "https://raw.githubusercontent.com/microsoft/playwright/$GIT_HEAD/utils/build/build-playwright-driver.sh" "$BUILD_SCRIPT"
+NODE_VERSION=$(sed -n 's/^NODE_VERSION="\([^"]*\)".*/\1/p' "$BUILD_SCRIPT")
+rm -f "$BUILD_SCRIPT"
 if [[ -z "$NODE_VERSION" ]]; then
   echo "Failed to determine Node.js version for playwright@$DRIVER_VERSION ($GIT_HEAD)"
   exit 1

--- a/utils/docker/Dockerfile.jammy
+++ b/utils/docker/Dockerfile.jammy
@@ -44,7 +44,6 @@ RUN mkdir /ms-playwright && \
 COPY . /tmp/pw-java
 
 RUN cd /tmp/pw-java && \
-    ./scripts/download_driver.sh && \
     mvn install -D skipTests --no-transfer-progress && \
     DEBIAN_FRONTEND=noninteractive mvn exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI \
                      -D exec.args="install-deps" -f playwright/pom.xml --no-transfer-progress && \

--- a/utils/docker/Dockerfile.noble
+++ b/utils/docker/Dockerfile.noble
@@ -44,7 +44,6 @@ RUN mkdir /ms-playwright && \
 COPY . /tmp/pw-java
 
 RUN cd /tmp/pw-java && \
-    ./scripts/download_driver.sh && \
     mvn install -D skipTests --no-transfer-progress && \
     DEBIAN_FRONTEND=noninteractive mvn exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI \
                      -D exec.args="install-deps" -f playwright/pom.xml --no-transfer-progress && \

--- a/utils/docker/build.sh
+++ b/utils/docker/build.sh
@@ -34,4 +34,8 @@ fi
 
 PW_TARGET_ARCH=$(echo $1 | cut -c3-)
 
+# Assemble the driver on the host where npm is available; the Dockerfile picks
+# it up via `COPY . /tmp/pw-java`.
+../../scripts/download_driver.sh
+
 docker build --platform "${PLATFORM}" --build-arg "PW_TARGET_ARCH=${PW_TARGET_ARCH}" -t "$3" -f "Dockerfile.$2" ../../


### PR DESCRIPTION
## Summary

- Since #1927 `download_driver.sh` requires npm, which the docker image build doesn't have — `Test (jammy/noble)` jobs fail with `npm: command not found`.
- Move the driver assembly out of the Dockerfiles into `build.sh`, which runs on the host where npm is available; the image picks up the assembled driver via the existing `COPY . /tmp/pw-java`.
- Covers both the test workflow and `publish_docker.sh`, which funnel through `build.sh`.