### PR TITLE
feat(docker): add Ubuntu 26.04 (Resolute Raccoon) image

### DIFF
--- a/.github/workflows/test_docker.yml
+++ b/.github/workflows/test_docker.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        flavor: [jammy, noble]
+        flavor: [jammy, noble, resolute]
         runs-on: [ubuntu-24.04, ubuntu-24.04-arm]
         include:
           - runs-on: ubuntu-24.04

--- a/utils/docker/Dockerfile.resolute
+++ b/utils/docker/Dockerfile.resolute
@@ -1,0 +1,55 @@
+FROM ubuntu:resolute
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG TZ=America/Los_Angeles
+ARG DOCKER_IMAGE_NAME_TEMPLATE="mcr.microsoft.com/playwright/java:v%version%-resolute"
+
+ENV LANG=C.UTF-8
+ENV LC_ALL=C.UTF-8
+
+# === INSTALL JDK and Maven ===
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends openjdk-25-jdk \
+    # Install utilities required for downloading browsers
+    wget \
+    # Install utilities required for downloading driver
+    unzip \
+    # For the MSEdge install script
+    gpg && \
+    rm -rf /var/lib/apt/lists/* && \
+    # Create the pwuser
+    adduser pwuser
+
+# Ubuntu 22.04 and earlier come with Maven 3.6.3 which fails with
+# Java 25, so we install latest Maven from Apache instead.
+RUN VERSION=3.9.12 && \
+    wget -O - https://archive.apache.org/dist/maven/maven-3/$VERSION/binaries/apache-maven-$VERSION-bin.tar.gz | tar zxfv - -C /opt/ && \
+    ln -s /opt/apache-maven-$VERSION/bin/mvn /usr/local/bin/
+
+ARG PW_TARGET_ARCH
+ENV JAVA_HOME=/usr/lib/jvm/java-25-openjdk-${PW_TARGET_ARCH}
+
+# === BAKE BROWSERS INTO IMAGE ===
+
+# Browsers will remain downloaded in `/ms-playwright`.
+# Note: make sure to set 777 to the registry so that any user can access
+# registry.
+
+ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
+
+RUN mkdir /ms-playwright && \
+    mkdir /tmp/pw-java
+
+COPY . /tmp/pw-java
+
+RUN cd /tmp/pw-java && \
+    mvn install -D skipTests --no-transfer-progress && \
+    DEBIAN_FRONTEND=noninteractive mvn exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI \
+                     -D exec.args="install-deps" -f playwright/pom.xml --no-transfer-progress && \
+    mvn exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI \
+                     -D exec.args="install" -f playwright/pom.xml --no-transfer-progress && \
+    mvn exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI \
+                     -D exec.args="mark-docker-image '${DOCKER_IMAGE_NAME_TEMPLATE}'" -f playwright/pom.xml --no-transfer-progress && \
+    rm -rf /tmp/pw-java && \
+    chmod -R 777 $PLAYWRIGHT_BROWSERS_PATH

--- a/utils/docker/Dockerfile.resolute
+++ b/utils/docker/Dockerfile.resolute
@@ -19,7 +19,7 @@ RUN apt-get update && \
     gpg && \
     rm -rf /var/lib/apt/lists/* && \
     # Create the pwuser
-    adduser pwuser
+    useradd -m -s /bin/bash pwuser
 
 # Ubuntu 22.04 and earlier come with Maven 3.6.3 which fails with
 # Java 25, so we install latest Maven from Apache instead.

--- a/utils/docker/build.sh
+++ b/utils/docker/build.sh
@@ -3,7 +3,7 @@ set -e
 set +x
 
 if [[ ($1 == '--help') || ($1 == '-h') || ($1 == '') || ($2 == '') ]]; then
-  echo "usage: $(basename $0) {--arm64,--amd64} {jammy,noble} playwright:localbuild-noble"
+  echo "usage: $(basename $0) {--arm64,--amd64} {jammy,noble,resolute} playwright:localbuild-noble"
   echo
   echo "Build Playwright docker image and tag it as 'playwright:localbuild-noble'."
   echo "Once image is built, you can run it with"

--- a/utils/docker/publish_docker.sh
+++ b/utils/docker/publish_docker.sh
@@ -38,6 +38,11 @@ NOBLE_TAGS=(
   "v${PW_VERSION}-noble"
 )
 
+# Ubuntu 26.04
+RESOLUTE_TAGS=(
+  "v${PW_VERSION}-resolute"
+)
+
 tag_and_push() {
   local source="$1"
   local target="$2"
@@ -74,8 +79,10 @@ publish_docker_images_with_arch_suffix() {
     TAGS=("${JAMMY_TAGS[@]}")
   elif [[ "$FLAVOR" == "noble" ]]; then
     TAGS=("${NOBLE_TAGS[@]}")
+  elif [[ "$FLAVOR" == "resolute" ]]; then
+    TAGS=("${RESOLUTE_TAGS[@]}")
   else
-    echo "ERROR: unknown flavor - $FLAVOR. Must be either 'jammy', or 'noble'"
+    echo "ERROR: unknown flavor - $FLAVOR. Must be either 'jammy', 'noble', or 'resolute'"
     exit 1
   fi
   local ARCH="$2"
@@ -100,8 +107,10 @@ publish_docker_manifest () {
     TAGS=("${JAMMY_TAGS[@]}")
   elif [[ "$FLAVOR" == "noble" ]]; then
     TAGS=("${NOBLE_TAGS[@]}")
+  elif [[ "$FLAVOR" == "resolute" ]]; then
+    TAGS=("${RESOLUTE_TAGS[@]}")
   else
-    echo "ERROR: unknown flavor - $FLAVOR. Must be either 'jammy', 'noble'"
+    echo "ERROR: unknown flavor - $FLAVOR. Must be either 'jammy', 'noble', or 'resolute'"
     exit 1
   fi
 
@@ -127,3 +136,7 @@ publish_docker_manifest jammy amd64 arm64
 publish_docker_images_with_arch_suffix noble amd64
 publish_docker_images_with_arch_suffix noble arm64
 publish_docker_manifest noble amd64 arm64
+
+publish_docker_images_with_arch_suffix resolute amd64
+publish_docker_images_with_arch_suffix resolute arm64
+publish_docker_manifest resolute amd64 arm64


### PR DESCRIPTION
## Summary
- Add `Dockerfile.resolute` based on Ubuntu 26.04 LTS (Resolute Raccoon).
- Wire the `resolute` flavor through `build.sh` and `publish_docker.sh` (new `v<version>-resolute` tag).
- Add `resolute` to the docker test matrix.