### PR TITLE
fix(driver-bundle): exclude driver binaries from sources JAR

### DIFF
--- a/driver-bundle/pom.xml
+++ b/driver-bundle/pom.xml
@@ -28,4 +28,18 @@
       <artifactId>junit-jupiter-engine</artifactId>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <!-- The driver binaries for all platforms live in src/main/resources and must not
+           be packaged into the sources JAR (see issue #1913). -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <configuration>
+          <excludeResources>true</excludeResources>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>


### PR DESCRIPTION
## Summary
- The `maven-source-plugin` packages `src/main/resources`, so the per-platform driver binaries were bundled into `driver-bundle-*-sources.jar` (~214MB).
- Set `excludeResources=true` for the source plugin in `driver-bundle` so the sources JAR contains only the Java sources (`DriverJar.java`). Rebuilt locally: sources JAR went from 214MB to 5.4KB.

Fixes https://github.com/microsoft/playwright-java/issues/1913