### PR TITLE
fix(fetch): serialize LocalDate in post data

### DIFF
--- a/playwright/src/main/java/com/microsoft/playwright/impl/Serialization.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/Serialization.java
@@ -77,6 +77,7 @@ class Serialization {
 
   static final Gson jsonDataSerializer = new GsonBuilder().disableHtmlEscaping()
     .registerTypeAdapter(Date.class, new DateSerializer())
+    .registerTypeAdapter(LocalDate.class, new LocalDateSerializer())
     .registerTypeAdapter(LocalDateTime.class, new LocalDateTimeSerializer())
     .registerTypeAdapter(OffsetDateTime.class, new OffsetDateTimeSerializer())
     .serializeNulls().create();
@@ -568,6 +569,15 @@ class Serialization {
     @Override
     public JsonElement serialize(OffsetDateTime src, Type typeOfSrc, JsonSerializationContext context) {
       return new JsonPrimitive(dateFormat.format(Date.from(src.toInstant())));
+    }
+  }
+
+  private static class LocalDateSerializer implements JsonSerializer<LocalDate> {
+    @Override
+    public JsonElement serialize(LocalDate src, Type typeOfSrc, JsonSerializationContext context) {
+      // LocalDate has no time or zone, so emit the ISO-8601 date (yyyy-MM-dd) as-is to
+      // avoid shifting the calendar date when converting through a time zone.
+      return new JsonPrimitive(src.toString());
     }
   }
 

--- a/playwright/src/test/java/com/microsoft/playwright/TestBrowserContextFetch.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestBrowserContextFetch.java
@@ -28,6 +28,7 @@ import java.io.OutputStreamWriter;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.text.ParseException;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
@@ -531,6 +532,23 @@ public class TestBrowserContextFetch extends TestBase {
     request.get(server.EMPTY_PAGE, RequestOptions.create().setData(mapOf("date", offsetDateTime)));
     byte[] body = serverRequest.get().postBody;
     assertEquals("{\"date\":\"2024-07-10T18:15:30.000Z\"}", new String(body));
+  }
+
+  public static class LocalDateData {
+    public String name;
+    public LocalDate date;
+  }
+
+  @Test
+  void shouldSupportLocalDateInData() throws ExecutionException, InterruptedException {
+    APIRequestContext request = playwright.request().newContext();
+    LocalDateData testData = new LocalDateData();
+    testData.name = "foo";
+    testData.date = LocalDate.of(2022, 12, 23);
+    Future<Server.Request> serverRequest = server.futureRequest("/empty.html");
+    request.post(server.EMPTY_PAGE, RequestOptions.create().setData(testData));
+    byte[] body = serverRequest.get().postBody;
+    assertEquals("{\"name\":\"foo\",\"date\":\"2022-12-23\"}", new String(body));
   }
 
   @Test


### PR DESCRIPTION
## Summary
- Register a `LocalDate` gson adapter in `jsonDataSerializer` so POJOs with a `LocalDate` property can be sent via `RequestOptions.setData`.
- Serialized as an ISO-8601 date string (`yyyy-MM-dd`) without converting through a time zone, avoiding calendar-date shifts.

Fixes https://github.com/microsoft/playwright-java/issues/1865