### PR TITLE
feat(driver-bundle): split driver per platform and auto-select host

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ git clone https://github.com/microsoft/playwright-java
 cd playwright-java
 ```
 
-2. Run the following script to download and assemble the Playwright driver for all platforms into `driver-bundle/src/main/resources/driver/` directory (browser binaries for Chromium, Firefox and WebKit will be automatically downloaded later on first Playwright run).
+2. Run the following script to download and assemble the Playwright driver for all platforms, one per module, into the `driver-bundle-<platform>/src/main/resources/driver/<platform>/` directories (browser binaries for Chromium, Firefox and WebKit will be automatically downloaded later on first Playwright run).
 
 ```bash
 scripts/download_driver.sh

--- a/README.md
+++ b/README.md
@@ -54,6 +54,51 @@ public class PageScreenshot {
 }
 ```
 
+## Driver bundles and platform selection
+
+Playwright ships the driver (a Node.js binary plus the `playwright-core` package) as
+per-platform Maven artifacts. With **Maven**, the right one is selected automatically for the
+machine that runs the build, so depending on `playwright` is all you need — no extra
+configuration:
+
+| Artifact | Platform |
+| --- | --- |
+| `driver-bundle-mac-x64` | macOS Intel |
+| `driver-bundle-mac-arm64` | macOS Apple Silicon |
+| `driver-bundle-linux-x64` | Linux x64 |
+| `driver-bundle-linux-arm64` | Linux arm64 |
+| `driver-bundle-win-x64` | Windows x64 |
+
+### Bundling every platform (cross-platform / fat JARs)
+
+The automatic selection picks the driver for the build host, so a JAR built on Linux contains
+only the Linux driver. If you build on one OS and run on another (for example a distributable
+fat JAR), depend on `driver-bundle-all`, which bundles every platform:
+
+```xml
+<dependency>
+  <groupId>com.microsoft.playwright</groupId>
+  <artifactId>driver-bundle-all</artifactId>
+  <version>${playwright.version}</version>
+</dependency>
+```
+
+### Gradle
+
+Gradle does not evaluate the Maven POM profiles that drive the automatic selection, so a Gradle
+build will not pick a platform on its own (and converting the dependency from Maven does not
+carry the selection over). Declare the driver explicitly — either a single platform:
+
+```kotlin
+runtimeOnly("com.microsoft.playwright:driver-bundle-linux-x64:$playwrightVersion")
+```
+
+or every platform:
+
+```kotlin
+runtimeOnly("com.microsoft.playwright:driver-bundle-all:$playwrightVersion")
+```
+
 ## Other languages
 
 More comfortable in another programming language? [Playwright](https://playwright.dev) is also available in

--- a/driver-bundle-all/pom.xml
+++ b/driver-bundle-all/pom.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.microsoft.playwright</groupId>
+    <artifactId>parent-pom</artifactId>
+    <version>1.50.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>driver-bundle-all</artifactId>
+  <name>Playwright - Drivers For All Platforms</name>
+  <description>
+    Aggregates the Playwright driver for every supported platform (macOS, Linux and Windows).
+    Depend on this artifact when a single build must run on more than the host platform, for
+    example a cross-platform fat JAR. For the common case where only the host platform is needed,
+    rely on the transitive driver-bundle dependency, which selects the right platform automatically.
+  </description>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.microsoft.playwright</groupId>
+      <artifactId>driver-bundle-mac-x64</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.microsoft.playwright</groupId>
+      <artifactId>driver-bundle-mac-arm64</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.microsoft.playwright</groupId>
+      <artifactId>driver-bundle-linux-x64</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.microsoft.playwright</groupId>
+      <artifactId>driver-bundle-linux-arm64</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.microsoft.playwright</groupId>
+      <artifactId>driver-bundle-win-x64</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/driver-bundle-linux-arm64/pom.xml
+++ b/driver-bundle-linux-arm64/pom.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.microsoft.playwright</groupId>
+    <artifactId>parent-pom</artifactId>
+    <version>1.50.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>driver-bundle-linux-arm64</artifactId>
+  <name>Playwright - Driver For Linux arm64</name>
+  <description>
+    Playwright driver (Node.js binary and playwright-core package) for the Linux arm64 platform.
+    This artifact is normally selected automatically for the host platform via the driver-bundle
+    module; depend on it directly (or on driver-bundle-all) to bundle additional platforms.
+  </description>
+
+  <build>
+    <plugins>
+      <!-- The driver binaries live in src/main/resources and must not be packaged
+           into the sources JAR (see issue #1913). -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <configuration>
+          <excludeResources>true</excludeResources>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/driver-bundle-linux-arm64/src/main/resources/.gitignore
+++ b/driver-bundle-linux-arm64/src/main/resources/.gitignore
@@ -1,0 +1,2 @@
+driver/
+local-driver/

--- a/driver-bundle-linux-x64/pom.xml
+++ b/driver-bundle-linux-x64/pom.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.microsoft.playwright</groupId>
+    <artifactId>parent-pom</artifactId>
+    <version>1.50.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>driver-bundle-linux-x64</artifactId>
+  <name>Playwright - Driver For Linux x64</name>
+  <description>
+    Playwright driver (Node.js binary and playwright-core package) for the Linux x64 platform.
+    This artifact is normally selected automatically for the host platform via the driver-bundle
+    module; depend on it directly (or on driver-bundle-all) to bundle additional platforms.
+  </description>
+
+  <build>
+    <plugins>
+      <!-- The driver binaries live in src/main/resources and must not be packaged
+           into the sources JAR (see issue #1913). -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <configuration>
+          <excludeResources>true</excludeResources>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/driver-bundle-linux-x64/src/main/resources/.gitignore
+++ b/driver-bundle-linux-x64/src/main/resources/.gitignore
@@ -1,0 +1,2 @@
+driver/
+local-driver/

--- a/driver-bundle-mac-arm64/pom.xml
+++ b/driver-bundle-mac-arm64/pom.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.microsoft.playwright</groupId>
+    <artifactId>parent-pom</artifactId>
+    <version>1.50.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>driver-bundle-mac-arm64</artifactId>
+  <name>Playwright - Driver For macOS arm64</name>
+  <description>
+    Playwright driver (Node.js binary and playwright-core package) for the macOS arm64 platform.
+    This artifact is normally selected automatically for the host platform via the driver-bundle
+    module; depend on it directly (or on driver-bundle-all) to bundle additional platforms.
+  </description>
+
+  <build>
+    <plugins>
+      <!-- The driver binaries live in src/main/resources and must not be packaged
+           into the sources JAR (see issue #1913). -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <configuration>
+          <excludeResources>true</excludeResources>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/driver-bundle-mac-arm64/src/main/resources/.gitignore
+++ b/driver-bundle-mac-arm64/src/main/resources/.gitignore
@@ -1,0 +1,2 @@
+driver/
+local-driver/

--- a/driver-bundle-mac-x64/pom.xml
+++ b/driver-bundle-mac-x64/pom.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.microsoft.playwright</groupId>
+    <artifactId>parent-pom</artifactId>
+    <version>1.50.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>driver-bundle-mac-x64</artifactId>
+  <name>Playwright - Driver For macOS x64</name>
+  <description>
+    Playwright driver (Node.js binary and playwright-core package) for the macOS x64 platform.
+    This artifact is normally selected automatically for the host platform via the driver-bundle
+    module; depend on it directly (or on driver-bundle-all) to bundle additional platforms.
+  </description>
+
+  <build>
+    <plugins>
+      <!-- The driver binaries live in src/main/resources and must not be packaged
+           into the sources JAR (see issue #1913). -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <configuration>
+          <excludeResources>true</excludeResources>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/driver-bundle-mac-x64/src/main/resources/.gitignore
+++ b/driver-bundle-mac-x64/src/main/resources/.gitignore
@@ -1,0 +1,2 @@
+driver/
+local-driver/

--- a/driver-bundle-win-x64/pom.xml
+++ b/driver-bundle-win-x64/pom.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.microsoft.playwright</groupId>
+    <artifactId>parent-pom</artifactId>
+    <version>1.50.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>driver-bundle-win-x64</artifactId>
+  <name>Playwright - Driver For Windows x64</name>
+  <description>
+    Playwright driver (Node.js binary and playwright-core package) for the Windows x64 platform.
+    This artifact is normally selected automatically for the host platform via the driver-bundle
+    module; depend on it directly (or on driver-bundle-all) to bundle additional platforms.
+  </description>
+
+  <build>
+    <plugins>
+      <!-- The driver binaries live in src/main/resources and must not be packaged
+           into the sources JAR (see issue #1913). -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <configuration>
+          <excludeResources>true</excludeResources>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/driver-bundle-win-x64/src/main/resources/.gitignore
+++ b/driver-bundle-win-x64/src/main/resources/.gitignore
@@ -1,0 +1,2 @@
+driver/
+local-driver/

--- a/driver-bundle/pom.xml
+++ b/driver-bundle/pom.xml
@@ -10,10 +10,14 @@
   </parent>
 
   <artifactId>driver-bundle</artifactId>
-  <name>Playwright - Drivers For All Platforms</name>
+  <name>Playwright - Driver For The Host Platform</name>
   <description>
-    This module includes Playwright driver and related utilities for all supported platforms.
-    It is intended to be used on the systems where Playwright driver is not preinstalled.
+    This module loads the Playwright driver from the classpath (DriverJar) and, via the
+    platform-specific profiles below, pulls in the driver binaries for the host platform only.
+    Maven activates exactly one profile based on the build machine's operating system and
+    architecture, so a build downloads just the driver it needs. To bundle every platform (for
+    example a cross-platform fat JAR) depend on driver-bundle-all, or add the individual
+    driver-bundle-&lt;platform&gt; artifacts explicitly.
   </description>
 
   <dependencies>
@@ -29,17 +33,80 @@
     </dependency>
   </dependencies>
 
-  <build>
-    <plugins>
-      <!-- The driver binaries for all platforms live in src/main/resources and must not
-           be packaged into the sources JAR (see issue #1913). -->
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-source-plugin</artifactId>
-        <configuration>
-          <excludeResources>true</excludeResources>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
+  <profiles>
+    <!-- Each profile activates on the host OS/arch and contributes the matching driver
+         binaries as a runtime dependency. The activation is evaluated against the consumer's
+         build environment during transitive dependency resolution, so users that depend on
+         playwright automatically get the driver for their platform with no extra configuration. -->
+    <profile>
+      <id>driver-linux</id>
+      <activation>
+        <os><name>linux</name><arch>amd64</arch></os>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>com.microsoft.playwright</groupId>
+          <artifactId>driver-bundle-linux-x64</artifactId>
+          <version>${project.version}</version>
+          <scope>runtime</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
+      <id>driver-linux-arm64</id>
+      <activation>
+        <os><name>linux</name><arch>aarch64</arch></os>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>com.microsoft.playwright</groupId>
+          <artifactId>driver-bundle-linux-arm64</artifactId>
+          <version>${project.version}</version>
+          <scope>runtime</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
+      <id>driver-mac</id>
+      <activation>
+        <os><family>mac</family><arch>x86_64</arch></os>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>com.microsoft.playwright</groupId>
+          <artifactId>driver-bundle-mac-x64</artifactId>
+          <version>${project.version}</version>
+          <scope>runtime</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
+      <id>driver-mac-arm64</id>
+      <activation>
+        <os><family>mac</family><arch>aarch64</arch></os>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>com.microsoft.playwright</groupId>
+          <artifactId>driver-bundle-mac-arm64</artifactId>
+          <version>${project.version}</version>
+          <scope>runtime</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
+      <id>driver-win-x64</id>
+      <activation>
+        <os><family>windows</family></os>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>com.microsoft.playwright</groupId>
+          <artifactId>driver-bundle-win-x64</artifactId>
+          <version>${project.version}</version>
+          <scope>runtime</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
 </project>

--- a/driver-bundle/src/main/java/com/microsoft/playwright/impl/driver/jar/DriverJar.java
+++ b/driver-bundle/src/main/java/com/microsoft/playwright/impl/driver/jar/DriverJar.java
@@ -183,20 +183,20 @@ public class DriverJar extends Driver {
     String arch = System.getProperty("os.arch").toLowerCase();
 
     if (name.contains("windows")) {
-      return "win32_x64";
+      return "win-x64";
     }
     if (name.contains("linux")) {
       if (arch.equals("aarch64")) {
         return "linux-arm64";
       } else {
-        return "linux";
+        return "linux-x64";
       }
     }
     if (name.contains("mac os x")) {
       if (arch.equals("aarch64")) {
         return "mac-arm64";
       } else {
-        return "mac";
+        return "mac-x64";
       }
     }
     throw new RuntimeException("Unexpected os.name value: " + name);

--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,12 @@
 
   <modules>
     <module>driver</module>
+    <module>driver-bundle-mac-x64</module>
+    <module>driver-bundle-mac-arm64</module>
+    <module>driver-bundle-linux-x64</module>
+    <module>driver-bundle-linux-arm64</module>
+    <module>driver-bundle-win-x64</module>
+    <module>driver-bundle-all</module>
     <module>driver-bundle</module>
     <module>playwright</module>
   </modules>
@@ -62,6 +68,36 @@
       <dependency>
         <groupId>com.microsoft.playwright</groupId>
         <artifactId>driver-bundle</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.microsoft.playwright</groupId>
+        <artifactId>driver-bundle-all</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.microsoft.playwright</groupId>
+        <artifactId>driver-bundle-mac-x64</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.microsoft.playwright</groupId>
+        <artifactId>driver-bundle-mac-arm64</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.microsoft.playwright</groupId>
+        <artifactId>driver-bundle-linux-x64</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.microsoft.playwright</groupId>
+        <artifactId>driver-bundle-linux-arm64</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.microsoft.playwright</groupId>
+        <artifactId>driver-bundle-win-x64</artifactId>
         <version>${project.version}</version>
       </dependency>
       <dependency>

--- a/scripts/download_driver.sh
+++ b/scripts/download_driver.sh
@@ -11,7 +11,8 @@ if [[ ($1 == '-h') || ($1 == '--help') ]]; then
   echo "This script downloads and assembles the Playwright driver for all platforms."
   echo "Each driver is assembled from the 'playwright-core' npm package and the matching"
   echo "Node.js binary from https://nodejs.org, the same way the upstream Playwright build"
-  echo "does it. The result is put under 'driver-bundle/src/main/resources/driver'."
+  echo "does it. Each platform is written to its own module under"
+  echo "'driver-bundle-<platform>/src/main/resources/driver/<platform>'."
   echo ""
   echo "Usage: scripts/download_driver.sh [option]"
   echo ""
@@ -56,50 +57,52 @@ echo "Driver version:  $DRIVER_VERSION"
 echo "Upstream commit: $GIT_HEAD"
 echo "Node.js version: $NODE_VERSION"
 
-cd ../driver-bundle/src/main/resources
+# Each platform's driver is assembled into its own Maven module
+# (driver-bundle-<platform>/src/main/resources/driver/<platform>), so that a consumer build
+# only pulls in the driver for the host platform. See issue #1196. The platform token uses an
+# <os>-<arch> scheme (e.g. mac-x64) that matches both the artifact name and the directory that
+# DriverJar.platformDir() looks up.
+ROOT="$(cd .. && pwd)"
 
-if [[ -d 'driver' ]]; then
-  echo "Deleting existing drivers from $(pwd)"
-  rm -rf driver
-fi
-
-mkdir -p driver
-cd driver
-
-# Download the platform-independent driver package (playwright-core) once.
-CORE_TGZ="$(pwd)/playwright-core-$DRIVER_VERSION.tgz"
+# Download once into a temporary directory shared across platforms.
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+CORE_TGZ="$TMP_DIR/playwright-core-$DRIVER_VERSION.tgz"
 download "https://registry.npmjs.org/playwright-core/-/playwright-core-$DRIVER_VERSION.tgz" "$CORE_TGZ"
 
 # <java platform dir>:<nodejs platform suffix>:<archive extension>
 for ENTRY in \
-  "mac:darwin-x64:tar.gz" \
+  "mac-x64:darwin-x64:tar.gz" \
   "mac-arm64:darwin-arm64:tar.gz" \
-  "linux:linux-x64:tar.gz" \
+  "linux-x64:linux-x64:tar.gz" \
   "linux-arm64:linux-arm64:tar.gz" \
-  "win32_x64:win-x64:zip"
+  "win-x64:win-x64:zip"
 do
   IFS=':' read -r PLATFORM NODE_SUFFIX ARCHIVE <<< "$ENTRY"
-  echo "Assembling driver for $PLATFORM to $(pwd)/$PLATFORM"
-  mkdir "$PLATFORM"
+  DEST="$ROOT/driver-bundle-$PLATFORM/src/main/resources/driver"
+  if [[ -d "$DEST" ]]; then
+    echo "Deleting existing driver from $DEST"
+    rm -rf "$DEST"
+  fi
+  mkdir -p "$DEST/$PLATFORM"
+  echo "Assembling driver for $PLATFORM to $DEST/$PLATFORM"
 
   # 1. playwright-core package contents -> $PLATFORM/package
-  tar -xzf "$CORE_TGZ" -C "$PLATFORM"
+  tar -xzf "$CORE_TGZ" -C "$DEST/$PLATFORM"
 
   # 2. Node.js binary and its license from the official Node.js distribution.
   NODE_DIR="node-v$NODE_VERSION-$NODE_SUFFIX"
-  NODE_ARCHIVE="$NODE_DIR.$ARCHIVE"
+  NODE_ARCHIVE="$TMP_DIR/$NODE_DIR.$ARCHIVE"
   download "https://nodejs.org/dist/v$NODE_VERSION/$NODE_DIR.$ARCHIVE" "$NODE_ARCHIVE"
   if [[ $ARCHIVE == "zip" ]]; then
-    unzip -joq "$NODE_ARCHIVE" "$NODE_DIR/node.exe" -d "$PLATFORM"
-    unzip -joq "$NODE_ARCHIVE" "$NODE_DIR/LICENSE" -d "$PLATFORM"
+    unzip -joq "$NODE_ARCHIVE" "$NODE_DIR/node.exe" -d "$DEST/$PLATFORM"
+    unzip -joq "$NODE_ARCHIVE" "$NODE_DIR/LICENSE" -d "$DEST/$PLATFORM"
   else
-    tar -xzf "$NODE_ARCHIVE" -C "$PLATFORM" --strip-components=2 "$NODE_DIR/bin/node"
-    tar -xzf "$NODE_ARCHIVE" -C "$PLATFORM" --strip-components=1 "$NODE_DIR/LICENSE"
+    tar -xzf "$NODE_ARCHIVE" -C "$DEST/$PLATFORM" --strip-components=2 "$NODE_DIR/bin/node"
+    tar -xzf "$NODE_ARCHIVE" -C "$DEST/$PLATFORM" --strip-components=1 "$NODE_DIR/LICENSE"
   fi
   rm -f "$NODE_ARCHIVE"
 done
-
-rm -f "$CORE_TGZ"
 
 echo ""
 echo "All drivers have been successfully assembled."

--- a/tools/test-cli-fatjar/pom.xml
+++ b/tools/test-cli-fatjar/pom.xml
@@ -29,9 +29,10 @@
       <artifactId>playwright</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!-- A distributable CLI fat JAR must run on any platform, so bundle every driver. -->
     <dependency>
       <groupId>com.microsoft.playwright</groupId>
-      <artifactId>driver-bundle</artifactId>
+      <artifactId>driver-bundle-all</artifactId>
       <version>${project.version}</version>
     </dependency>
   </dependencies>


### PR DESCRIPTION
## Summary
- Split the monolithic `driver-bundle` (~194MB, all platforms) into per-platform artifacts: `driver-bundle-mac-x64`, `-mac-arm64`, `-linux-x64`, `-linux-arm64`, `-win-x64`.
- `driver-bundle` now ships only `DriverJar` and uses OS-activated Maven profiles to pull the host platform's artifact automatically — Maven users get just their platform's driver with no extra config (a Linux x64 build pulls ~45MB instead of ~194MB).
- `driver-bundle-all` aggregates every platform for cross-platform fat jars (used by `test-cli-fatjar`).

## Notes for review
- Behavior change: a fat jar now contains only the build host's driver by default; depend on `driver-bundle-all` for a cross-platform jar.
- Gradle does not evaluate Maven POM profiles, so Gradle users would need one explicit dependency (`driver-bundle-all` or a specific `driver-bundle-<platform>`). Worth documenting if we take this approach.

Fixes https://github.com/microsoft/playwright-java/issues/1196