### PR TITLE
feat: add Automatic-Module-Name manifest entries

### DIFF
--- a/driver-bundle/pom.xml
+++ b/driver-bundle/pom.xml
@@ -16,6 +16,10 @@
     Node.js is preinstalled on the host (see PLAYWRIGHT_NODEJS_PATH).
   </description>
 
+  <properties>
+    <automatic.module.name>com.microsoft.playwright.driver.bundle</automatic.module.name>
+  </properties>
+
   <build>
     <plugins>
       <!-- The Node.js binaries for all platforms live in src/main/resources and must not

--- a/driver/pom.xml
+++ b/driver/pom.xml
@@ -16,6 +16,10 @@
     package; the Node.js binary comes from the driver-bundle module or a preinstalled Node.js.
   </description>
 
+  <properties>
+    <automatic.module.name>com.microsoft.playwright.driver</automatic.module.name>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/playwright/pom.xml
+++ b/playwright/pom.xml
@@ -19,6 +19,10 @@
     This is the main package that provides Playwright client.
   </description>
 
+  <properties>
+    <automatic.module.name>com.microsoft.playwright</automatic.module.name>
+  </properties>
+
   <build>
     <plugins>
       <plugin>
@@ -37,6 +41,14 @@
             <goals>
               <goal>test-jar</goal>
             </goals>
+            <configuration>
+              <archive>
+                <manifestEntries>
+                  <!-- A name of its own, so the main jar and the test-jar never claim the same module. -->
+                  <Automatic-Module-Name>com.microsoft.playwright.test</Automatic-Module-Name>
+                </manifestEntries>
+              </archive>
+            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -192,6 +192,9 @@
               <manifest>
                 <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
               </manifest>
+              <manifestEntries>
+                <Automatic-Module-Name>${automatic.module.name}</Automatic-Module-Name>
+              </manifestEntries>
             </archive>
           </configuration>
         </plugin>


### PR DESCRIPTION
Give the published jars stable Java module names so they can be required from the module path instead of relying on filename-derived automatic names:

- playwright: com.microsoft.playwright
- driver: com.microsoft.playwright.driver
- driver-bundle: com.microsoft.playwright.driver.bundle

The playwright test-jar carries its own name
(com.microsoft.playwright.test) so the main jar and the test-jar never claim the same module.