### PR TITLE
chore(release): mark 1.62.0

### DIFF
--- a/driver-bundle/pom.xml
+++ b/driver-bundle/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.microsoft.playwright</groupId>
     <artifactId>parent-pom</artifactId>
-    <version>1.50.0-SNAPSHOT</version>
+    <version>1.62.0</version>
   </parent>
 
   <artifactId>driver-bundle</artifactId>

--- a/driver/pom.xml
+++ b/driver/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.microsoft.playwright</groupId>
     <artifactId>parent-pom</artifactId>
-    <version>1.50.0-SNAPSHOT</version>
+    <version>1.62.0</version>
   </parent>
 
   <artifactId>driver</artifactId>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>org.example</groupId>
   <artifactId>examples</artifactId>
-  <version>1.50.0-SNAPSHOT</version>
+  <version>1.62.0</version>
   <name>Playwright Client Examples</name>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/playwright/pom.xml
+++ b/playwright/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>com.microsoft.playwright</groupId>
     <artifactId>parent-pom</artifactId>
-    <version>1.50.0-SNAPSHOT</version>
+    <version>1.62.0</version>
   </parent>
 
   <artifactId>playwright</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.microsoft.playwright</groupId>
   <artifactId>parent-pom</artifactId>
-  <version>1.50.0-SNAPSHOT</version>
+  <version>1.62.0</version>
   <packaging>pom</packaging>
   <name>Playwright Parent Project</name>
   <description>Java library to automate Chromium, Firefox and WebKit with a single API.

--- a/tools/api-generator/pom.xml
+++ b/tools/api-generator/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.microsoft.playwright</groupId>
   <artifactId>api-generator</artifactId>
-  <version>1.50.0-SNAPSHOT</version>
+  <version>1.62.0</version>
   <name>Playwright - API Generator</name>
   <description>
     This is an internal module used to generate Java API from the upstream Playwright

--- a/tools/test-cli-fatjar/pom.xml
+++ b/tools/test-cli-fatjar/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.microsoft.playwright</groupId>
   <artifactId>test-cli-fatjar</artifactId>
-  <version>1.50.0-SNAPSHOT</version>
+  <version>1.62.0</version>
   <name>Test Playwright Command Line FatJar</name>
   <properties>
     <compiler.version>1.8</compiler.version>

--- a/tools/test-cli-version/pom.xml
+++ b/tools/test-cli-version/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.microsoft.playwright</groupId>
   <artifactId>test-cli-version</artifactId>
-  <version>1.50.0-SNAPSHOT</version>
+  <version>1.62.0</version>
   <name>Test Playwright Command Line Version</name>
   <properties>
     <compiler.version>1.8</compiler.version>

--- a/tools/test-local-installation/pom.xml
+++ b/tools/test-local-installation/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.microsoft.playwright</groupId>
   <artifactId>test-local-installation</artifactId>
-  <version>1.50.0-SNAPSHOT</version>
+  <version>1.62.0</version>
   <name>Test local installation</name>
   <description>Runs Playwright test suite (copied from playwright module) against locally cached Playwright</description>
   <properties>

--- a/tools/test-spring-boot-starter/pom.xml
+++ b/tools/test-spring-boot-starter/pom.xml
@@ -9,7 +9,7 @@
   </parent>
   <groupId>com.microsoft.playwright</groupId>
   <artifactId>test-spring-boot-starter</artifactId>
-  <version>1.50.0-SNAPSHOT</version>
+  <version>1.62.0</version>
   <name>Test Playwright With Spring Boot</name>
   <properties>
     <spring.version>2.4.3</spring.version>

--- a/tools/update-docs-version/pom.xml
+++ b/tools/update-docs-version/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.microsoft.playwright</groupId>
   <artifactId>update-version</artifactId>
-  <version>1.50.0-SNAPSHOT</version>
+  <version>1.62.0</version>
   <name>Playwright - Update Version in Documentation</name>
   <description>
     This is an internal module used to update versions in the documentation based on


### PR DESCRIPTION
The Maven projects remained at `1.50.0-SNAPSHOT` after the driver roll.

Sets every project version and the example dependency to `1.62.0` using `./scripts/set_maven_version.sh 1.62.0`.
