### PR TITLE
feat(api): add JSpecify nullability annotations

### DIFF
--- a/playwright/pom.xml
+++ b/playwright/pom.xml
@@ -66,6 +66,10 @@
       <artifactId>gson</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.jspecify</groupId>
+      <artifactId>jspecify</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.java-websocket</groupId>
       <artifactId>Java-WebSocket</artifactId>
     </dependency>
@@ -99,4 +103,64 @@
       <artifactId>driver-bundle</artifactId>
     </dependency>
   </dependencies>
+  <profiles>
+    <profile>
+      <id>nullaway</id>
+      <activation>
+        <jdk>[21,)</jdk>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>nullaway-testCompile</id>
+                <phase>test-compile</phase>
+                <goals>
+                  <goal>testCompile</goal>
+                </goals>
+                <configuration>
+                  <fork>true</fork>
+                  <outputDirectory>${project.build.directory}/nullaway-test-classes</outputDirectory>
+                  <testIncludes>
+                    <testInclude>com/microsoft/playwright/nullability/JSpecifyApiConsumer.java</testInclude>
+                  </testIncludes>
+                  <compilerArgs>
+                    <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</arg>
+                    <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED</arg>
+                    <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED</arg>
+                    <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED</arg>
+                    <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED</arg>
+                    <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED</arg>
+                    <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED</arg>
+                    <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED</arg>
+                    <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</arg>
+                    <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED</arg>
+                    <arg>-XDcompilePolicy=simple</arg>
+                    <arg>--should-stop=ifError=FLOW</arg>
+                    <arg>-XDaddTypeAnnotationsToSymbol=true</arg>
+                    <arg>-Xplugin:ErrorProne -XepDisableAllChecks -Xep:NullAway:ERROR -XepOpt:NullAway:OnlyNullMarked=true -XepOpt:NullAway:JSpecifyMode=true</arg>
+                  </compilerArgs>
+                  <annotationProcessorPaths>
+                    <path>
+                      <groupId>com.google.errorprone</groupId>
+                      <artifactId>error_prone_core</artifactId>
+                      <version>${error-prone.version}</version>
+                    </path>
+                    <path>
+                      <groupId>com.uber.nullaway</groupId>
+                      <artifactId>nullaway</artifactId>
+                      <version>${nullaway.version}</version>
+                    </path>
+                  </annotationProcessorPaths>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/playwright/pom.xml
+++ b/playwright/pom.xml
@@ -123,6 +123,7 @@
                 </goals>
                 <configuration>
                   <fork>true</fork>
+                  <!-- Separate output so that the default testCompile does not mark this file as up to date. -->
                   <outputDirectory>${project.build.directory}/nullaway-test-classes</outputDirectory>
                   <testIncludes>
                     <testInclude>com/microsoft/playwright/nullability/JSpecifyApiConsumer.java</testInclude>

--- a/playwright/src/main/java/com/microsoft/playwright/APIRequest.java
+++ b/playwright/src/main/java/com/microsoft/playwright/APIRequest.java
@@ -16,6 +16,7 @@
 
 package com.microsoft.playwright;
 
+import org.jspecify.annotations.Nullable;
 import com.microsoft.playwright.options.*;
 import java.nio.file.Path;
 import java.util.*;
@@ -40,7 +41,7 @@ public interface APIRequest {
      * {@code http://localhost:3000/bar.html}</li>
      * </ul>
      */
-    public String baseURL;
+    public @Nullable String baseURL;
     /**
      * TLS Client Authentication allows the server to request a client certificate and verify it.
      *
@@ -58,15 +59,15 @@ public interface APIRequest {
      * <p> <strong>NOTE:</strong> When using WebKit on macOS, accessing {@code localhost} will not pick up client certificates. You can make it work by
      * replacing {@code localhost} with {@code local.playwright}.
      */
-    public List<ClientCertificate> clientCertificates;
+    public @Nullable List<ClientCertificate> clientCertificates;
     /**
      * An object containing additional HTTP headers to be sent with every request. Defaults to none.
      */
-    public Map<String, String> extraHTTPHeaders;
+    public @Nullable Map<String, String> extraHTTPHeaders;
     /**
      * Whether to throw on response codes other than 2xx and 3xx. By default response object is returned for all status codes.
      */
-    public Boolean failOnStatusCode;
+    public @Nullable Boolean failOnStatusCode;
     /**
      * Credentials for <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication">HTTP authentication</a>. If
      * no origin is specified, the username and password are sent to any servers upon unauthorized responses.
@@ -74,21 +75,21 @@ public interface APIRequest {
      * <p> Pass an array to use different credentials for different origins. The first entry that matches the request origin is
      * used, and entries with no origin match any request.
      */
-    public Object httpCredentials;
+    public @Nullable Object httpCredentials;
     /**
      * Whether to ignore HTTPS errors when sending network requests. Defaults to {@code false}.
      */
-    public Boolean ignoreHTTPSErrors;
+    public @Nullable Boolean ignoreHTTPSErrors;
     /**
      * Maximum number of request redirects that will be followed automatically. An error will be thrown if the number is
      * exceeded. Defaults to {@code 20}. Pass {@code 0} to not follow redirects. This can be overwritten for each request
      * individually.
      */
-    public Integer maxRedirects;
+    public @Nullable Integer maxRedirects;
     /**
      * Network proxy settings.
      */
-    public Proxy proxy;
+    public @Nullable Proxy proxy;
     /**
      * Populates context with given storage state. This option can be used to initialize context with logged-in information
      * obtained via {@link com.microsoft.playwright.BrowserContext#storageState BrowserContext.storageState()} or {@link
@@ -97,22 +98,22 @@ public interface APIRequest {
      * BrowserContext.storageState()} or {@link com.microsoft.playwright.APIRequestContext#storageState
      * APIRequestContext.storageState()} methods.
      */
-    public String storageState;
+    public @Nullable String storageState;
     /**
      * Populates context with given storage state. This option can be used to initialize context with logged-in information
      * obtained via {@link com.microsoft.playwright.BrowserContext#storageState BrowserContext.storageState()}. Path to the
      * file with saved storage state.
      */
-    public Path storageStatePath;
+    public @Nullable Path storageStatePath;
     /**
      * Maximum time in milliseconds to wait for the response. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable
      * timeout.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
     /**
      * Specific user agent to use in this context.
      */
-    public String userAgent;
+    public @Nullable String userAgent;
 
     /**
      * Methods like {@link com.microsoft.playwright.APIRequestContext#get APIRequestContext.get()} take the base URL into
@@ -277,6 +278,6 @@ public interface APIRequest {
    *
    * @since v1.16
    */
-  APIRequestContext newContext(NewContextOptions options);
+  APIRequestContext newContext(@Nullable NewContextOptions options);
 }
 

--- a/playwright/src/main/java/com/microsoft/playwright/APIRequestContext.java
+++ b/playwright/src/main/java/com/microsoft/playwright/APIRequestContext.java
@@ -16,6 +16,7 @@
 
 package com.microsoft.playwright;
 
+import org.jspecify.annotations.Nullable;
 import com.microsoft.playwright.options.*;
 import java.nio.file.Path;
 
@@ -46,7 +47,7 @@ public interface APIRequestContext {
     /**
      * The reason to be reported to the operations interrupted by the context disposal.
      */
-    public String reason;
+    public @Nullable String reason;
 
     /**
      * The reason to be reported to the operations interrupted by the context disposal.
@@ -60,16 +61,16 @@ public interface APIRequestContext {
     /**
      * Set to {@code true} to include IndexedDB in the storage state snapshot.
      */
-    public Boolean indexedDB;
+    public @Nullable Boolean indexedDB;
     /**
      * Set to {@code true} to include the origin private file system in the storage state snapshot.
      */
-    public Boolean opfs;
+    public @Nullable Boolean opfs;
     /**
      * The file path to save the storage state to. If {@code path} is a relative path, then it is resolved relative to current
      * working directory. If no path is provided, storage state is still returned, but won't be saved to the disk.
      */
-    public Path path;
+    public @Nullable Path path;
 
     /**
      * Set to {@code true} to include IndexedDB in the storage state snapshot.
@@ -114,7 +115,7 @@ public interface APIRequestContext {
    * @param params Optional request parameters.
    * @since v1.16
    */
-  APIResponse delete(String url, RequestOptions params);
+  APIResponse delete(String url, @Nullable RequestOptions params);
   /**
    * All responses returned by {@link com.microsoft.playwright.APIRequestContext#get APIRequestContext.get()} and similar
    * methods are stored in the memory, so that you can later call {@link com.microsoft.playwright.APIResponse#body
@@ -134,7 +135,7 @@ public interface APIRequestContext {
    *
    * @since v1.16
    */
-  void dispose(DisposeOptions options);
+  void dispose(@Nullable DisposeOptions options);
   /**
    * Sends HTTP(S) request and returns its response. The method will populate request cookies from the context and update
    * context cookies from the response. The method will automatically follow redirects.
@@ -207,7 +208,7 @@ public interface APIRequestContext {
    * @param params Optional request parameters.
    * @since v1.16
    */
-  APIResponse fetch(String urlOrRequest, RequestOptions params);
+  APIResponse fetch(String urlOrRequest, @Nullable RequestOptions params);
   /**
    * Sends HTTP(S) request and returns its response. The method will populate request cookies from the context and update
    * context cookies from the response. The method will automatically follow redirects.
@@ -280,7 +281,7 @@ public interface APIRequestContext {
    * @param params Optional request parameters.
    * @since v1.16
    */
-  APIResponse fetch(Request urlOrRequest, RequestOptions params);
+  APIResponse fetch(Request urlOrRequest, @Nullable RequestOptions params);
   /**
    * Sends HTTP(S) <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/GET">GET</a> request and returns its
    * response. The method will populate request cookies from the context and update context cookies from the response. The
@@ -319,7 +320,7 @@ public interface APIRequestContext {
    * @param params Optional request parameters.
    * @since v1.16
    */
-  APIResponse get(String url, RequestOptions params);
+  APIResponse get(String url, @Nullable RequestOptions params);
   /**
    * Sends HTTP(S) <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/HEAD">HEAD</a> request and returns its
    * response. The method will populate request cookies from the context and update context cookies from the response. The
@@ -340,7 +341,7 @@ public interface APIRequestContext {
    * @param params Optional request parameters.
    * @since v1.16
    */
-  APIResponse head(String url, RequestOptions params);
+  APIResponse head(String url, @Nullable RequestOptions params);
   /**
    * Sends HTTP(S) <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/PATCH">PATCH</a> request and returns
    * its response. The method will populate request cookies from the context and update context cookies from the response.
@@ -361,7 +362,7 @@ public interface APIRequestContext {
    * @param params Optional request parameters.
    * @since v1.16
    */
-  APIResponse patch(String url, RequestOptions params);
+  APIResponse patch(String url, @Nullable RequestOptions params);
   /**
    * Sends HTTP(S) <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/POST">POST</a> request and returns its
    * response. The method will populate request cookies from the context and update context cookies from the response. The
@@ -456,7 +457,7 @@ public interface APIRequestContext {
    * @param params Optional request parameters.
    * @since v1.16
    */
-  APIResponse post(String url, RequestOptions params);
+  APIResponse post(String url, @Nullable RequestOptions params);
   /**
    * Sends HTTP(S) <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/PUT">PUT</a> request and returns its
    * response. The method will populate request cookies from the context and update context cookies from the response. The
@@ -477,7 +478,7 @@ public interface APIRequestContext {
    * @param params Optional request parameters.
    * @since v1.16
    */
-  APIResponse put(String url, RequestOptions params);
+  APIResponse put(String url, @Nullable RequestOptions params);
   /**
    * Returns storage state for this request context, contains current cookies and local storage snapshot if it was passed to
    * the constructor.
@@ -493,7 +494,7 @@ public interface APIRequestContext {
    *
    * @since v1.16
    */
-  String storageState(StorageStateOptions options);
+  String storageState(@Nullable StorageStateOptions options);
   /**
    * Tracing recorder for requests made through this API request context.
    *

--- a/playwright/src/main/java/com/microsoft/playwright/APIResponse.java
+++ b/playwright/src/main/java/com/microsoft/playwright/APIResponse.java
@@ -16,6 +16,7 @@
 
 package com.microsoft.playwright;
 
+import org.jspecify.annotations.Nullable;
 import com.microsoft.playwright.options.*;
 import java.util.*;
 
@@ -61,14 +62,14 @@ public interface APIResponse {
    *
    * @since v1.61
    */
-  SecurityDetails securityDetails();
+  @Nullable SecurityDetails securityDetails();
   /**
    * Returns the IP address and port of the server. Resolves to {@code null} if the server address is not available. For
    * redirected requests, returns the information for the last request in the redirect chain.
    *
    * @since v1.61
    */
-  ServerAddr serverAddr();
+  @Nullable ServerAddr serverAddr();
   /**
    * Contains the status code of the response (e.g., 200 for a success).
    *

--- a/playwright/src/main/java/com/microsoft/playwright/Browser.java
+++ b/playwright/src/main/java/com/microsoft/playwright/Browser.java
@@ -16,6 +16,7 @@
 
 package com.microsoft.playwright;
 
+import org.jspecify.annotations.Nullable;
 import com.microsoft.playwright.options.*;
 import java.nio.file.Path;
 import java.util.*;
@@ -69,7 +70,7 @@ public interface Browser extends AutoCloseable {
     /**
      * The reason to be reported to the operations interrupted by the browser closure.
      */
-    public String reason;
+    public @Nullable String reason;
 
     /**
      * The reason to be reported to the operations interrupted by the browser closure.
@@ -83,7 +84,7 @@ public interface Browser extends AutoCloseable {
     /**
      * Whether to automatically download all the attachments. Defaults to {@code true} where all the downloads are accepted.
      */
-    public Boolean acceptDownloads;
+    public @Nullable Boolean acceptDownloads;
     /**
      * When using {@link com.microsoft.playwright.Page#navigate Page.navigate()}, {@link com.microsoft.playwright.Page#route
      * Page.route()}, {@link com.microsoft.playwright.Page#waitForURL Page.waitForURL()}, {@link
@@ -100,11 +101,11 @@ public interface Browser extends AutoCloseable {
      * {@code http://localhost:3000/bar.html}</li>
      * </ul>
      */
-    public String baseURL;
+    public @Nullable String baseURL;
     /**
      * Toggles bypassing page's Content-Security-Policy. Defaults to {@code false}.
      */
-    public Boolean bypassCSP;
+    public @Nullable Boolean bypassCSP;
     /**
      * TLS Client Authentication allows the server to request a client certificate and verify it.
      *
@@ -122,7 +123,7 @@ public interface Browser extends AutoCloseable {
      * <p> <strong>NOTE:</strong> When using WebKit on macOS, accessing {@code localhost} will not pick up client certificates. You can make it work by
      * replacing {@code localhost} with {@code local.playwright}.
      */
-    public List<ClientCertificate> clientCertificates;
+    public @Nullable List<ClientCertificate> clientCertificates;
     /**
      * Emulates <a
      * href="https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme">prefers-colors-scheme</a> media
@@ -130,34 +131,34 @@ public interface Browser extends AutoCloseable {
      * Page.emulateMedia()} for more details. Passing {@code null} resets emulation to system defaults. Defaults to {@code
      * "light"}.
      */
-    public Optional<ColorScheme> colorScheme;
+    public @Nullable Optional<ColorScheme> colorScheme;
     /**
      * Emulates {@code "prefers-contrast"} media feature, supported values are {@code "no-preference"}, {@code "more"}. See
      * {@link com.microsoft.playwright.Page#emulateMedia Page.emulateMedia()} for more details. Passing {@code null} resets
      * emulation to system defaults. Defaults to {@code "no-preference"}.
      */
-    public Optional<Contrast> contrast;
+    public @Nullable Optional<Contrast> contrast;
     /**
      * Specify device scale factor (can be thought of as dpr). Defaults to {@code 1}. Learn more about <a
      * href="https://playwright.dev/java/docs/emulation#devices">emulating devices with device scale factor</a>.
      */
-    public Double deviceScaleFactor;
+    public @Nullable Double deviceScaleFactor;
     /**
      * An object containing additional HTTP headers to be sent with every request. Defaults to none.
      */
-    public Map<String, String> extraHTTPHeaders;
+    public @Nullable Map<String, String> extraHTTPHeaders;
     /**
      * Emulates {@code "forced-colors"} media feature, supported values are {@code "active"}, {@code "none"}. See {@link
      * com.microsoft.playwright.Page#emulateMedia Page.emulateMedia()} for more details. Passing {@code null} resets emulation
      * to system defaults. Defaults to {@code "none"}.
      */
-    public Optional<ForcedColors> forcedColors;
-    public Geolocation geolocation;
+    public @Nullable Optional<ForcedColors> forcedColors;
+    public @Nullable Geolocation geolocation;
     /**
      * Specifies if viewport supports touch events. Defaults to false. Learn more about <a
      * href="https://playwright.dev/java/docs/emulation#devices">mobile emulation</a>.
      */
-    public Boolean hasTouch;
+    public @Nullable Boolean hasTouch;
     /**
      * Credentials for <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication">HTTP authentication</a>. If
      * no origin is specified, the username and password are sent to any servers upon unauthorized responses.
@@ -165,89 +166,89 @@ public interface Browser extends AutoCloseable {
      * <p> Pass an array to use different credentials for different origins. The first entry that matches the request origin is
      * used, and entries with no origin match any request.
      */
-    public Object httpCredentials;
+    public @Nullable Object httpCredentials;
     /**
      * Whether to ignore HTTPS errors when sending network requests. Defaults to {@code false}.
      */
-    public Boolean ignoreHTTPSErrors;
+    public @Nullable Boolean ignoreHTTPSErrors;
     /**
      * Whether the {@code meta viewport} tag is taken into account and touch events are enabled. isMobile is a part of device,
      * so you don't actually need to set it manually. Defaults to {@code false} and is not supported in Firefox. Learn more
      * about <a href="https://playwright.dev/java/docs/emulation#ismobile">mobile emulation</a>.
      */
-    public Boolean isMobile;
+    public @Nullable Boolean isMobile;
     /**
      * Whether or not to enable JavaScript in the context. Defaults to {@code true}. Learn more about <a
      * href="https://playwright.dev/java/docs/emulation#javascript-enabled">disabling JavaScript</a>.
      */
-    public Boolean javaScriptEnabled;
+    public @Nullable Boolean javaScriptEnabled;
     /**
      * Specify user locale, for example {@code en-GB}, {@code de-DE}, etc. Locale will affect {@code navigator.language} value,
      * {@code Accept-Language} request header value as well as number and date formatting rules. Defaults to the system default
      * locale. Learn more about emulation in our <a
      * href="https://playwright.dev/java/docs/emulation#locale--timezone">emulation guide</a>.
      */
-    public String locale;
+    public @Nullable String locale;
     /**
      * Whether to emulate network being offline. Defaults to {@code false}. Learn more about <a
      * href="https://playwright.dev/java/docs/emulation#offline">network emulation</a>.
      */
-    public Boolean offline;
+    public @Nullable Boolean offline;
     /**
      * A list of permissions to grant to all pages in this context. See {@link
      * com.microsoft.playwright.BrowserContext#grantPermissions BrowserContext.grantPermissions()} for more details. Defaults
      * to none.
      */
-    public List<String> permissions;
+    public @Nullable List<String> permissions;
     /**
      * Network proxy settings to use with this context. Defaults to none.
      */
-    public Proxy proxy;
+    public @Nullable Proxy proxy;
     /**
      * Optional setting to control resource content management. If {@code omit} is specified, content is not persisted. If
      * {@code attach} is specified, resources are persisted as separate files and all of these files are archived along with
      * the HAR file. Defaults to {@code embed}, which stores content inline the HAR file as per HAR specification.
      */
-    public HarContentPolicy recordHarContent;
+    public @Nullable HarContentPolicy recordHarContent;
     /**
      * When set to {@code minimal}, only record information necessary for routing from HAR. This omits sizes, timing, page,
      * cookies, security and other types of HAR information that are not used when replaying from HAR. Defaults to {@code
      * full}.
      */
-    public HarMode recordHarMode;
+    public @Nullable HarMode recordHarMode;
     /**
      * Optional setting to control whether to omit request content from the HAR. Defaults to {@code false}.
      */
-    public Boolean recordHarOmitContent;
+    public @Nullable Boolean recordHarOmitContent;
     /**
      * Enables <a href="http://www.softwareishard.com/blog/har-12-spec">HAR</a> recording for all pages into the specified HAR
      * file on the filesystem. If not specified, the HAR is not recorded. Make sure to call {@link
      * com.microsoft.playwright.BrowserContext#close BrowserContext.close()} for the HAR to be saved.
      */
-    public Path recordHarPath;
-    public Object recordHarUrlFilter;
+    public @Nullable Path recordHarPath;
+    public @Nullable Object recordHarUrlFilter;
     /**
      * Enables video recording for all pages into the specified directory. If not specified videos are not recorded. Make sure
      * to call {@link com.microsoft.playwright.BrowserContext#close BrowserContext.close()} for videos to be saved.
      */
-    public Path recordVideoDir;
+    public @Nullable Path recordVideoDir;
     /**
      * Dimensions of the recorded videos. If not specified the size will be equal to {@code viewport} scaled down to fit into
      * 800x800. If {@code viewport} is not configured explicitly the video size defaults to 800x450. Actual picture of each
      * page will be scaled down if necessary to fit the specified size.
      */
-    public RecordVideoSize recordVideoSize;
+    public @Nullable RecordVideoSize recordVideoSize;
     /**
      * Emulates {@code "prefers-reduced-motion"} media feature, supported values are {@code "reduce"}, {@code "no-preference"}.
      * See {@link com.microsoft.playwright.Page#emulateMedia Page.emulateMedia()} for more details. Passing {@code null} resets
      * emulation to system defaults. Defaults to {@code "no-preference"}.
      */
-    public Optional<ReducedMotion> reducedMotion;
+    public @Nullable Optional<ReducedMotion> reducedMotion;
     /**
      * Emulates consistent window screen size available inside web page via {@code window.screen}. Is only used when the {@code
      * viewport} is set.
      */
-    public ScreenSize screenSize;
+    public @Nullable ScreenSize screenSize;
     /**
      * Whether to allow sites to register Service workers. Defaults to {@code "allow"}.
      * <ul>
@@ -256,35 +257,35 @@ public interface Browser extends AutoCloseable {
      * <li> {@code "block"}: Playwright will block all registration of Service Workers.</li>
      * </ul>
      */
-    public ServiceWorkerPolicy serviceWorkers;
+    public @Nullable ServiceWorkerPolicy serviceWorkers;
     /**
      * Populates context with given storage state. This option can be used to initialize context with logged-in information
      * obtained via {@link com.microsoft.playwright.BrowserContext#storageState BrowserContext.storageState()}.
      */
-    public String storageState;
+    public @Nullable String storageState;
     /**
      * Populates context with given storage state. This option can be used to initialize context with logged-in information
      * obtained via {@link com.microsoft.playwright.BrowserContext#storageState BrowserContext.storageState()}. Path to the
      * file with saved storage state.
      */
-    public Path storageStatePath;
+    public @Nullable Path storageStatePath;
     /**
      * If set to true, enables strict selectors mode for this context. In the strict selectors mode all operations on selectors
      * that imply single target DOM element will throw when more than one element matches the selector. This option does not
      * affect any Locator APIs (Locators are always strict). Defaults to {@code false}. See {@code Locator} to learn more about
      * the strict mode.
      */
-    public Boolean strictSelectors;
+    public @Nullable Boolean strictSelectors;
     /**
      * Changes the timezone of the context. See <a
      * href="https://cs.chromium.org/chromium/src/third_party/icu/source/data/misc/metaZones.txt?rcl=faee8bc70570192d82d2978a71e2a615788597d1">ICU's
      * metaZones.txt</a> for a list of supported timezone IDs. Defaults to the system timezone.
      */
-    public String timezoneId;
+    public @Nullable String timezoneId;
     /**
      * Specific user agent to use in this context.
      */
-    public String userAgent;
+    public @Nullable String userAgent;
     /**
      * Emulates consistent viewport for each page. Defaults to an 1280x720 viewport. Use {@code null} to disable the consistent
      * viewport emulation. Learn more about <a href="https://playwright.dev/java/docs/emulation#viewport">viewport
@@ -293,7 +294,7 @@ public interface Browser extends AutoCloseable {
      * <p> <strong>NOTE:</strong> The {@code null} value opts out from the default presets, makes viewport depend on the host window size defined by the
      * operating system. It makes the execution of the tests non-deterministic.
      */
-    public Optional<ViewportSize> viewportSize;
+    public @Nullable Optional<ViewportSize> viewportSize;
 
     /**
      * Whether to automatically download all the attachments. Defaults to {@code true} where all the downloads are accepted.
@@ -357,7 +358,7 @@ public interface Browser extends AutoCloseable {
      * Page.emulateMedia()} for more details. Passing {@code null} resets emulation to system defaults. Defaults to {@code
      * "light"}.
      */
-    public NewContextOptions setColorScheme(ColorScheme colorScheme) {
+    public NewContextOptions setColorScheme(@Nullable ColorScheme colorScheme) {
       this.colorScheme = Optional.ofNullable(colorScheme);
       return this;
     }
@@ -366,7 +367,7 @@ public interface Browser extends AutoCloseable {
      * {@link com.microsoft.playwright.Page#emulateMedia Page.emulateMedia()} for more details. Passing {@code null} resets
      * emulation to system defaults. Defaults to {@code "no-preference"}.
      */
-    public NewContextOptions setContrast(Contrast contrast) {
+    public NewContextOptions setContrast(@Nullable Contrast contrast) {
       this.contrast = Optional.ofNullable(contrast);
       return this;
     }
@@ -390,7 +391,7 @@ public interface Browser extends AutoCloseable {
      * com.microsoft.playwright.Page#emulateMedia Page.emulateMedia()} for more details. Passing {@code null} resets emulation
      * to system defaults. Defaults to {@code "none"}.
      */
-    public NewContextOptions setForcedColors(ForcedColors forcedColors) {
+    public NewContextOptions setForcedColors(@Nullable ForcedColors forcedColors) {
       this.forcedColors = Optional.ofNullable(forcedColors);
       return this;
     }
@@ -577,7 +578,7 @@ public interface Browser extends AutoCloseable {
      * See {@link com.microsoft.playwright.Page#emulateMedia Page.emulateMedia()} for more details. Passing {@code null} resets
      * emulation to system defaults. Defaults to {@code "no-preference"}.
      */
-    public NewContextOptions setReducedMotion(ReducedMotion reducedMotion) {
+    public NewContextOptions setReducedMotion(@Nullable ReducedMotion reducedMotion) {
       this.reducedMotion = Optional.ofNullable(reducedMotion);
       return this;
     }
@@ -670,7 +671,7 @@ public interface Browser extends AutoCloseable {
      * <p> <strong>NOTE:</strong> The {@code null} value opts out from the default presets, makes viewport depend on the host window size defined by the
      * operating system. It makes the execution of the tests non-deterministic.
      */
-    public NewContextOptions setViewportSize(ViewportSize viewportSize) {
+    public NewContextOptions setViewportSize(@Nullable ViewportSize viewportSize) {
       this.viewportSize = Optional.ofNullable(viewportSize);
       return this;
     }
@@ -679,7 +680,7 @@ public interface Browser extends AutoCloseable {
     /**
      * Whether to automatically download all the attachments. Defaults to {@code true} where all the downloads are accepted.
      */
-    public Boolean acceptDownloads;
+    public @Nullable Boolean acceptDownloads;
     /**
      * When using {@link com.microsoft.playwright.Page#navigate Page.navigate()}, {@link com.microsoft.playwright.Page#route
      * Page.route()}, {@link com.microsoft.playwright.Page#waitForURL Page.waitForURL()}, {@link
@@ -696,11 +697,11 @@ public interface Browser extends AutoCloseable {
      * {@code http://localhost:3000/bar.html}</li>
      * </ul>
      */
-    public String baseURL;
+    public @Nullable String baseURL;
     /**
      * Toggles bypassing page's Content-Security-Policy. Defaults to {@code false}.
      */
-    public Boolean bypassCSP;
+    public @Nullable Boolean bypassCSP;
     /**
      * TLS Client Authentication allows the server to request a client certificate and verify it.
      *
@@ -718,7 +719,7 @@ public interface Browser extends AutoCloseable {
      * <p> <strong>NOTE:</strong> When using WebKit on macOS, accessing {@code localhost} will not pick up client certificates. You can make it work by
      * replacing {@code localhost} with {@code local.playwright}.
      */
-    public List<ClientCertificate> clientCertificates;
+    public @Nullable List<ClientCertificate> clientCertificates;
     /**
      * Emulates <a
      * href="https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme">prefers-colors-scheme</a> media
@@ -726,34 +727,34 @@ public interface Browser extends AutoCloseable {
      * Page.emulateMedia()} for more details. Passing {@code null} resets emulation to system defaults. Defaults to {@code
      * "light"}.
      */
-    public Optional<ColorScheme> colorScheme;
+    public @Nullable Optional<ColorScheme> colorScheme;
     /**
      * Emulates {@code "prefers-contrast"} media feature, supported values are {@code "no-preference"}, {@code "more"}. See
      * {@link com.microsoft.playwright.Page#emulateMedia Page.emulateMedia()} for more details. Passing {@code null} resets
      * emulation to system defaults. Defaults to {@code "no-preference"}.
      */
-    public Optional<Contrast> contrast;
+    public @Nullable Optional<Contrast> contrast;
     /**
      * Specify device scale factor (can be thought of as dpr). Defaults to {@code 1}. Learn more about <a
      * href="https://playwright.dev/java/docs/emulation#devices">emulating devices with device scale factor</a>.
      */
-    public Double deviceScaleFactor;
+    public @Nullable Double deviceScaleFactor;
     /**
      * An object containing additional HTTP headers to be sent with every request. Defaults to none.
      */
-    public Map<String, String> extraHTTPHeaders;
+    public @Nullable Map<String, String> extraHTTPHeaders;
     /**
      * Emulates {@code "forced-colors"} media feature, supported values are {@code "active"}, {@code "none"}. See {@link
      * com.microsoft.playwright.Page#emulateMedia Page.emulateMedia()} for more details. Passing {@code null} resets emulation
      * to system defaults. Defaults to {@code "none"}.
      */
-    public Optional<ForcedColors> forcedColors;
-    public Geolocation geolocation;
+    public @Nullable Optional<ForcedColors> forcedColors;
+    public @Nullable Geolocation geolocation;
     /**
      * Specifies if viewport supports touch events. Defaults to false. Learn more about <a
      * href="https://playwright.dev/java/docs/emulation#devices">mobile emulation</a>.
      */
-    public Boolean hasTouch;
+    public @Nullable Boolean hasTouch;
     /**
      * Credentials for <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication">HTTP authentication</a>. If
      * no origin is specified, the username and password are sent to any servers upon unauthorized responses.
@@ -761,89 +762,89 @@ public interface Browser extends AutoCloseable {
      * <p> Pass an array to use different credentials for different origins. The first entry that matches the request origin is
      * used, and entries with no origin match any request.
      */
-    public Object httpCredentials;
+    public @Nullable Object httpCredentials;
     /**
      * Whether to ignore HTTPS errors when sending network requests. Defaults to {@code false}.
      */
-    public Boolean ignoreHTTPSErrors;
+    public @Nullable Boolean ignoreHTTPSErrors;
     /**
      * Whether the {@code meta viewport} tag is taken into account and touch events are enabled. isMobile is a part of device,
      * so you don't actually need to set it manually. Defaults to {@code false} and is not supported in Firefox. Learn more
      * about <a href="https://playwright.dev/java/docs/emulation#ismobile">mobile emulation</a>.
      */
-    public Boolean isMobile;
+    public @Nullable Boolean isMobile;
     /**
      * Whether or not to enable JavaScript in the context. Defaults to {@code true}. Learn more about <a
      * href="https://playwright.dev/java/docs/emulation#javascript-enabled">disabling JavaScript</a>.
      */
-    public Boolean javaScriptEnabled;
+    public @Nullable Boolean javaScriptEnabled;
     /**
      * Specify user locale, for example {@code en-GB}, {@code de-DE}, etc. Locale will affect {@code navigator.language} value,
      * {@code Accept-Language} request header value as well as number and date formatting rules. Defaults to the system default
      * locale. Learn more about emulation in our <a
      * href="https://playwright.dev/java/docs/emulation#locale--timezone">emulation guide</a>.
      */
-    public String locale;
+    public @Nullable String locale;
     /**
      * Whether to emulate network being offline. Defaults to {@code false}. Learn more about <a
      * href="https://playwright.dev/java/docs/emulation#offline">network emulation</a>.
      */
-    public Boolean offline;
+    public @Nullable Boolean offline;
     /**
      * A list of permissions to grant to all pages in this context. See {@link
      * com.microsoft.playwright.BrowserContext#grantPermissions BrowserContext.grantPermissions()} for more details. Defaults
      * to none.
      */
-    public List<String> permissions;
+    public @Nullable List<String> permissions;
     /**
      * Network proxy settings to use with this context. Defaults to none.
      */
-    public Proxy proxy;
+    public @Nullable Proxy proxy;
     /**
      * Optional setting to control resource content management. If {@code omit} is specified, content is not persisted. If
      * {@code attach} is specified, resources are persisted as separate files and all of these files are archived along with
      * the HAR file. Defaults to {@code embed}, which stores content inline the HAR file as per HAR specification.
      */
-    public HarContentPolicy recordHarContent;
+    public @Nullable HarContentPolicy recordHarContent;
     /**
      * When set to {@code minimal}, only record information necessary for routing from HAR. This omits sizes, timing, page,
      * cookies, security and other types of HAR information that are not used when replaying from HAR. Defaults to {@code
      * full}.
      */
-    public HarMode recordHarMode;
+    public @Nullable HarMode recordHarMode;
     /**
      * Optional setting to control whether to omit request content from the HAR. Defaults to {@code false}.
      */
-    public Boolean recordHarOmitContent;
+    public @Nullable Boolean recordHarOmitContent;
     /**
      * Enables <a href="http://www.softwareishard.com/blog/har-12-spec">HAR</a> recording for all pages into the specified HAR
      * file on the filesystem. If not specified, the HAR is not recorded. Make sure to call {@link
      * com.microsoft.playwright.BrowserContext#close BrowserContext.close()} for the HAR to be saved.
      */
-    public Path recordHarPath;
-    public Object recordHarUrlFilter;
+    public @Nullable Path recordHarPath;
+    public @Nullable Object recordHarUrlFilter;
     /**
      * Enables video recording for all pages into the specified directory. If not specified videos are not recorded. Make sure
      * to call {@link com.microsoft.playwright.BrowserContext#close BrowserContext.close()} for videos to be saved.
      */
-    public Path recordVideoDir;
+    public @Nullable Path recordVideoDir;
     /**
      * Dimensions of the recorded videos. If not specified the size will be equal to {@code viewport} scaled down to fit into
      * 800x800. If {@code viewport} is not configured explicitly the video size defaults to 800x450. Actual picture of each
      * page will be scaled down if necessary to fit the specified size.
      */
-    public RecordVideoSize recordVideoSize;
+    public @Nullable RecordVideoSize recordVideoSize;
     /**
      * Emulates {@code "prefers-reduced-motion"} media feature, supported values are {@code "reduce"}, {@code "no-preference"}.
      * See {@link com.microsoft.playwright.Page#emulateMedia Page.emulateMedia()} for more details. Passing {@code null} resets
      * emulation to system defaults. Defaults to {@code "no-preference"}.
      */
-    public Optional<ReducedMotion> reducedMotion;
+    public @Nullable Optional<ReducedMotion> reducedMotion;
     /**
      * Emulates consistent window screen size available inside web page via {@code window.screen}. Is only used when the {@code
      * viewport} is set.
      */
-    public ScreenSize screenSize;
+    public @Nullable ScreenSize screenSize;
     /**
      * Whether to allow sites to register Service workers. Defaults to {@code "allow"}.
      * <ul>
@@ -852,35 +853,35 @@ public interface Browser extends AutoCloseable {
      * <li> {@code "block"}: Playwright will block all registration of Service Workers.</li>
      * </ul>
      */
-    public ServiceWorkerPolicy serviceWorkers;
+    public @Nullable ServiceWorkerPolicy serviceWorkers;
     /**
      * Populates context with given storage state. This option can be used to initialize context with logged-in information
      * obtained via {@link com.microsoft.playwright.BrowserContext#storageState BrowserContext.storageState()}.
      */
-    public String storageState;
+    public @Nullable String storageState;
     /**
      * Populates context with given storage state. This option can be used to initialize context with logged-in information
      * obtained via {@link com.microsoft.playwright.BrowserContext#storageState BrowserContext.storageState()}. Path to the
      * file with saved storage state.
      */
-    public Path storageStatePath;
+    public @Nullable Path storageStatePath;
     /**
      * If set to true, enables strict selectors mode for this context. In the strict selectors mode all operations on selectors
      * that imply single target DOM element will throw when more than one element matches the selector. This option does not
      * affect any Locator APIs (Locators are always strict). Defaults to {@code false}. See {@code Locator} to learn more about
      * the strict mode.
      */
-    public Boolean strictSelectors;
+    public @Nullable Boolean strictSelectors;
     /**
      * Changes the timezone of the context. See <a
      * href="https://cs.chromium.org/chromium/src/third_party/icu/source/data/misc/metaZones.txt?rcl=faee8bc70570192d82d2978a71e2a615788597d1">ICU's
      * metaZones.txt</a> for a list of supported timezone IDs. Defaults to the system timezone.
      */
-    public String timezoneId;
+    public @Nullable String timezoneId;
     /**
      * Specific user agent to use in this context.
      */
-    public String userAgent;
+    public @Nullable String userAgent;
     /**
      * Emulates consistent viewport for each page. Defaults to an 1280x720 viewport. Use {@code null} to disable the consistent
      * viewport emulation. Learn more about <a href="https://playwright.dev/java/docs/emulation#viewport">viewport
@@ -889,7 +890,7 @@ public interface Browser extends AutoCloseable {
      * <p> <strong>NOTE:</strong> The {@code null} value opts out from the default presets, makes viewport depend on the host window size defined by the
      * operating system. It makes the execution of the tests non-deterministic.
      */
-    public Optional<ViewportSize> viewportSize;
+    public @Nullable Optional<ViewportSize> viewportSize;
 
     /**
      * Whether to automatically download all the attachments. Defaults to {@code true} where all the downloads are accepted.
@@ -953,7 +954,7 @@ public interface Browser extends AutoCloseable {
      * Page.emulateMedia()} for more details. Passing {@code null} resets emulation to system defaults. Defaults to {@code
      * "light"}.
      */
-    public NewPageOptions setColorScheme(ColorScheme colorScheme) {
+    public NewPageOptions setColorScheme(@Nullable ColorScheme colorScheme) {
       this.colorScheme = Optional.ofNullable(colorScheme);
       return this;
     }
@@ -962,7 +963,7 @@ public interface Browser extends AutoCloseable {
      * {@link com.microsoft.playwright.Page#emulateMedia Page.emulateMedia()} for more details. Passing {@code null} resets
      * emulation to system defaults. Defaults to {@code "no-preference"}.
      */
-    public NewPageOptions setContrast(Contrast contrast) {
+    public NewPageOptions setContrast(@Nullable Contrast contrast) {
       this.contrast = Optional.ofNullable(contrast);
       return this;
     }
@@ -986,7 +987,7 @@ public interface Browser extends AutoCloseable {
      * com.microsoft.playwright.Page#emulateMedia Page.emulateMedia()} for more details. Passing {@code null} resets emulation
      * to system defaults. Defaults to {@code "none"}.
      */
-    public NewPageOptions setForcedColors(ForcedColors forcedColors) {
+    public NewPageOptions setForcedColors(@Nullable ForcedColors forcedColors) {
       this.forcedColors = Optional.ofNullable(forcedColors);
       return this;
     }
@@ -1173,7 +1174,7 @@ public interface Browser extends AutoCloseable {
      * See {@link com.microsoft.playwright.Page#emulateMedia Page.emulateMedia()} for more details. Passing {@code null} resets
      * emulation to system defaults. Defaults to {@code "no-preference"}.
      */
-    public NewPageOptions setReducedMotion(ReducedMotion reducedMotion) {
+    public NewPageOptions setReducedMotion(@Nullable ReducedMotion reducedMotion) {
       this.reducedMotion = Optional.ofNullable(reducedMotion);
       return this;
     }
@@ -1266,7 +1267,7 @@ public interface Browser extends AutoCloseable {
      * <p> <strong>NOTE:</strong> The {@code null} value opts out from the default presets, makes viewport depend on the host window size defined by the
      * operating system. It makes the execution of the tests non-deterministic.
      */
-    public NewPageOptions setViewportSize(ViewportSize viewportSize) {
+    public NewPageOptions setViewportSize(@Nullable ViewportSize viewportSize) {
       this.viewportSize = Optional.ofNullable(viewportSize);
       return this;
     }
@@ -1275,16 +1276,16 @@ public interface Browser extends AutoCloseable {
     /**
      * Host to bind the web socket server to. When specified, a web socket server is created instead of a named pipe.
      */
-    public String host;
+    public @Nullable String host;
     /**
      * Port to bind the web socket server to. When specified, a web socket server is created instead of a named pipe. Use
      * {@code 0} to let the OS pick an available port.
      */
-    public Integer port;
+    public @Nullable Integer port;
     /**
      * Working directory associated with this browser server.
      */
-    public String workspaceDir;
+    public @Nullable String workspaceDir;
 
     /**
      * Host to bind the web socket server to. When specified, a web socket server is created instead of a named pipe.
@@ -1313,15 +1314,15 @@ public interface Browser extends AutoCloseable {
     /**
      * specify custom categories to use instead of default.
      */
-    public List<String> categories;
+    public @Nullable List<String> categories;
     /**
      * A path to write the trace file to.
      */
-    public Path path;
+    public @Nullable Path path;
     /**
      * captures screenshots in the trace.
      */
-    public Boolean screenshots;
+    public @Nullable Boolean screenshots;
 
     /**
      * specify custom categories to use instead of default.
@@ -1386,7 +1387,7 @@ public interface Browser extends AutoCloseable {
    *
    * @since v1.8
    */
-  void close(CloseOptions options);
+  void close(@Nullable CloseOptions options);
   /**
    * Returns an array of all open browser contexts. In a newly created browser, this will return zero browser contexts.
    *
@@ -1466,7 +1467,7 @@ public interface Browser extends AutoCloseable {
    *
    * @since v1.8
    */
-  BrowserContext newContext(NewContextOptions options);
+  BrowserContext newContext(@Nullable NewContextOptions options);
   /**
    * Creates a new page in a new browser context. Closing this page will close the context as well.
    *
@@ -1490,7 +1491,7 @@ public interface Browser extends AutoCloseable {
    *
    * @since v1.8
    */
-  Page newPage(NewPageOptions options);
+  Page newPage(@Nullable NewPageOptions options);
   /**
    * Binds the browser to a named pipe or web socket, making it available for other clients to connect to.
    *
@@ -1506,7 +1507,7 @@ public interface Browser extends AutoCloseable {
    * @param title Title of the browser server, used for identification.
    * @since v1.59
    */
-  BindResult bind(String title, BindOptions options);
+  BindResult bind(String title, @Nullable BindOptions options);
   /**
    * <strong>NOTE:</strong> This API controls <a href="https://www.chromium.org/developers/how-tos/trace-event-profiling-tool">Chromium Tracing</a>
    * which is a low-level chromium-specific debugging tool. API to control <a
@@ -1528,7 +1529,7 @@ public interface Browser extends AutoCloseable {
    * @param page Optional, if specified, tracing includes screenshots of the given page.
    * @since v1.11
    */
-  default void startTracing(Page page) {
+  default void startTracing(@Nullable Page page) {
     startTracing(page, null);
   }
   /**
@@ -1575,7 +1576,7 @@ public interface Browser extends AutoCloseable {
    * @param page Optional, if specified, tracing includes screenshots of the given page.
    * @since v1.11
    */
-  void startTracing(Page page, StartTracingOptions options);
+  void startTracing(@Nullable Page page, @Nullable StartTracingOptions options);
   /**
    * <strong>NOTE:</strong> This API controls <a href="https://www.chromium.org/developers/how-tos/trace-event-profiling-tool">Chromium Tracing</a>
    * which is a low-level chromium-specific debugging tool. API to control <a

--- a/playwright/src/main/java/com/microsoft/playwright/BrowserContext.java
+++ b/playwright/src/main/java/com/microsoft/playwright/BrowserContext.java
@@ -16,6 +16,7 @@
 
 package com.microsoft.playwright;
 
+import org.jspecify.annotations.Nullable;
 import com.microsoft.playwright.options.*;
 import java.nio.file.Path;
 import java.util.*;
@@ -278,15 +279,15 @@ public interface BrowserContext extends AutoCloseable {
     /**
      * Only removes cookies with the given domain.
      */
-    public Object domain;
+    public @Nullable Object domain;
     /**
      * Only removes cookies with the given name.
      */
-    public Object name;
+    public @Nullable Object name;
     /**
      * Only removes cookies with the given path.
      */
-    public Object path;
+    public @Nullable Object path;
 
     /**
      * Only removes cookies with the given domain.
@@ -335,7 +336,7 @@ public interface BrowserContext extends AutoCloseable {
     /**
      * The reason to be reported to the operations interrupted by the context closure.
      */
-    public String reason;
+    public @Nullable String reason;
 
     /**
      * The reason to be reported to the operations interrupted by the context closure.
@@ -349,7 +350,7 @@ public interface BrowserContext extends AutoCloseable {
     /**
      * The [origin] to grant permissions to, e.g. "https://example.com".
      */
-    public String origin;
+    public @Nullable String origin;
 
     /**
      * The [origin] to grant permissions to, e.g. "https://example.com".
@@ -363,7 +364,7 @@ public interface BrowserContext extends AutoCloseable {
     /**
      * How often a route should be used. By default it will be used every time.
      */
-    public Integer times;
+    public @Nullable Integer times;
 
     /**
      * How often a route should be used. By default it will be used every time.
@@ -382,28 +383,28 @@ public interface BrowserContext extends AutoCloseable {
      *
      * <p> Defaults to abort.
      */
-    public HarNotFound notFound;
+    public @Nullable HarNotFound notFound;
     /**
      * If specified, updates the given HAR with the actual network information instead of serving from file. The file is
      * written to disk when {@link com.microsoft.playwright.BrowserContext#close BrowserContext.close()} is called.
      */
-    public Boolean update;
+    public @Nullable Boolean update;
     /**
      * Optional setting to control resource content management. If {@code attach} is specified, resources are persisted as
      * separate files or entries in the ZIP archive. If {@code embed} is specified, content is stored inline the HAR file.
      */
-    public RouteFromHarUpdateContentPolicy updateContent;
+    public @Nullable RouteFromHarUpdateContentPolicy updateContent;
     /**
      * When set to {@code minimal}, only record information necessary for routing from HAR. This omits sizes, timing, page,
      * cookies, security and other types of HAR information that are not used when replaying from HAR. Defaults to {@code
      * minimal}.
      */
-    public HarMode updateMode;
+    public @Nullable HarMode updateMode;
     /**
      * A glob pattern, regular expression or predicate to match the request URL. Only requests with URL matching the pattern
      * will be served from the HAR file. If not specified, all requests are served from the HAR file.
      */
-    public Object url;
+    public @Nullable Object url;
 
     /**
      * <ul>
@@ -469,13 +470,13 @@ public interface BrowserContext extends AutoCloseable {
      * com.microsoft.playwright.Credentials#install Credentials.install()}), and prevent all real authenticators from working
      * in this context.
      */
-    public Boolean credentials;
+    public @Nullable Boolean credentials;
     /**
      * Set to {@code true} to include <a href="https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API">IndexedDB</a> in
      * the storage state snapshot. If your application uses IndexedDB to store authentication tokens, like Firebase
      * Authentication, enable this.
      */
-    public Boolean indexedDB;
+    public @Nullable Boolean indexedDB;
     /**
      * Set to {@code true} to include the <a
      * href="https://developer.mozilla.org/en-US/docs/Web/API/File_System_API/Origin_private_file_system">origin private file
@@ -483,12 +484,12 @@ public interface BrowserContext extends AutoCloseable {
      *
      * <p> <strong>NOTE:</strong> OPFS is currently not supported in ephemeral WebKit contexts.
      */
-    public Boolean opfs;
+    public @Nullable Boolean opfs;
     /**
      * The file path to save the storage state to. If {@code path} is a relative path, then it is resolved relative to current
      * working directory. If no path is provided, storage state is still returned, but won't be saved to the disk.
      */
-    public Path path;
+    public @Nullable Path path;
 
     /**
      * Set to {@code true} to include the context's virtual WebAuthn {@link com.microsoft.playwright.BrowserContext#credentials
@@ -539,7 +540,7 @@ public interface BrowserContext extends AutoCloseable {
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * Maximum time to wait for in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The
@@ -556,13 +557,13 @@ public interface BrowserContext extends AutoCloseable {
     /**
      * Receives the {@code ConsoleMessage} object and resolves to truthy value when the waiting should resolve.
      */
-    public Predicate<ConsoleMessage> predicate;
+    public @Nullable Predicate<ConsoleMessage> predicate;
     /**
      * Maximum time to wait for in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The
      * default value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
      * BrowserContext.setDefaultTimeout()}.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * Receives the {@code ConsoleMessage} object and resolves to truthy value when the waiting should resolve.
@@ -585,13 +586,13 @@ public interface BrowserContext extends AutoCloseable {
     /**
      * Receives the {@code Page} object and resolves to truthy value when the waiting should resolve.
      */
-    public Predicate<Page> predicate;
+    public @Nullable Predicate<Page> predicate;
     /**
      * Maximum time to wait for in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The
      * default value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
      * BrowserContext.setDefaultTimeout()}.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * Receives the {@code Page} object and resolves to truthy value when the waiting should resolve.
@@ -707,7 +708,7 @@ public interface BrowserContext extends AutoCloseable {
    *
    * @since v1.8
    */
-  Browser browser();
+  @Nullable Browser browser();
   /**
    * Removes cookies from context. Accepts optional filter.
    *
@@ -743,7 +744,7 @@ public interface BrowserContext extends AutoCloseable {
    *
    * @since v1.8
    */
-  void clearCookies(ClearCookiesOptions options);
+  void clearCookies(@Nullable ClearCookiesOptions options);
   /**
    * Clears all permission overrides for the browser context.
    *
@@ -775,7 +776,7 @@ public interface BrowserContext extends AutoCloseable {
    *
    * @since v1.8
    */
-  void close(CloseOptions options);
+  void close(@Nullable CloseOptions options);
   /**
    * If no URLs are specified, this method returns all cookies. If URLs are specified, only cookies that affect those URLs
    * are returned.
@@ -792,7 +793,7 @@ public interface BrowserContext extends AutoCloseable {
    * @param urls Optional list of URLs.
    * @since v1.8
    */
-  List<Cookie> cookies(String urls);
+  List<Cookie> cookies(@Nullable String urls);
   /**
    * If no URLs are specified, this method returns all cookies. If URLs are specified, only cookies that affect those URLs
    * are returned.
@@ -800,7 +801,7 @@ public interface BrowserContext extends AutoCloseable {
    * @param urls Optional list of URLs.
    * @since v1.8
    */
-  List<Cookie> cookies(List<String> urls);
+  List<Cookie> cookies(@Nullable List<String> urls);
   /**
    * The method adds a function called {@code name} on the {@code window} object of every frame in every page in the context.
    * When called, the function executes {@code callback} and returns a <a
@@ -972,7 +973,7 @@ public interface BrowserContext extends AutoCloseable {
    * </ul>
    * @since v1.8
    */
-  void grantPermissions(List<String> permissions, GrantPermissionsOptions options);
+  void grantPermissions(List<String> permissions, @Nullable GrantPermissionsOptions options);
   /**
    * Indicates that the browser context is in the process of closing or has already been closed.
    *
@@ -1126,7 +1127,7 @@ public interface BrowserContext extends AutoCloseable {
    * @param handler handler function to route the request.
    * @since v1.8
    */
-  AutoCloseable route(String url, Consumer<Route> handler, RouteOptions options);
+  AutoCloseable route(String url, Consumer<Route> handler, @Nullable RouteOptions options);
   /**
    * Routing provides the capability to modify network requests that are made by any page in the browser context. Once route
    * is enabled, every request matching the url pattern will stall unless it's continued, fulfilled or aborted.
@@ -1236,7 +1237,7 @@ public interface BrowserContext extends AutoCloseable {
    * @param handler handler function to route the request.
    * @since v1.8
    */
-  AutoCloseable route(Pattern url, Consumer<Route> handler, RouteOptions options);
+  AutoCloseable route(Pattern url, Consumer<Route> handler, @Nullable RouteOptions options);
   /**
    * Routing provides the capability to modify network requests that are made by any page in the browser context. Once route
    * is enabled, every request matching the url pattern will stall unless it's continued, fulfilled or aborted.
@@ -1346,7 +1347,7 @@ public interface BrowserContext extends AutoCloseable {
    * @param handler handler function to route the request.
    * @since v1.8
    */
-  AutoCloseable route(Predicate<String> url, Consumer<Route> handler, RouteOptions options);
+  AutoCloseable route(Predicate<String> url, Consumer<Route> handler, @Nullable RouteOptions options);
   /**
    * If specified the network requests that are made in the context will be served from the HAR file. Read more about <a
    * href="https://playwright.dev/java/docs/mock#replaying-from-har">Replaying from HAR</a>.
@@ -1374,7 +1375,7 @@ public interface BrowserContext extends AutoCloseable {
    * path} is a relative path, then it is resolved relative to the current working directory.
    * @since v1.23
    */
-  void routeFromHAR(Path har, RouteFromHAROptions options);
+  void routeFromHAR(Path har, @Nullable RouteFromHAROptions options);
   /**
    * This method allows to modify websocket connections that are made by any page in the browser context.
    *
@@ -1513,7 +1514,7 @@ public interface BrowserContext extends AutoCloseable {
    *
    * @since v1.8
    */
-  void setGeolocation(Geolocation geolocation);
+  void setGeolocation(@Nullable Geolocation geolocation);
   /**
    *
    *
@@ -1536,7 +1537,7 @@ public interface BrowserContext extends AutoCloseable {
    *
    * @since v1.8
    */
-  String storageState(StorageStateOptions options);
+  String storageState(@Nullable StorageStateOptions options);
   /**
    * Clears the existing cookies, local storage, IndexedDB entries, origin private file system entries and virtual WebAuthn
    * credentials, and sets the new storage state. When the storage state contains credentials, the virtual WebAuthn
@@ -1589,7 +1590,7 @@ public interface BrowserContext extends AutoCloseable {
    * BrowserContext.route()}.
    * @since v1.8
    */
-  void unroute(String url, Consumer<Route> handler);
+  void unroute(String url, @Nullable Consumer<Route> handler);
   /**
    * Removes a route created with {@link com.microsoft.playwright.BrowserContext#route BrowserContext.route()}. When {@code
    * handler} is not specified, removes all routes for the {@code url}.
@@ -1611,7 +1612,7 @@ public interface BrowserContext extends AutoCloseable {
    * BrowserContext.route()}.
    * @since v1.8
    */
-  void unroute(Pattern url, Consumer<Route> handler);
+  void unroute(Pattern url, @Nullable Consumer<Route> handler);
   /**
    * Removes a route created with {@link com.microsoft.playwright.BrowserContext#route BrowserContext.route()}. When {@code
    * handler} is not specified, removes all routes for the {@code url}.
@@ -1633,7 +1634,7 @@ public interface BrowserContext extends AutoCloseable {
    * BrowserContext.route()}.
    * @since v1.8
    */
-  void unroute(Predicate<String> url, Consumer<Route> handler);
+  void unroute(Predicate<String> url, @Nullable Consumer<Route> handler);
   /**
    * The method will block until the condition returns true. All Playwright events will be dispatched while the method is
    * waiting for the condition.
@@ -1681,7 +1682,7 @@ public interface BrowserContext extends AutoCloseable {
    * @param condition Condition to wait for.
    * @since v1.32
    */
-  void waitForCondition(BooleanSupplier condition, WaitForConditionOptions options);
+  void waitForCondition(BooleanSupplier condition, @Nullable WaitForConditionOptions options);
   /**
    * Performs action and waits for a {@code ConsoleMessage} to be logged by in the pages in the context. If predicate is
    * provided, it passes {@code ConsoleMessage} value into the {@code predicate} function and waits for {@code
@@ -1703,7 +1704,7 @@ public interface BrowserContext extends AutoCloseable {
    * @param callback Callback that performs the action triggering the event.
    * @since v1.34
    */
-  ConsoleMessage waitForConsoleMessage(WaitForConsoleMessageOptions options, Runnable callback);
+  ConsoleMessage waitForConsoleMessage(@Nullable WaitForConsoleMessageOptions options, Runnable callback);
   /**
    * Performs action and waits for a new {@code Page} to be created in the context. If predicate is provided, it passes
    * {@code Page} value into the {@code predicate} function and waits for {@code predicate(event)} to return a truthy value.
@@ -1723,6 +1724,6 @@ public interface BrowserContext extends AutoCloseable {
    * @param callback Callback that performs the action triggering the event.
    * @since v1.9
    */
-  Page waitForPage(WaitForPageOptions options, Runnable callback);
+  Page waitForPage(@Nullable WaitForPageOptions options, Runnable callback);
 }
 

--- a/playwright/src/main/java/com/microsoft/playwright/BrowserType.java
+++ b/playwright/src/main/java/com/microsoft/playwright/BrowserType.java
@@ -16,6 +16,7 @@
 
 package com.microsoft.playwright;
 
+import org.jspecify.annotations.Nullable;
 import com.microsoft.playwright.options.*;
 import java.nio.file.Path;
 import java.util.*;
@@ -62,20 +63,20 @@ public interface BrowserType {
      * <li> {@code "*.test.internal-domain,*.staging.internal-domain,<loopback>"} to expose test/staging deployments and localhost.</li>
      * </ol>
      */
-    public String exposeNetwork;
+    public @Nullable String exposeNetwork;
     /**
      * Additional HTTP headers to be sent with web socket connect request. Optional.
      */
-    public Map<String, String> headers;
+    public @Nullable Map<String, String> headers;
     /**
      * Slows down Playwright operations by the specified amount of milliseconds. Useful so that you can see what is going on.
      * Defaults to 0.
      */
-    public Double slowMo;
+    public @Nullable Double slowMo;
     /**
      * Maximum time in milliseconds to wait for the connection to be established. Defaults to {@code 0} (no timeout).
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * This option exposes network available on the connecting client to the browser being connected to. Consists of a list of
@@ -127,16 +128,16 @@ public interface BrowserType {
     /**
      * If specified, browser artifacts (such as traces and downloads) are saved into this directory.
      */
-    public Path artifactsDir;
+    public @Nullable Path artifactsDir;
     /**
      * Additional HTTP headers to be sent with connect request. Optional.
      */
-    public Map<String, String> headers;
+    public @Nullable Map<String, String> headers;
     /**
      * Tells Playwright that it runs on the same host as the CDP server. It will enable certain optimizations that rely upon
      * the file system being the same between Playwright and the Browser.
      */
-    public Boolean isLocal;
+    public @Nullable Boolean isLocal;
     /**
      * When true, Playwright will not apply its default overrides to the existing default browser context. Specifically, {@code
      * acceptDownloads} is left at the browser's setting, focus emulation is not enabled, and media emulation options (such as
@@ -145,17 +146,17 @@ public interface BrowserType {
      * contexts created via {@link com.microsoft.playwright.Browser#newContext Browser.newContext()} are not affected. Defaults
      * to {@code false}.
      */
-    public Boolean noDefaults;
+    public @Nullable Boolean noDefaults;
     /**
      * Slows down Playwright operations by the specified amount of milliseconds. Useful so that you can see what is going on.
      * Defaults to 0.
      */
-    public Double slowMo;
+    public @Nullable Double slowMo;
     /**
      * Maximum time in milliseconds to wait for the connection to be established. Defaults to {@code 30000} (30 seconds). Pass
      * {@code 0} to disable timeout.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * If specified, browser artifacts (such as traces and downloads) are saved into this directory.
@@ -215,13 +216,13 @@ public interface BrowserType {
      * <p> Additional arguments to pass to the browser instance. The list of Chromium flags can be found <a
      * href="https://peter.sh/experiments/chromium-command-line-switches/">here</a>.
      */
-    public List<String> args;
+    public @Nullable List<String> args;
     /**
      * If specified, artifacts (traces, videos, downloads, HAR files, etc.) are saved into this directory. The directory is not
      * cleaned up when the browser closes. If not specified, a temporary directory is used and cleaned up when the browser
      * closes.
      */
-    public Path artifactsDir;
+    public @Nullable Path artifactsDir;
     /**
      * Browser distribution channel.
      *
@@ -232,27 +233,27 @@ public interface BrowserType {
      * use branded <a href="https://playwright.dev/java/docs/browsers#google-chrome--microsoft-edge">Google Chrome and
      * Microsoft Edge</a>.
      */
-    public Object channel;
+    public @Nullable Object channel;
     /**
      * Enable Chromium sandboxing. Defaults to {@code false}.
      */
-    public Boolean chromiumSandbox;
+    public @Nullable Boolean chromiumSandbox;
     /**
      * If specified, accepted downloads are downloaded into this directory. Otherwise, temporary directory is created and is
      * deleted when browser is closed. In either case, the downloads are deleted when the browser context they were created in
      * is closed.
      */
-    public Path downloadsPath;
+    public @Nullable Path downloadsPath;
     /**
      * Specify environment variables that will be visible to the browser. Defaults to {@code process.env}.
      */
-    public Map<String, String> env;
+    public @Nullable Map<String, String> env;
     /**
      * Path to a browser executable to run instead of the bundled one. If {@code executablePath} is a relative path, then it is
      * resolved relative to the current working directory. Note that Playwright only works with the bundled Chromium, Firefox
      * or WebKit, use at your own risk.
      */
-    public Path executablePath;
+    public @Nullable Path executablePath;
     /**
      * Firefox user preferences. Learn more about the Firefox user preferences at <a
      * href="https://support.mozilla.org/en-US/kb/about-config-editor-firefox">{@code about:config}</a>.
@@ -260,52 +261,52 @@ public interface BrowserType {
      * <p> You can also provide a path to a custom <a href="https://mozilla.github.io/policy-templates/">{@code policies.json}
      * file</a> via {@code PLAYWRIGHT_FIREFOX_POLICIES_JSON} environment variable.
      */
-    public Map<String, Object> firefoxUserPrefs;
+    public @Nullable Map<String, Object> firefoxUserPrefs;
     /**
      * Close the browser process on SIGHUP. Defaults to {@code true}.
      */
-    public Boolean handleSIGHUP;
+    public @Nullable Boolean handleSIGHUP;
     /**
      * Close the browser process on Ctrl-C. Defaults to {@code true}.
      */
-    public Boolean handleSIGINT;
+    public @Nullable Boolean handleSIGINT;
     /**
      * Close the browser process on SIGTERM. Defaults to {@code true}.
      */
-    public Boolean handleSIGTERM;
+    public @Nullable Boolean handleSIGTERM;
     /**
      * Whether to run browser in headless mode. More details for <a
      * href="https://developers.google.com/web/updates/2017/04/headless-chrome">Chromium</a> and <a
      * href="https://hacks.mozilla.org/2017/12/using-headless-mode-in-firefox/">Firefox</a>. Defaults to {@code true}.
      */
-    public Boolean headless;
+    public @Nullable Boolean headless;
     /**
      * If {@code true}, Playwright does not pass its own configurations args and only uses the ones from {@code args}.
      * Dangerous option; use with care. Defaults to {@code false}.
      */
-    public Boolean ignoreAllDefaultArgs;
+    public @Nullable Boolean ignoreAllDefaultArgs;
     /**
      * If {@code true}, Playwright does not pass its own configurations args and only uses the ones from {@code args}.
      * Dangerous option; use with care.
      */
-    public List<String> ignoreDefaultArgs;
+    public @Nullable List<String> ignoreDefaultArgs;
     /**
      * Network proxy settings.
      */
-    public Proxy proxy;
+    public @Nullable Proxy proxy;
     /**
      * Slows down Playwright operations by the specified amount of milliseconds. Useful so that you can see what is going on.
      */
-    public Double slowMo;
+    public @Nullable Double slowMo;
     /**
      * Maximum time in milliseconds to wait for the browser instance to start. Defaults to {@code 30000} (30 seconds). Pass
      * {@code 0} to disable timeout.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
     /**
      * If specified, traces are saved into this directory.
      */
-    public Path tracesDir;
+    public @Nullable Path tracesDir;
 
     /**
      * <strong>NOTE:</strong> Use custom browser args at your own risk, as some of them may break Playwright functionality.
@@ -484,20 +485,20 @@ public interface BrowserType {
     /**
      * Whether to automatically download all the attachments. Defaults to {@code true} where all the downloads are accepted.
      */
-    public Boolean acceptDownloads;
+    public @Nullable Boolean acceptDownloads;
     /**
      * <strong>NOTE:</strong> Use custom browser args at your own risk, as some of them may break Playwright functionality.
      *
      * <p> Additional arguments to pass to the browser instance. The list of Chromium flags can be found <a
      * href="https://peter.sh/experiments/chromium-command-line-switches/">here</a>.
      */
-    public List<String> args;
+    public @Nullable List<String> args;
     /**
      * If specified, artifacts (traces, videos, downloads, HAR files, etc.) are saved into this directory. The directory is not
      * cleaned up when the browser closes. If not specified, a temporary directory is used and cleaned up when the browser
      * closes.
      */
-    public Path artifactsDir;
+    public @Nullable Path artifactsDir;
     /**
      * When using {@link com.microsoft.playwright.Page#navigate Page.navigate()}, {@link com.microsoft.playwright.Page#route
      * Page.route()}, {@link com.microsoft.playwright.Page#waitForURL Page.waitForURL()}, {@link
@@ -514,11 +515,11 @@ public interface BrowserType {
      * {@code http://localhost:3000/bar.html}</li>
      * </ul>
      */
-    public String baseURL;
+    public @Nullable String baseURL;
     /**
      * Toggles bypassing page's Content-Security-Policy. Defaults to {@code false}.
      */
-    public Boolean bypassCSP;
+    public @Nullable Boolean bypassCSP;
     /**
      * Browser distribution channel.
      *
@@ -529,11 +530,11 @@ public interface BrowserType {
      * use branded <a href="https://playwright.dev/java/docs/browsers#google-chrome--microsoft-edge">Google Chrome and
      * Microsoft Edge</a>.
      */
-    public Object channel;
+    public @Nullable Object channel;
     /**
      * Enable Chromium sandboxing. Defaults to {@code false}.
      */
-    public Boolean chromiumSandbox;
+    public @Nullable Boolean chromiumSandbox;
     /**
      * TLS Client Authentication allows the server to request a client certificate and verify it.
      *
@@ -551,7 +552,7 @@ public interface BrowserType {
      * <p> <strong>NOTE:</strong> When using WebKit on macOS, accessing {@code localhost} will not pick up client certificates. You can make it work by
      * replacing {@code localhost} with {@code local.playwright}.
      */
-    public List<ClientCertificate> clientCertificates;
+    public @Nullable List<ClientCertificate> clientCertificates;
     /**
      * Emulates <a
      * href="https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme">prefers-colors-scheme</a> media
@@ -559,38 +560,38 @@ public interface BrowserType {
      * Page.emulateMedia()} for more details. Passing {@code null} resets emulation to system defaults. Defaults to {@code
      * "light"}.
      */
-    public Optional<ColorScheme> colorScheme;
+    public @Nullable Optional<ColorScheme> colorScheme;
     /**
      * Emulates {@code "prefers-contrast"} media feature, supported values are {@code "no-preference"}, {@code "more"}. See
      * {@link com.microsoft.playwright.Page#emulateMedia Page.emulateMedia()} for more details. Passing {@code null} resets
      * emulation to system defaults. Defaults to {@code "no-preference"}.
      */
-    public Optional<Contrast> contrast;
+    public @Nullable Optional<Contrast> contrast;
     /**
      * Specify device scale factor (can be thought of as dpr). Defaults to {@code 1}. Learn more about <a
      * href="https://playwright.dev/java/docs/emulation#devices">emulating devices with device scale factor</a>.
      */
-    public Double deviceScaleFactor;
+    public @Nullable Double deviceScaleFactor;
     /**
      * If specified, accepted downloads are downloaded into this directory. Otherwise, temporary directory is created and is
      * deleted when browser is closed. In either case, the downloads are deleted when the browser context they were created in
      * is closed.
      */
-    public Path downloadsPath;
+    public @Nullable Path downloadsPath;
     /**
      * Specify environment variables that will be visible to the browser. Defaults to {@code process.env}.
      */
-    public Map<String, String> env;
+    public @Nullable Map<String, String> env;
     /**
      * Path to a browser executable to run instead of the bundled one. If {@code executablePath} is a relative path, then it is
      * resolved relative to the current working directory. Note that Playwright only works with the bundled Chromium, Firefox
      * or WebKit, use at your own risk.
      */
-    public Path executablePath;
+    public @Nullable Path executablePath;
     /**
      * An object containing additional HTTP headers to be sent with every request. Defaults to none.
      */
-    public Map<String, String> extraHTTPHeaders;
+    public @Nullable Map<String, String> extraHTTPHeaders;
     /**
      * Firefox user preferences. Learn more about the Firefox user preferences at <a
      * href="https://support.mozilla.org/en-US/kb/about-config-editor-firefox">{@code about:config}</a>.
@@ -598,37 +599,37 @@ public interface BrowserType {
      * <p> You can also provide a path to a custom <a href="https://mozilla.github.io/policy-templates/">{@code policies.json}
      * file</a> via {@code PLAYWRIGHT_FIREFOX_POLICIES_JSON} environment variable.
      */
-    public Map<String, Object> firefoxUserPrefs;
+    public @Nullable Map<String, Object> firefoxUserPrefs;
     /**
      * Emulates {@code "forced-colors"} media feature, supported values are {@code "active"}, {@code "none"}. See {@link
      * com.microsoft.playwright.Page#emulateMedia Page.emulateMedia()} for more details. Passing {@code null} resets emulation
      * to system defaults. Defaults to {@code "none"}.
      */
-    public Optional<ForcedColors> forcedColors;
-    public Geolocation geolocation;
+    public @Nullable Optional<ForcedColors> forcedColors;
+    public @Nullable Geolocation geolocation;
     /**
      * Close the browser process on SIGHUP. Defaults to {@code true}.
      */
-    public Boolean handleSIGHUP;
+    public @Nullable Boolean handleSIGHUP;
     /**
      * Close the browser process on Ctrl-C. Defaults to {@code true}.
      */
-    public Boolean handleSIGINT;
+    public @Nullable Boolean handleSIGINT;
     /**
      * Close the browser process on SIGTERM. Defaults to {@code true}.
      */
-    public Boolean handleSIGTERM;
+    public @Nullable Boolean handleSIGTERM;
     /**
      * Specifies if viewport supports touch events. Defaults to false. Learn more about <a
      * href="https://playwright.dev/java/docs/emulation#devices">mobile emulation</a>.
      */
-    public Boolean hasTouch;
+    public @Nullable Boolean hasTouch;
     /**
      * Whether to run browser in headless mode. More details for <a
      * href="https://developers.google.com/web/updates/2017/04/headless-chrome">Chromium</a> and <a
      * href="https://hacks.mozilla.org/2017/12/using-headless-mode-in-firefox/">Firefox</a>. Defaults to {@code true}.
      */
-    public Boolean headless;
+    public @Nullable Boolean headless;
     /**
      * Credentials for <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication">HTTP authentication</a>. If
      * no origin is specified, the username and password are sent to any servers upon unauthorized responses.
@@ -636,99 +637,99 @@ public interface BrowserType {
      * <p> Pass an array to use different credentials for different origins. The first entry that matches the request origin is
      * used, and entries with no origin match any request.
      */
-    public Object httpCredentials;
+    public @Nullable Object httpCredentials;
     /**
      * If {@code true}, Playwright does not pass its own configurations args and only uses the ones from {@code args}.
      * Dangerous option; use with care. Defaults to {@code false}.
      */
-    public Boolean ignoreAllDefaultArgs;
+    public @Nullable Boolean ignoreAllDefaultArgs;
     /**
      * If {@code true}, Playwright does not pass its own configurations args and only uses the ones from {@code args}.
      * Dangerous option; use with care.
      */
-    public List<String> ignoreDefaultArgs;
+    public @Nullable List<String> ignoreDefaultArgs;
     /**
      * Whether to ignore HTTPS errors when sending network requests. Defaults to {@code false}.
      */
-    public Boolean ignoreHTTPSErrors;
+    public @Nullable Boolean ignoreHTTPSErrors;
     /**
      * Whether the {@code meta viewport} tag is taken into account and touch events are enabled. isMobile is a part of device,
      * so you don't actually need to set it manually. Defaults to {@code false} and is not supported in Firefox. Learn more
      * about <a href="https://playwright.dev/java/docs/emulation#ismobile">mobile emulation</a>.
      */
-    public Boolean isMobile;
+    public @Nullable Boolean isMobile;
     /**
      * Whether or not to enable JavaScript in the context. Defaults to {@code true}. Learn more about <a
      * href="https://playwright.dev/java/docs/emulation#javascript-enabled">disabling JavaScript</a>.
      */
-    public Boolean javaScriptEnabled;
+    public @Nullable Boolean javaScriptEnabled;
     /**
      * Specify user locale, for example {@code en-GB}, {@code de-DE}, etc. Locale will affect {@code navigator.language} value,
      * {@code Accept-Language} request header value as well as number and date formatting rules. Defaults to the system default
      * locale. Learn more about emulation in our <a
      * href="https://playwright.dev/java/docs/emulation#locale--timezone">emulation guide</a>.
      */
-    public String locale;
+    public @Nullable String locale;
     /**
      * Whether to emulate network being offline. Defaults to {@code false}. Learn more about <a
      * href="https://playwright.dev/java/docs/emulation#offline">network emulation</a>.
      */
-    public Boolean offline;
+    public @Nullable Boolean offline;
     /**
      * A list of permissions to grant to all pages in this context. See {@link
      * com.microsoft.playwright.BrowserContext#grantPermissions BrowserContext.grantPermissions()} for more details. Defaults
      * to none.
      */
-    public List<String> permissions;
+    public @Nullable List<String> permissions;
     /**
      * Network proxy settings.
      */
-    public Proxy proxy;
+    public @Nullable Proxy proxy;
     /**
      * Optional setting to control resource content management. If {@code omit} is specified, content is not persisted. If
      * {@code attach} is specified, resources are persisted as separate files and all of these files are archived along with
      * the HAR file. Defaults to {@code embed}, which stores content inline the HAR file as per HAR specification.
      */
-    public HarContentPolicy recordHarContent;
+    public @Nullable HarContentPolicy recordHarContent;
     /**
      * When set to {@code minimal}, only record information necessary for routing from HAR. This omits sizes, timing, page,
      * cookies, security and other types of HAR information that are not used when replaying from HAR. Defaults to {@code
      * full}.
      */
-    public HarMode recordHarMode;
+    public @Nullable HarMode recordHarMode;
     /**
      * Optional setting to control whether to omit request content from the HAR. Defaults to {@code false}.
      */
-    public Boolean recordHarOmitContent;
+    public @Nullable Boolean recordHarOmitContent;
     /**
      * Enables <a href="http://www.softwareishard.com/blog/har-12-spec">HAR</a> recording for all pages into the specified HAR
      * file on the filesystem. If not specified, the HAR is not recorded. Make sure to call {@link
      * com.microsoft.playwright.BrowserContext#close BrowserContext.close()} for the HAR to be saved.
      */
-    public Path recordHarPath;
-    public Object recordHarUrlFilter;
+    public @Nullable Path recordHarPath;
+    public @Nullable Object recordHarUrlFilter;
     /**
      * Enables video recording for all pages into the specified directory. If not specified videos are not recorded. Make sure
      * to call {@link com.microsoft.playwright.BrowserContext#close BrowserContext.close()} for videos to be saved.
      */
-    public Path recordVideoDir;
+    public @Nullable Path recordVideoDir;
     /**
      * Dimensions of the recorded videos. If not specified the size will be equal to {@code viewport} scaled down to fit into
      * 800x800. If {@code viewport} is not configured explicitly the video size defaults to 800x450. Actual picture of each
      * page will be scaled down if necessary to fit the specified size.
      */
-    public RecordVideoSize recordVideoSize;
+    public @Nullable RecordVideoSize recordVideoSize;
     /**
      * Emulates {@code "prefers-reduced-motion"} media feature, supported values are {@code "reduce"}, {@code "no-preference"}.
      * See {@link com.microsoft.playwright.Page#emulateMedia Page.emulateMedia()} for more details. Passing {@code null} resets
      * emulation to system defaults. Defaults to {@code "no-preference"}.
      */
-    public Optional<ReducedMotion> reducedMotion;
+    public @Nullable Optional<ReducedMotion> reducedMotion;
     /**
      * Emulates consistent window screen size available inside web page via {@code window.screen}. Is only used when the {@code
      * viewport} is set.
      */
-    public ScreenSize screenSize;
+    public @Nullable ScreenSize screenSize;
     /**
      * Whether to allow sites to register Service workers. Defaults to {@code "allow"}.
      * <ul>
@@ -737,37 +738,37 @@ public interface BrowserType {
      * <li> {@code "block"}: Playwright will block all registration of Service Workers.</li>
      * </ul>
      */
-    public ServiceWorkerPolicy serviceWorkers;
+    public @Nullable ServiceWorkerPolicy serviceWorkers;
     /**
      * Slows down Playwright operations by the specified amount of milliseconds. Useful so that you can see what is going on.
      */
-    public Double slowMo;
+    public @Nullable Double slowMo;
     /**
      * If set to true, enables strict selectors mode for this context. In the strict selectors mode all operations on selectors
      * that imply single target DOM element will throw when more than one element matches the selector. This option does not
      * affect any Locator APIs (Locators are always strict). Defaults to {@code false}. See {@code Locator} to learn more about
      * the strict mode.
      */
-    public Boolean strictSelectors;
+    public @Nullable Boolean strictSelectors;
     /**
      * Maximum time in milliseconds to wait for the browser instance to start. Defaults to {@code 30000} (30 seconds). Pass
      * {@code 0} to disable timeout.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
     /**
      * Changes the timezone of the context. See <a
      * href="https://cs.chromium.org/chromium/src/third_party/icu/source/data/misc/metaZones.txt?rcl=faee8bc70570192d82d2978a71e2a615788597d1">ICU's
      * metaZones.txt</a> for a list of supported timezone IDs. Defaults to the system timezone.
      */
-    public String timezoneId;
+    public @Nullable String timezoneId;
     /**
      * If specified, traces are saved into this directory.
      */
-    public Path tracesDir;
+    public @Nullable Path tracesDir;
     /**
      * Specific user agent to use in this context.
      */
-    public String userAgent;
+    public @Nullable String userAgent;
     /**
      * Emulates consistent viewport for each page. Defaults to an 1280x720 viewport. Use {@code null} to disable the consistent
      * viewport emulation. Learn more about <a href="https://playwright.dev/java/docs/emulation#viewport">viewport
@@ -776,7 +777,7 @@ public interface BrowserType {
      * <p> <strong>NOTE:</strong> The {@code null} value opts out from the default presets, makes viewport depend on the host window size defined by the
      * operating system. It makes the execution of the tests non-deterministic.
      */
-    public Optional<ViewportSize> viewportSize;
+    public @Nullable Optional<ViewportSize> viewportSize;
 
     /**
      * Whether to automatically download all the attachments. Defaults to {@code true} where all the downloads are accepted.
@@ -895,7 +896,7 @@ public interface BrowserType {
      * Page.emulateMedia()} for more details. Passing {@code null} resets emulation to system defaults. Defaults to {@code
      * "light"}.
      */
-    public LaunchPersistentContextOptions setColorScheme(ColorScheme colorScheme) {
+    public LaunchPersistentContextOptions setColorScheme(@Nullable ColorScheme colorScheme) {
       this.colorScheme = Optional.ofNullable(colorScheme);
       return this;
     }
@@ -904,7 +905,7 @@ public interface BrowserType {
      * {@link com.microsoft.playwright.Page#emulateMedia Page.emulateMedia()} for more details. Passing {@code null} resets
      * emulation to system defaults. Defaults to {@code "no-preference"}.
      */
-    public LaunchPersistentContextOptions setContrast(Contrast contrast) {
+    public LaunchPersistentContextOptions setContrast(@Nullable Contrast contrast) {
       this.contrast = Optional.ofNullable(contrast);
       return this;
     }
@@ -964,7 +965,7 @@ public interface BrowserType {
      * com.microsoft.playwright.Page#emulateMedia Page.emulateMedia()} for more details. Passing {@code null} resets emulation
      * to system defaults. Defaults to {@code "none"}.
      */
-    public LaunchPersistentContextOptions setForcedColors(ForcedColors forcedColors) {
+    public LaunchPersistentContextOptions setForcedColors(@Nullable ForcedColors forcedColors) {
       this.forcedColors = Optional.ofNullable(forcedColors);
       return this;
     }
@@ -1197,7 +1198,7 @@ public interface BrowserType {
      * See {@link com.microsoft.playwright.Page#emulateMedia Page.emulateMedia()} for more details. Passing {@code null} resets
      * emulation to system defaults. Defaults to {@code "no-preference"}.
      */
-    public LaunchPersistentContextOptions setReducedMotion(ReducedMotion reducedMotion) {
+    public LaunchPersistentContextOptions setReducedMotion(@Nullable ReducedMotion reducedMotion) {
       this.reducedMotion = Optional.ofNullable(reducedMotion);
       return this;
     }
@@ -1295,7 +1296,7 @@ public interface BrowserType {
      * <p> <strong>NOTE:</strong> The {@code null} value opts out from the default presets, makes viewport depend on the host window size defined by the
      * operating system. It makes the execution of the tests non-deterministic.
      */
-    public LaunchPersistentContextOptions setViewportSize(ViewportSize viewportSize) {
+    public LaunchPersistentContextOptions setViewportSize(@Nullable ViewportSize viewportSize) {
       this.viewportSize = Optional.ofNullable(viewportSize);
       return this;
     }
@@ -1321,7 +1322,7 @@ public interface BrowserType {
    * @param endpoint A Playwright browser websocket endpoint to connect to. You obtain this endpoint via {@code BrowserServer.wsEndpoint}.
    * @since v1.8
    */
-  Browser connect(String endpoint, ConnectOptions options);
+  Browser connect(String endpoint, @Nullable ConnectOptions options);
   /**
    * This method attaches Playwright to an existing browser instance using the Chrome DevTools Protocol.
    *
@@ -1377,7 +1378,7 @@ public interface BrowserType {
    * ws://127.0.0.1:9222/devtools/browser/387adf4c-243f-4051-a181-46798f4a46f4}.
    * @since v1.9
    */
-  Browser connectOverCDP(String endpointURL, ConnectOverCDPOptions options);
+  Browser connectOverCDP(String endpointURL, @Nullable ConnectOverCDPOptions options);
   /**
    * A path where Playwright expects to find a bundled browser executable.
    *
@@ -1453,7 +1454,7 @@ public interface BrowserType {
    *
    * @since v1.8
    */
-  Browser launch(LaunchOptions options);
+  Browser launch(@Nullable LaunchOptions options);
   /**
    * Returns the persistent browser context instance.
    *
@@ -1501,7 +1502,7 @@ public interface BrowserType {
    * as your automation profile instead. See https://developer.chrome.com/blog/remote-debugging-port for details.
    * @since v1.8
    */
-  BrowserContext launchPersistentContext(Path userDataDir, LaunchPersistentContextOptions options);
+  BrowserContext launchPersistentContext(Path userDataDir, @Nullable LaunchPersistentContextOptions options);
   /**
    * Returns browser name. For example: {@code "chromium"}, {@code "webkit"} or {@code "firefox"}.
    *

--- a/playwright/src/main/java/com/microsoft/playwright/CDPSession.java
+++ b/playwright/src/main/java/com/microsoft/playwright/CDPSession.java
@@ -16,6 +16,7 @@
 
 package com.microsoft.playwright;
 
+import org.jspecify.annotations.Nullable;
 import java.util.function.Consumer;
 import com.google.gson.JsonObject;
 
@@ -81,7 +82,7 @@ public interface CDPSession {
    * @param args Optional method parameters.
    * @since v1.8
    */
-  JsonObject send(String method, JsonObject args);
+  JsonObject send(String method, @Nullable JsonObject args);
   /**
    * Register an event handler for events with the specified event name. The given handler will be called for every event
    * with the given name.

--- a/playwright/src/main/java/com/microsoft/playwright/Clock.java
+++ b/playwright/src/main/java/com/microsoft/playwright/Clock.java
@@ -16,6 +16,7 @@
 
 package com.microsoft.playwright;
 
+import org.jspecify.annotations.Nullable;
 import java.util.Date;
 
 /**
@@ -30,7 +31,7 @@ public interface Clock {
     /**
      * Time to initialize with, current system time by default.
      */
-    public Object time;
+    public @Nullable Object time;
 
     /**
      * Time to initialize with, current system time by default.
@@ -129,7 +130,7 @@ public interface Clock {
    *
    * @since v1.45
    */
-  void install(InstallOptions options);
+  void install(@Nullable InstallOptions options);
   /**
    * Advance the clock, firing all the time-related callbacks.
    *

--- a/playwright/src/main/java/com/microsoft/playwright/ConsoleMessage.java
+++ b/playwright/src/main/java/com/microsoft/playwright/ConsoleMessage.java
@@ -16,6 +16,7 @@
 
 package com.microsoft.playwright;
 
+import org.jspecify.annotations.Nullable;
 import java.util.*;
 
 /**
@@ -62,7 +63,7 @@ public interface ConsoleMessage {
    *
    * @since v1.34
    */
-  Page page();
+  @Nullable Page page();
   /**
    * The text of the console message.
    *
@@ -90,6 +91,6 @@ public interface ConsoleMessage {
    *
    * @since v1.57
    */
-  Worker worker();
+  @Nullable Worker worker();
 }
 

--- a/playwright/src/main/java/com/microsoft/playwright/Credentials.java
+++ b/playwright/src/main/java/com/microsoft/playwright/Credentials.java
@@ -16,6 +16,7 @@
 
 package com.microsoft.playwright;
 
+import org.jspecify.annotations.Nullable;
 import com.microsoft.playwright.options.*;
 import java.util.*;
 
@@ -87,19 +88,19 @@ public interface Credentials {
     /**
      * Base64url-encoded credential id. Auto-generated if omitted.
      */
-    public String id;
+    public @Nullable String id;
     /**
      * Base64url-encoded PKCS#8 (DER) private key. Auto-generated if omitted.
      */
-    public String privateKey;
+    public @Nullable String privateKey;
     /**
      * Base64url-encoded SPKI (DER) public key. Auto-generated if omitted.
      */
-    public String publicKey;
+    public @Nullable String publicKey;
     /**
      * Base64url-encoded user handle. Auto-generated if omitted.
      */
-    public String userHandle;
+    public @Nullable String userHandle;
 
     /**
      * Base64url-encoded credential id. Auto-generated if omitted.
@@ -134,11 +135,11 @@ public interface Credentials {
     /**
      * Only return the credential with this base64url-encoded id.
      */
-    public String id;
+    public @Nullable String id;
     /**
      * Only return credentials for this relying party id.
      */
-    public String rpId;
+    public @Nullable String rpId;
 
     /**
      * Only return the credential with this base64url-encoded id.
@@ -203,7 +204,7 @@ public interface Credentials {
    * @param rpId Relying party id (typically the site's effective domain).
    * @since v1.61
    */
-  VirtualCredential create(String rpId, CreateOptions options);
+  VirtualCredential create(String rpId, @Nullable CreateOptions options);
   /**
    * Removes a credential from the authenticator by its id. Works for any credential currently held — both those seeded with
    * {@link com.microsoft.playwright.Credentials#create Credentials.create()} and those the page registered itself by calling
@@ -238,6 +239,6 @@ public interface Credentials {
    *
    * @since v1.61
    */
-  List<VirtualCredential> get(GetOptions options);
+  List<VirtualCredential> get(@Nullable GetOptions options);
 }
 

--- a/playwright/src/main/java/com/microsoft/playwright/Debugger.java
+++ b/playwright/src/main/java/com/microsoft/playwright/Debugger.java
@@ -16,6 +16,7 @@
 
 package com.microsoft.playwright;
 
+import org.jspecify.annotations.Nullable;
 import com.microsoft.playwright.options.*;
 import java.util.*;
 
@@ -39,7 +40,7 @@ public interface Debugger {
    *
    * @since v1.59
    */
-  DebuggerPausedDetails pausedDetails();
+  @Nullable DebuggerPausedDetails pausedDetails();
   /**
    * Configures the debugger to pause before the next action is executed.
    *

--- a/playwright/src/main/java/com/microsoft/playwright/Dialog.java
+++ b/playwright/src/main/java/com/microsoft/playwright/Dialog.java
@@ -16,6 +16,7 @@
 
 package com.microsoft.playwright;
 
+import org.jspecify.annotations.Nullable;
 
 /**
  * {@code Dialog} objects are dispatched by page via the {@link com.microsoft.playwright.Page#onDialog Page.onDialog()}
@@ -63,7 +64,7 @@ public interface Dialog {
    * @param promptText A text to enter in prompt. Does not cause any effects if the dialog's {@code type} is not prompt. Optional.
    * @since v1.8
    */
-  void accept(String promptText);
+  void accept(@Nullable String promptText);
   /**
    * If dialog is prompt, returns default prompt value. Otherwise, returns empty string.
    *
@@ -87,7 +88,7 @@ public interface Dialog {
    *
    * @since v1.34
    */
-  Page page();
+  @Nullable Page page();
   /**
    * Returns dialog's type, can be one of {@code alert}, {@code beforeunload}, {@code confirm} or {@code prompt}.
    *

--- a/playwright/src/main/java/com/microsoft/playwright/Download.java
+++ b/playwright/src/main/java/com/microsoft/playwright/Download.java
@@ -16,6 +16,7 @@
 
 package com.microsoft.playwright;
 
+import org.jspecify.annotations.Nullable;
 import java.io.InputStream;
 import java.nio.file.Path;
 
@@ -65,7 +66,7 @@ public interface Download {
    *
    * @since v1.8
    */
-  String failure();
+  @Nullable String failure();
   /**
    * Get the page that the download belongs to.
    *

--- a/playwright/src/main/java/com/microsoft/playwright/ElementHandle.java
+++ b/playwright/src/main/java/com/microsoft/playwright/ElementHandle.java
@@ -16,6 +16,7 @@
 
 package com.microsoft.playwright;
 
+import org.jspecify.annotations.Nullable;
 import com.microsoft.playwright.options.*;
 import java.nio.file.Path;
 import java.util.*;
@@ -63,36 +64,36 @@ public interface ElementHandle extends JSHandle {
      * Whether to bypass the <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks. Defaults to
      * {@code false}.
      */
-    public Boolean force;
+    public @Nullable Boolean force;
     /**
      * @deprecated This option has no effect.
      */
-    public Boolean noWaitAfter;
+    public @Nullable Boolean noWaitAfter;
     /**
      * A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the
      * element.
      */
-    public Position position;
+    public @Nullable Position position;
     /**
      * Controls whether Playwright scrolls the element into view before performing the action. Defaults to {@code "auto"},
      * which scrolls the element into view when necessary, including scrolling nested scrollable containers. When set to {@code
      * "none"}, Playwright does not scroll the element and the action fails if the element is not already in the viewport. This
      * is useful to assert that an element is reachable by the user without additional scrolling.
      */
-    public ScrollMode scroll;
+    public @Nullable ScrollMode scroll;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
      * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
     /**
      * When set, this method only performs the <a href="https://playwright.dev/java/docs/actionability">actionability</a>
      * checks and skips the action. Defaults to {@code false}. Useful to wait until the element is ready for the action without
      * performing it.
      */
-    public Boolean trial;
+    public @Nullable Boolean trial;
 
     /**
      * Whether to bypass the <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks. Defaults to
@@ -158,61 +159,61 @@ public interface ElementHandle extends JSHandle {
     /**
      * Defaults to {@code left}.
      */
-    public MouseButton button;
+    public @Nullable MouseButton button;
     /**
      * defaults to 1. See [UIEvent.detail].
      */
-    public Integer clickCount;
+    public @Nullable Integer clickCount;
     /**
      * Time to wait between {@code mousedown} and {@code mouseup} in milliseconds. Defaults to 0.
      */
-    public Double delay;
+    public @Nullable Double delay;
     /**
      * Whether to bypass the <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks. Defaults to
      * {@code false}.
      */
-    public Boolean force;
+    public @Nullable Boolean force;
     /**
      * Modifier keys to press. Ensures that only these modifiers are pressed during the operation, and then restores current
      * modifiers back. If not specified, currently pressed modifiers are used. "ControlOrMeta" resolves to "Control" on Windows
      * and Linux and to "Meta" on macOS.
      */
-    public List<KeyboardModifier> modifiers;
+    public @Nullable List<KeyboardModifier> modifiers;
     /**
      * @deprecated This option will default to {@code true} in the future.
      */
-    public Boolean noWaitAfter;
+    public @Nullable Boolean noWaitAfter;
     /**
      * A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the
      * element.
      */
-    public Position position;
+    public @Nullable Position position;
     /**
      * Controls whether Playwright scrolls the element into view before performing the action. Defaults to {@code "auto"},
      * which scrolls the element into view when necessary, including scrolling nested scrollable containers. When set to {@code
      * "none"}, Playwright does not scroll the element and the action fails if the element is not already in the viewport. This
      * is useful to assert that an element is reachable by the user without additional scrolling.
      */
-    public ScrollMode scroll;
+    public @Nullable ScrollMode scroll;
     /**
      * Defaults to 1. Sends {@code n} interpolated {@code mousemove} events to represent travel between Playwright's current
      * cursor position and the provided destination. When set to 1, emits a single {@code mousemove} event at the destination
      * location.
      */
-    public Integer steps;
+    public @Nullable Integer steps;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
      * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
     /**
      * When set, this method only performs the <a href="https://playwright.dev/java/docs/actionability">actionability</a>
      * checks and skips the action. Defaults to {@code false}. Useful to wait until the element is ready for the action without
      * performing it.
      */
-    public Boolean trial;
+    public @Nullable Boolean trial;
 
     /**
      * Defaults to {@code left}.
@@ -317,57 +318,57 @@ public interface ElementHandle extends JSHandle {
     /**
      * Defaults to {@code left}.
      */
-    public MouseButton button;
+    public @Nullable MouseButton button;
     /**
      * Time to wait between {@code mousedown} and {@code mouseup} in milliseconds. Defaults to 0.
      */
-    public Double delay;
+    public @Nullable Double delay;
     /**
      * Whether to bypass the <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks. Defaults to
      * {@code false}.
      */
-    public Boolean force;
+    public @Nullable Boolean force;
     /**
      * Modifier keys to press. Ensures that only these modifiers are pressed during the operation, and then restores current
      * modifiers back. If not specified, currently pressed modifiers are used. "ControlOrMeta" resolves to "Control" on Windows
      * and Linux and to "Meta" on macOS.
      */
-    public List<KeyboardModifier> modifiers;
+    public @Nullable List<KeyboardModifier> modifiers;
     /**
      * @deprecated This option has no effect.
      */
-    public Boolean noWaitAfter;
+    public @Nullable Boolean noWaitAfter;
     /**
      * A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the
      * element.
      */
-    public Position position;
+    public @Nullable Position position;
     /**
      * Controls whether Playwright scrolls the element into view before performing the action. Defaults to {@code "auto"},
      * which scrolls the element into view when necessary, including scrolling nested scrollable containers. When set to {@code
      * "none"}, Playwright does not scroll the element and the action fails if the element is not already in the viewport. This
      * is useful to assert that an element is reachable by the user without additional scrolling.
      */
-    public ScrollMode scroll;
+    public @Nullable ScrollMode scroll;
     /**
      * Defaults to 1. Sends {@code n} interpolated {@code mousemove} events to represent travel between Playwright's current
      * cursor position and the provided destination. When set to 1, emits a single {@code mousemove} event at the destination
      * location.
      */
-    public Integer steps;
+    public @Nullable Integer steps;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
      * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
     /**
      * When set, this method only performs the <a href="https://playwright.dev/java/docs/actionability">actionability</a>
      * checks and skips the action. Defaults to {@code false}. Useful to wait until the element is ready for the action without
      * performing it.
      */
-    public Boolean trial;
+    public @Nullable Boolean trial;
 
     /**
      * Defaults to {@code left}.
@@ -466,18 +467,18 @@ public interface ElementHandle extends JSHandle {
      * Whether to bypass the <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks. Defaults to
      * {@code false}.
      */
-    public Boolean force;
+    public @Nullable Boolean force;
     /**
      * @deprecated This option has no effect.
      */
-    public Boolean noWaitAfter;
+    public @Nullable Boolean noWaitAfter;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
      * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * Whether to bypass the <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks. Defaults to
@@ -510,42 +511,42 @@ public interface ElementHandle extends JSHandle {
      * Whether to bypass the <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks. Defaults to
      * {@code false}.
      */
-    public Boolean force;
+    public @Nullable Boolean force;
     /**
      * Modifier keys to press. Ensures that only these modifiers are pressed during the operation, and then restores current
      * modifiers back. If not specified, currently pressed modifiers are used. "ControlOrMeta" resolves to "Control" on Windows
      * and Linux and to "Meta" on macOS.
      */
-    public List<KeyboardModifier> modifiers;
+    public @Nullable List<KeyboardModifier> modifiers;
     /**
      * @deprecated This option has no effect.
      */
-    public Boolean noWaitAfter;
+    public @Nullable Boolean noWaitAfter;
     /**
      * A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the
      * element.
      */
-    public Position position;
+    public @Nullable Position position;
     /**
      * Controls whether Playwright scrolls the element into view before performing the action. Defaults to {@code "auto"},
      * which scrolls the element into view when necessary, including scrolling nested scrollable containers. When set to {@code
      * "none"}, Playwright does not scroll the element and the action fails if the element is not already in the viewport. This
      * is useful to assert that an element is reachable by the user without additional scrolling.
      */
-    public ScrollMode scroll;
+    public @Nullable ScrollMode scroll;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
      * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
     /**
      * When set, this method only performs the <a href="https://playwright.dev/java/docs/actionability">actionability</a>
      * checks and skips the action. Defaults to {@code false}. Useful to wait until the element is ready for the action without
      * performing it.
      */
-    public Boolean trial;
+    public @Nullable Boolean trial;
 
     /**
      * Whether to bypass the <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks. Defaults to
@@ -620,7 +621,7 @@ public interface ElementHandle extends JSHandle {
     /**
      * @deprecated This option is ignored. The value is returned immediately.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * @deprecated This option is ignored. The value is returned immediately.
@@ -634,18 +635,18 @@ public interface ElementHandle extends JSHandle {
     /**
      * Time to wait between {@code keydown} and {@code keyup} in milliseconds. Defaults to 0.
      */
-    public Double delay;
+    public @Nullable Double delay;
     /**
      * @deprecated This option will default to {@code true} in the future.
      */
-    public Boolean noWaitAfter;
+    public @Nullable Boolean noWaitAfter;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
      * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * Time to wait between {@code keydown} and {@code keyup} in milliseconds. Defaults to 0.
@@ -683,42 +684,42 @@ public interface ElementHandle extends JSHandle {
      *
      * <p> Defaults to {@code "allow"} that leaves animations untouched.
      */
-    public ScreenshotAnimations animations;
+    public @Nullable ScreenshotAnimations animations;
     /**
      * When set to {@code "hide"}, screenshot will hide text caret. When set to {@code "initial"}, text caret behavior will not
      * be changed.  Defaults to {@code "hide"}.
      */
-    public ScreenshotCaret caret;
+    public @Nullable ScreenshotCaret caret;
     /**
      * Specify locators that should be masked when the screenshot is taken. Masked elements will be overlaid with a pink box
      * {@code #FF00FF} (customized by {@code maskColor}) that completely covers its bounding box. The mask is also applied to
      * invisible elements, see <a href="https://playwright.dev/java/docs/locators#matching-only-visible-elements">Matching only
      * visible elements</a> to disable that.
      */
-    public List<Locator> mask;
+    public @Nullable List<Locator> mask;
     /**
      * Specify the color of the overlay box for masked elements, in <a
      * href="https://developer.mozilla.org/en-US/docs/Web/CSS/color_value">CSS color format</a>. Default color is pink {@code
      * #FF00FF}.
      */
-    public String maskColor;
+    public @Nullable String maskColor;
     /**
      * Hides default white background and allows capturing screenshots with transparency. Not applicable to {@code jpeg}
      * images. Defaults to {@code false}.
      */
-    public Boolean omitBackground;
+    public @Nullable Boolean omitBackground;
     /**
      * The file path to save the image to. The screenshot type will be inferred from file extension. If {@code path} is a
      * relative path, then it is resolved relative to the current working directory. If no path is provided, the image won't be
      * saved to the disk.
      */
-    public Path path;
+    public @Nullable Path path;
     /**
      * The quality of the image, between 0-100. Not applicable to {@code png} images. For {@code jpeg} the default is {@code
      * 80}. For {@code webp}, a quality of {@code 100} (the default) produces a lossless image, while lower values use lossy
      * compression.
      */
-    public Integer quality;
+    public @Nullable Integer quality;
     /**
      * When set to {@code "css"}, screenshot will have a single pixel per each css pixel on the page. For high-dpi devices,
      * this will keep screenshots small. Using {@code "device"} option will produce a single pixel per each device pixel, so
@@ -726,24 +727,24 @@ public interface ElementHandle extends JSHandle {
      *
      * <p> Defaults to {@code "device"}.
      */
-    public ScreenshotScale scale;
+    public @Nullable ScreenshotScale scale;
     /**
      * Text of the stylesheet to apply while making the screenshot. This is where you can hide dynamic elements, make elements
      * invisible or change their properties to help you creating repeatable screenshots. This stylesheet pierces the Shadow DOM
      * and applies to the inner frames.
      */
-    public String style;
+    public @Nullable String style;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
      * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
     /**
      * Specify screenshot type, defaults to {@code png}.
      */
-    public ScreenshotType type;
+    public @Nullable ScreenshotType type;
 
     /**
      * When set to {@code "disabled"}, stops CSS animations, CSS transitions and Web Animations. Animations get different
@@ -857,7 +858,7 @@ public interface ElementHandle extends JSHandle {
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
@@ -875,18 +876,18 @@ public interface ElementHandle extends JSHandle {
      * Whether to bypass the <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks. Defaults to
      * {@code false}.
      */
-    public Boolean force;
+    public @Nullable Boolean force;
     /**
      * @deprecated This option has no effect.
      */
-    public Boolean noWaitAfter;
+    public @Nullable Boolean noWaitAfter;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
      * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * Whether to bypass the <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks. Defaults to
@@ -919,14 +920,14 @@ public interface ElementHandle extends JSHandle {
      * Whether to bypass the <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks. Defaults to
      * {@code false}.
      */
-    public Boolean force;
+    public @Nullable Boolean force;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
      * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * Whether to bypass the <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks. Defaults to
@@ -952,36 +953,36 @@ public interface ElementHandle extends JSHandle {
      * Whether to bypass the <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks. Defaults to
      * {@code false}.
      */
-    public Boolean force;
+    public @Nullable Boolean force;
     /**
      * @deprecated This option has no effect.
      */
-    public Boolean noWaitAfter;
+    public @Nullable Boolean noWaitAfter;
     /**
      * A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the
      * element.
      */
-    public Position position;
+    public @Nullable Position position;
     /**
      * Controls whether Playwright scrolls the element into view before performing the action. Defaults to {@code "auto"},
      * which scrolls the element into view when necessary, including scrolling nested scrollable containers. When set to {@code
      * "none"}, Playwright does not scroll the element and the action fails if the element is not already in the viewport. This
      * is useful to assert that an element is reachable by the user without additional scrolling.
      */
-    public ScrollMode scroll;
+    public @Nullable ScrollMode scroll;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
      * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
     /**
      * When set, this method only performs the <a href="https://playwright.dev/java/docs/actionability">actionability</a>
      * checks and skips the action. Defaults to {@code false}. Useful to wait until the element is ready for the action without
      * performing it.
      */
-    public Boolean trial;
+    public @Nullable Boolean trial;
 
     /**
      * Whether to bypass the <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks. Defaults to
@@ -1047,14 +1048,14 @@ public interface ElementHandle extends JSHandle {
     /**
      * @deprecated This option has no effect.
      */
-    public Boolean noWaitAfter;
+    public @Nullable Boolean noWaitAfter;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
      * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * @deprecated This option has no effect.
@@ -1079,42 +1080,42 @@ public interface ElementHandle extends JSHandle {
      * Whether to bypass the <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks. Defaults to
      * {@code false}.
      */
-    public Boolean force;
+    public @Nullable Boolean force;
     /**
      * Modifier keys to press. Ensures that only these modifiers are pressed during the operation, and then restores current
      * modifiers back. If not specified, currently pressed modifiers are used. "ControlOrMeta" resolves to "Control" on Windows
      * and Linux and to "Meta" on macOS.
      */
-    public List<KeyboardModifier> modifiers;
+    public @Nullable List<KeyboardModifier> modifiers;
     /**
      * @deprecated This option has no effect.
      */
-    public Boolean noWaitAfter;
+    public @Nullable Boolean noWaitAfter;
     /**
      * A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the
      * element.
      */
-    public Position position;
+    public @Nullable Position position;
     /**
      * Controls whether Playwright scrolls the element into view before performing the action. Defaults to {@code "auto"},
      * which scrolls the element into view when necessary, including scrolling nested scrollable containers. When set to {@code
      * "none"}, Playwright does not scroll the element and the action fails if the element is not already in the viewport. This
      * is useful to assert that an element is reachable by the user without additional scrolling.
      */
-    public ScrollMode scroll;
+    public @Nullable ScrollMode scroll;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
      * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
     /**
      * When set, this method only performs the <a href="https://playwright.dev/java/docs/actionability">actionability</a>
      * checks and skips the action. Defaults to {@code false}. Useful to wait until the element is ready for the action without
      * performing it.
      */
-    public Boolean trial;
+    public @Nullable Boolean trial;
 
     /**
      * Whether to bypass the <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks. Defaults to
@@ -1189,18 +1190,18 @@ public interface ElementHandle extends JSHandle {
     /**
      * Time to wait between key presses in milliseconds. Defaults to 0.
      */
-    public Double delay;
+    public @Nullable Double delay;
     /**
      * @deprecated This option has no effect.
      */
-    public Boolean noWaitAfter;
+    public @Nullable Boolean noWaitAfter;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
      * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * Time to wait between key presses in milliseconds. Defaults to 0.
@@ -1232,36 +1233,36 @@ public interface ElementHandle extends JSHandle {
      * Whether to bypass the <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks. Defaults to
      * {@code false}.
      */
-    public Boolean force;
+    public @Nullable Boolean force;
     /**
      * @deprecated This option has no effect.
      */
-    public Boolean noWaitAfter;
+    public @Nullable Boolean noWaitAfter;
     /**
      * A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the
      * element.
      */
-    public Position position;
+    public @Nullable Position position;
     /**
      * Controls whether Playwright scrolls the element into view before performing the action. Defaults to {@code "auto"},
      * which scrolls the element into view when necessary, including scrolling nested scrollable containers. When set to {@code
      * "none"}, Playwright does not scroll the element and the action fails if the element is not already in the viewport. This
      * is useful to assert that an element is reachable by the user without additional scrolling.
      */
-    public ScrollMode scroll;
+    public @Nullable ScrollMode scroll;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
      * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
     /**
      * When set, this method only performs the <a href="https://playwright.dev/java/docs/actionability">actionability</a>
      * checks and skips the action. Defaults to {@code false}. Useful to wait until the element is ready for the action without
      * performing it.
      */
-    public Boolean trial;
+    public @Nullable Boolean trial;
 
     /**
      * Whether to bypass the <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks. Defaults to
@@ -1330,7 +1331,7 @@ public interface ElementHandle extends JSHandle {
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
@@ -1355,19 +1356,19 @@ public interface ElementHandle extends JSHandle {
      * visibility:hidden}. This is opposite to the {@code "visible"} option.</li>
      * </ul>
      */
-    public WaitForSelectorState state;
+    public @Nullable WaitForSelectorState state;
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
-    public Boolean strict;
+    public @Nullable Boolean strict;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
      * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * Defaults to {@code "visible"}. Can be either:
@@ -1425,7 +1426,7 @@ public interface ElementHandle extends JSHandle {
    *
    * @since v1.8
    */
-  BoundingBox boundingBox();
+  @Nullable BoundingBox boundingBox();
   /**
    * This method checks the element by performing the following steps:
    * <ol>
@@ -1467,7 +1468,7 @@ public interface ElementHandle extends JSHandle {
    *
    * @since v1.8
    */
-  void check(CheckOptions options);
+  void check(@Nullable CheckOptions options);
   /**
    * This method clicks the element by performing the following steps:
    * <ol>
@@ -1507,13 +1508,13 @@ public interface ElementHandle extends JSHandle {
    *
    * @since v1.8
    */
-  void click(ClickOptions options);
+  void click(@Nullable ClickOptions options);
   /**
    * Returns the content frame for element handles referencing iframe nodes, or {@code null} otherwise
    *
    * @since v1.8
    */
-  Frame contentFrame();
+  @Nullable Frame contentFrame();
   /**
    * This method double clicks the element by performing the following steps:
    * <ol>
@@ -1555,7 +1556,7 @@ public interface ElementHandle extends JSHandle {
    *
    * @since v1.8
    */
-  void dblclick(DblclickOptions options);
+  void dblclick(@Nullable DblclickOptions options);
   /**
    * The snippet below dispatches the {@code click} event on the element. Regardless of the visibility state of the element,
    * {@code click} is dispatched. This is equivalent to calling <a
@@ -1642,7 +1643,7 @@ public interface ElementHandle extends JSHandle {
    * @param eventInit Optional event-specific initialization properties.
    * @since v1.8
    */
-  void dispatchEvent(String type, Object eventInit);
+  void dispatchEvent(String type, @Nullable Object eventInit);
   /**
    * Returns the return value of {@code expression}.
    *
@@ -1666,7 +1667,7 @@ public interface ElementHandle extends JSHandle {
    * automatically invoked.
    * @since v1.9
    */
-  default Object evalOnSelector(String selector, String expression) {
+  default @Nullable Object evalOnSelector(String selector, String expression) {
     return evalOnSelector(selector, expression, null);
   }
   /**
@@ -1693,7 +1694,7 @@ public interface ElementHandle extends JSHandle {
    * @param arg Optional argument to pass to {@code expression}.
    * @since v1.9
    */
-  Object evalOnSelector(String selector, String expression, Object arg);
+  @Nullable Object evalOnSelector(String selector, String expression, @Nullable Object arg);
   /**
    * Returns the return value of {@code expression}.
    *
@@ -1716,7 +1717,7 @@ public interface ElementHandle extends JSHandle {
    * automatically invoked.
    * @since v1.9
    */
-  default Object evalOnSelectorAll(String selector, String expression) {
+  default @Nullable Object evalOnSelectorAll(String selector, String expression) {
     return evalOnSelectorAll(selector, expression, null);
   }
   /**
@@ -1742,7 +1743,7 @@ public interface ElementHandle extends JSHandle {
    * @param arg Optional argument to pass to {@code expression}.
    * @since v1.9
    */
-  Object evalOnSelectorAll(String selector, String expression, Object arg);
+  @Nullable Object evalOnSelectorAll(String selector, String expression, @Nullable Object arg);
   /**
    * This method waits for <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks, focuses the
    * element, fills it and triggers an {@code input} event after filling. Note that you can pass an empty string to clear the
@@ -1778,7 +1779,7 @@ public interface ElementHandle extends JSHandle {
    * @param value Value to set for the {@code <input>}, {@code <textarea>} or {@code [contenteditable]} element.
    * @since v1.8
    */
-  void fill(String value, FillOptions options);
+  void fill(String value, @Nullable FillOptions options);
   /**
    * Calls <a href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/focus">focus</a> on the element.
    *
@@ -1791,7 +1792,7 @@ public interface ElementHandle extends JSHandle {
    * @param name Attribute name to get the value for.
    * @since v1.8
    */
-  String getAttribute(String name);
+  @Nullable String getAttribute(String name);
   /**
    * This method hovers over the element by performing the following steps:
    * <ol>
@@ -1829,7 +1830,7 @@ public interface ElementHandle extends JSHandle {
    *
    * @since v1.8
    */
-  void hover(HoverOptions options);
+  void hover(@Nullable HoverOptions options);
   /**
    * Returns the {@code element.innerHTML}.
    *
@@ -1863,7 +1864,7 @@ public interface ElementHandle extends JSHandle {
    *
    * @since v1.13
    */
-  String inputValue(InputValueOptions options);
+  String inputValue(@Nullable InputValueOptions options);
   /**
    * Returns whether the element is checked. Throws if the element is not a checkbox or radio input.
    *
@@ -1907,7 +1908,7 @@ public interface ElementHandle extends JSHandle {
    *
    * @since v1.8
    */
-  Frame ownerFrame();
+  @Nullable Frame ownerFrame();
   /**
    * Focuses the element, and then uses {@link com.microsoft.playwright.Keyboard#down Keyboard.down()} and {@link
    * com.microsoft.playwright.Keyboard#up Keyboard.up()}.
@@ -1967,7 +1968,7 @@ public interface ElementHandle extends JSHandle {
    * @param key Name of the key to press or a character to generate, such as {@code ArrowLeft} or {@code a}.
    * @since v1.8
    */
-  void press(String key, PressOptions options);
+  void press(String key, @Nullable PressOptions options);
   /**
    * The method finds an element matching the specified selector in the {@code ElementHandle}'s subtree. If no elements match
    * the selector, returns {@code null}.
@@ -1975,7 +1976,7 @@ public interface ElementHandle extends JSHandle {
    * @param selector A selector to query for.
    * @since v1.9
    */
-  ElementHandle querySelector(String selector);
+  @Nullable ElementHandle querySelector(String selector);
   /**
    * The method finds all elements matching the specified selector in the {@code ElementHandle}s subtree. If no elements
    * match the selector, returns empty array.
@@ -2011,7 +2012,7 @@ public interface ElementHandle extends JSHandle {
    *
    * @since v1.8
    */
-  byte[] screenshot(ScreenshotOptions options);
+  byte[] screenshot(@Nullable ScreenshotOptions options);
   /**
    * This method waits for <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks, then tries to
    * scroll element into view, unless it is completely visible as defined by <a
@@ -2041,7 +2042,7 @@ public interface ElementHandle extends JSHandle {
    *
    * @since v1.8
    */
-  void scrollIntoViewIfNeeded(ScrollIntoViewIfNeededOptions options);
+  void scrollIntoViewIfNeeded(@Nullable ScrollIntoViewIfNeededOptions options);
   /**
    * This method waits for <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks, waits until all
    * specified options are present in the {@code <select>} element and selects these options.
@@ -2101,7 +2102,7 @@ public interface ElementHandle extends JSHandle {
    * and labels. Option is considered matching if all specified properties match.
    * @since v1.8
    */
-  List<String> selectOption(String values, SelectOptionOptions options);
+  List<String> selectOption(String values, @Nullable SelectOptionOptions options);
   /**
    * This method waits for <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks, waits until all
    * specified options are present in the {@code <select>} element and selects these options.
@@ -2161,7 +2162,7 @@ public interface ElementHandle extends JSHandle {
    * and labels. Option is considered matching if all specified properties match.
    * @since v1.8
    */
-  List<String> selectOption(ElementHandle values, SelectOptionOptions options);
+  List<String> selectOption(ElementHandle values, @Nullable SelectOptionOptions options);
   /**
    * This method waits for <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks, waits until all
    * specified options are present in the {@code <select>} element and selects these options.
@@ -2221,7 +2222,7 @@ public interface ElementHandle extends JSHandle {
    * and labels. Option is considered matching if all specified properties match.
    * @since v1.8
    */
-  List<String> selectOption(String[] values, SelectOptionOptions options);
+  List<String> selectOption(String[] values, @Nullable SelectOptionOptions options);
   /**
    * This method waits for <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks, waits until all
    * specified options are present in the {@code <select>} element and selects these options.
@@ -2281,7 +2282,7 @@ public interface ElementHandle extends JSHandle {
    * and labels. Option is considered matching if all specified properties match.
    * @since v1.8
    */
-  List<String> selectOption(SelectOption values, SelectOptionOptions options);
+  List<String> selectOption(SelectOption values, @Nullable SelectOptionOptions options);
   /**
    * This method waits for <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks, waits until all
    * specified options are present in the {@code <select>} element and selects these options.
@@ -2341,7 +2342,7 @@ public interface ElementHandle extends JSHandle {
    * and labels. Option is considered matching if all specified properties match.
    * @since v1.8
    */
-  List<String> selectOption(ElementHandle[] values, SelectOptionOptions options);
+  List<String> selectOption(ElementHandle[] values, @Nullable SelectOptionOptions options);
   /**
    * This method waits for <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks, waits until all
    * specified options are present in the {@code <select>} element and selects these options.
@@ -2401,7 +2402,7 @@ public interface ElementHandle extends JSHandle {
    * and labels. Option is considered matching if all specified properties match.
    * @since v1.8
    */
-  List<String> selectOption(SelectOption[] values, SelectOptionOptions options);
+  List<String> selectOption(SelectOption[] values, @Nullable SelectOptionOptions options);
   /**
    * This method waits for <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks, then focuses
    * the element and selects all its text content.
@@ -2425,7 +2426,7 @@ public interface ElementHandle extends JSHandle {
    *
    * @since v1.8
    */
-  void selectText(SelectTextOptions options);
+  void selectText(@Nullable SelectTextOptions options);
   /**
    * This method checks or unchecks an element by performing the following steps:
    * <ol>
@@ -2465,7 +2466,7 @@ public interface ElementHandle extends JSHandle {
    * @param checked Whether to check or uncheck the checkbox.
    * @since v1.15
    */
-  void setChecked(boolean checked, SetCheckedOptions options);
+  void setChecked(boolean checked, @Nullable SetCheckedOptions options);
   /**
    * Sets the value of the file input to these file paths or files. If some of the {@code filePaths} are relative paths, then
    * they are resolved relative to the current working directory. For empty array, clears the selected files. For inputs with
@@ -2495,7 +2496,7 @@ public interface ElementHandle extends JSHandle {
    *
    * @since v1.8
    */
-  void setInputFiles(Path files, SetInputFilesOptions options);
+  void setInputFiles(Path files, @Nullable SetInputFilesOptions options);
   /**
    * Sets the value of the file input to these file paths or files. If some of the {@code filePaths} are relative paths, then
    * they are resolved relative to the current working directory. For empty array, clears the selected files. For inputs with
@@ -2525,7 +2526,7 @@ public interface ElementHandle extends JSHandle {
    *
    * @since v1.8
    */
-  void setInputFiles(Path[] files, SetInputFilesOptions options);
+  void setInputFiles(Path[] files, @Nullable SetInputFilesOptions options);
   /**
    * Sets the value of the file input to these file paths or files. If some of the {@code filePaths} are relative paths, then
    * they are resolved relative to the current working directory. For empty array, clears the selected files. For inputs with
@@ -2555,7 +2556,7 @@ public interface ElementHandle extends JSHandle {
    *
    * @since v1.8
    */
-  void setInputFiles(FilePayload files, SetInputFilesOptions options);
+  void setInputFiles(FilePayload files, @Nullable SetInputFilesOptions options);
   /**
    * Sets the value of the file input to these file paths or files. If some of the {@code filePaths} are relative paths, then
    * they are resolved relative to the current working directory. For empty array, clears the selected files. For inputs with
@@ -2585,7 +2586,7 @@ public interface ElementHandle extends JSHandle {
    *
    * @since v1.8
    */
-  void setInputFiles(FilePayload[] files, SetInputFilesOptions options);
+  void setInputFiles(FilePayload[] files, @Nullable SetInputFilesOptions options);
   /**
    * This method taps the element by performing the following steps:
    * <ol>
@@ -2627,13 +2628,13 @@ public interface ElementHandle extends JSHandle {
    *
    * @since v1.8
    */
-  void tap(TapOptions options);
+  void tap(@Nullable TapOptions options);
   /**
    * Returns the {@code node.textContent}.
    *
    * @since v1.8
    */
-  String textContent();
+  @Nullable String textContent();
   /**
    * @deprecated In most cases, you should use {@link com.microsoft.playwright.Locator#fill Locator.fill()} instead. You only need to
    * press keys one by one if there is special keyboard handling on the page - in this case use {@link
@@ -2653,7 +2654,7 @@ public interface ElementHandle extends JSHandle {
    * @param text A text to type into a focused element.
    * @since v1.8
    */
-  void type(String text, TypeOptions options);
+  void type(String text, @Nullable TypeOptions options);
   /**
    * This method checks the element by performing the following steps:
    * <ol>
@@ -2695,7 +2696,7 @@ public interface ElementHandle extends JSHandle {
    *
    * @since v1.8
    */
-  void uncheck(UncheckOptions options);
+  void uncheck(@Nullable UncheckOptions options);
   /**
    * Returns when the element satisfies the {@code state}.
    *
@@ -2753,7 +2754,7 @@ public interface ElementHandle extends JSHandle {
    * @param state A state to wait for, see below for more details.
    * @since v1.8
    */
-  void waitForElementState(ElementState state, WaitForElementStateOptions options);
+  void waitForElementState(ElementState state, @Nullable WaitForElementStateOptions options);
   /**
    * Returns element specified by selector when it satisfies {@code state} option. Returns {@code null} if waiting for {@code
    * hidden} or {@code detached}.
@@ -2778,7 +2779,7 @@ public interface ElementHandle extends JSHandle {
    * @param selector A selector to query for.
    * @since v1.8
    */
-  default ElementHandle waitForSelector(String selector) {
+  default @Nullable ElementHandle waitForSelector(String selector) {
     return waitForSelector(selector, null);
   }
   /**
@@ -2805,6 +2806,6 @@ public interface ElementHandle extends JSHandle {
    * @param selector A selector to query for.
    * @since v1.8
    */
-  ElementHandle waitForSelector(String selector, WaitForSelectorOptions options);
+  @Nullable ElementHandle waitForSelector(String selector, @Nullable WaitForSelectorOptions options);
 }
 

--- a/playwright/src/main/java/com/microsoft/playwright/FileChooser.java
+++ b/playwright/src/main/java/com/microsoft/playwright/FileChooser.java
@@ -16,6 +16,7 @@
 
 package com.microsoft.playwright;
 
+import org.jspecify.annotations.Nullable;
 import com.microsoft.playwright.options.*;
 import java.nio.file.Path;
 
@@ -32,14 +33,14 @@ public interface FileChooser {
     /**
      * @deprecated This option has no effect.
      */
-    public Boolean noWaitAfter;
+    public @Nullable Boolean noWaitAfter;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
      * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * @deprecated This option has no effect.
@@ -92,7 +93,7 @@ public interface FileChooser {
    *
    * @since v1.8
    */
-  void setFiles(Path files, SetFilesOptions options);
+  void setFiles(Path files, @Nullable SetFilesOptions options);
   /**
    * Sets the value of the file input this chooser is associated with. If some of the {@code filePaths} are relative paths,
    * then they are resolved relative to the current working directory. For empty array, clears the selected files.
@@ -108,7 +109,7 @@ public interface FileChooser {
    *
    * @since v1.8
    */
-  void setFiles(Path[] files, SetFilesOptions options);
+  void setFiles(Path[] files, @Nullable SetFilesOptions options);
   /**
    * Sets the value of the file input this chooser is associated with. If some of the {@code filePaths} are relative paths,
    * then they are resolved relative to the current working directory. For empty array, clears the selected files.
@@ -124,7 +125,7 @@ public interface FileChooser {
    *
    * @since v1.8
    */
-  void setFiles(FilePayload files, SetFilesOptions options);
+  void setFiles(FilePayload files, @Nullable SetFilesOptions options);
   /**
    * Sets the value of the file input this chooser is associated with. If some of the {@code filePaths} are relative paths,
    * then they are resolved relative to the current working directory. For empty array, clears the selected files.
@@ -140,6 +141,6 @@ public interface FileChooser {
    *
    * @since v1.8
    */
-  void setFiles(FilePayload[] files, SetFilesOptions options);
+  void setFiles(FilePayload[] files, @Nullable SetFilesOptions options);
 }
 

--- a/playwright/src/main/java/com/microsoft/playwright/Frame.java
+++ b/playwright/src/main/java/com/microsoft/playwright/Frame.java
@@ -16,6 +16,7 @@
 
 package com.microsoft.playwright;
 
+import org.jspecify.annotations.Nullable;
 import com.microsoft.playwright.options.*;
 import java.nio.file.Path;
 import java.util.*;
@@ -65,21 +66,21 @@ public interface Frame {
     /**
      * Raw JavaScript content to be injected into frame.
      */
-    public String content;
+    public @Nullable String content;
     /**
      * Path to the JavaScript file to be injected into frame. If {@code path} is a relative path, then it is resolved relative
      * to the current working directory.
      */
-    public Path path;
+    public @Nullable Path path;
     /**
      * Script type. Use 'module' in order to load a JavaScript ES6 module. See <a
      * href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script">script</a> for more details.
      */
-    public String type;
+    public @Nullable String type;
     /**
      * URL of a script to be added.
      */
-    public String url;
+    public @Nullable String url;
 
     /**
      * Raw JavaScript content to be injected into frame.
@@ -116,16 +117,16 @@ public interface Frame {
     /**
      * Raw CSS content to be injected into frame.
      */
-    public String content;
+    public @Nullable String content;
     /**
      * Path to the CSS file to be injected into frame. If {@code path} is a relative path, then it is resolved relative to the
      * current working directory.
      */
-    public Path path;
+    public @Nullable Path path;
     /**
      * URL of the {@code <link>} tag.
      */
-    public String url;
+    public @Nullable String url;
 
     /**
      * Raw CSS content to be injected into frame.
@@ -155,41 +156,41 @@ public interface Frame {
      * Whether to bypass the <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks. Defaults to
      * {@code false}.
      */
-    public Boolean force;
+    public @Nullable Boolean force;
     /**
      * @deprecated This option has no effect.
      */
-    public Boolean noWaitAfter;
+    public @Nullable Boolean noWaitAfter;
     /**
      * A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the
      * element.
      */
-    public Position position;
+    public @Nullable Position position;
     /**
      * Controls whether Playwright scrolls the element into view before performing the action. Defaults to {@code "auto"},
      * which scrolls the element into view when necessary, including scrolling nested scrollable containers. When set to {@code
      * "none"}, Playwright does not scroll the element and the action fails if the element is not already in the viewport. This
      * is useful to assert that an element is reachable by the user without additional scrolling.
      */
-    public ScrollMode scroll;
+    public @Nullable ScrollMode scroll;
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
-    public Boolean strict;
+    public @Nullable Boolean strict;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
      * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
     /**
      * When set, this method only performs the <a href="https://playwright.dev/java/docs/actionability">actionability</a>
      * checks and skips the action. Defaults to {@code false}. Useful to wait until the element is ready for the action without
      * performing it.
      */
-    public Boolean trial;
+    public @Nullable Boolean trial;
 
     /**
      * Whether to bypass the <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks. Defaults to
@@ -263,61 +264,61 @@ public interface Frame {
     /**
      * Defaults to {@code left}.
      */
-    public MouseButton button;
+    public @Nullable MouseButton button;
     /**
      * defaults to 1. See [UIEvent.detail].
      */
-    public Integer clickCount;
+    public @Nullable Integer clickCount;
     /**
      * Time to wait between {@code mousedown} and {@code mouseup} in milliseconds. Defaults to 0.
      */
-    public Double delay;
+    public @Nullable Double delay;
     /**
      * Whether to bypass the <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks. Defaults to
      * {@code false}.
      */
-    public Boolean force;
+    public @Nullable Boolean force;
     /**
      * Modifier keys to press. Ensures that only these modifiers are pressed during the operation, and then restores current
      * modifiers back. If not specified, currently pressed modifiers are used. "ControlOrMeta" resolves to "Control" on Windows
      * and Linux and to "Meta" on macOS.
      */
-    public List<KeyboardModifier> modifiers;
+    public @Nullable List<KeyboardModifier> modifiers;
     /**
      * @deprecated This option will default to {@code true} in the future.
      */
-    public Boolean noWaitAfter;
+    public @Nullable Boolean noWaitAfter;
     /**
      * A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the
      * element.
      */
-    public Position position;
+    public @Nullable Position position;
     /**
      * Controls whether Playwright scrolls the element into view before performing the action. Defaults to {@code "auto"},
      * which scrolls the element into view when necessary, including scrolling nested scrollable containers. When set to {@code
      * "none"}, Playwright does not scroll the element and the action fails if the element is not already in the viewport. This
      * is useful to assert that an element is reachable by the user without additional scrolling.
      */
-    public ScrollMode scroll;
+    public @Nullable ScrollMode scroll;
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
-    public Boolean strict;
+    public @Nullable Boolean strict;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
      * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
     /**
      * When set, this method only performs the <a href="https://playwright.dev/java/docs/actionability">actionability</a>
      * checks and skips the action. Defaults to {@code false}. Useful to wait until the element is ready for the action without
      * performing it. Note that keyboard {@code modifiers} will be pressed regardless of {@code trial} to allow testing
      * elements which are only visible when those keys are pressed.
      */
-    public Boolean trial;
+    public @Nullable Boolean trial;
 
     /**
      * Defaults to {@code left}.
@@ -422,57 +423,57 @@ public interface Frame {
     /**
      * Defaults to {@code left}.
      */
-    public MouseButton button;
+    public @Nullable MouseButton button;
     /**
      * Time to wait between {@code mousedown} and {@code mouseup} in milliseconds. Defaults to 0.
      */
-    public Double delay;
+    public @Nullable Double delay;
     /**
      * Whether to bypass the <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks. Defaults to
      * {@code false}.
      */
-    public Boolean force;
+    public @Nullable Boolean force;
     /**
      * Modifier keys to press. Ensures that only these modifiers are pressed during the operation, and then restores current
      * modifiers back. If not specified, currently pressed modifiers are used. "ControlOrMeta" resolves to "Control" on Windows
      * and Linux and to "Meta" on macOS.
      */
-    public List<KeyboardModifier> modifiers;
+    public @Nullable List<KeyboardModifier> modifiers;
     /**
      * @deprecated This option has no effect.
      */
-    public Boolean noWaitAfter;
+    public @Nullable Boolean noWaitAfter;
     /**
      * A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the
      * element.
      */
-    public Position position;
+    public @Nullable Position position;
     /**
      * Controls whether Playwright scrolls the element into view before performing the action. Defaults to {@code "auto"},
      * which scrolls the element into view when necessary, including scrolling nested scrollable containers. When set to {@code
      * "none"}, Playwright does not scroll the element and the action fails if the element is not already in the viewport. This
      * is useful to assert that an element is reachable by the user without additional scrolling.
      */
-    public ScrollMode scroll;
+    public @Nullable ScrollMode scroll;
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
-    public Boolean strict;
+    public @Nullable Boolean strict;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
      * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
     /**
      * When set, this method only performs the <a href="https://playwright.dev/java/docs/actionability">actionability</a>
      * checks and skips the action. Defaults to {@code false}. Useful to wait until the element is ready for the action without
      * performing it. Note that keyboard {@code modifiers} will be pressed regardless of {@code trial} to allow testing
      * elements which are only visible when those keys are pressed.
      */
-    public Boolean trial;
+    public @Nullable Boolean trial;
 
     /**
      * Defaults to {@code left}.
@@ -571,14 +572,14 @@ public interface Frame {
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
-    public Boolean strict;
+    public @Nullable Boolean strict;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
      * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
@@ -604,51 +605,51 @@ public interface Frame {
      * Whether to bypass the <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks. Defaults to
      * {@code false}.
      */
-    public Boolean force;
+    public @Nullable Boolean force;
     /**
      * @deprecated This option has no effect.
      */
-    public Boolean noWaitAfter;
+    public @Nullable Boolean noWaitAfter;
     /**
      * Controls whether Playwright scrolls the element into view before performing the action. Defaults to {@code "auto"},
      * which scrolls the element into view when necessary, including scrolling nested scrollable containers. When set to {@code
      * "none"}, Playwright does not scroll the element and the action fails if the element is not already in the viewport. This
      * is useful to assert that an element is reachable by the user without additional scrolling.
      */
-    public ScrollMode scroll;
+    public @Nullable ScrollMode scroll;
     /**
      * Clicks on the source element at this point relative to the top-left corner of the element's padding box. If not
      * specified, some visible point of the element is used.
      */
-    public Position sourcePosition;
+    public @Nullable Position sourcePosition;
     /**
      * Defaults to 1. Sends {@code n} interpolated {@code mousemove} events to represent travel between the {@code mousedown}
      * and {@code mouseup} of the drag. When set to 1, emits a single {@code mousemove} event at the destination location.
      */
-    public Integer steps;
+    public @Nullable Integer steps;
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
-    public Boolean strict;
+    public @Nullable Boolean strict;
     /**
      * Drops on the target element at this point relative to the top-left corner of the element's padding box. If not
      * specified, some visible point of the element is used.
      */
-    public Position targetPosition;
+    public @Nullable Position targetPosition;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
      * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
     /**
      * When set, this method only performs the <a href="https://playwright.dev/java/docs/actionability">actionability</a>
      * checks and skips the action. Defaults to {@code false}. Useful to wait until the element is ready for the action without
      * performing it.
      */
-    public Boolean trial;
+    public @Nullable Boolean trial;
 
     /**
      * Whether to bypass the <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks. Defaults to
@@ -746,7 +747,7 @@ public interface Frame {
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
-    public Boolean strict;
+    public @Nullable Boolean strict;
 
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
@@ -762,23 +763,23 @@ public interface Frame {
      * Whether to bypass the <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks. Defaults to
      * {@code false}.
      */
-    public Boolean force;
+    public @Nullable Boolean force;
     /**
      * @deprecated This option has no effect.
      */
-    public Boolean noWaitAfter;
+    public @Nullable Boolean noWaitAfter;
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
-    public Boolean strict;
+    public @Nullable Boolean strict;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
      * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * Whether to bypass the <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks. Defaults to
@@ -819,14 +820,14 @@ public interface Frame {
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
-    public Boolean strict;
+    public @Nullable Boolean strict;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
      * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
@@ -852,14 +853,14 @@ public interface Frame {
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
-    public Boolean strict;
+    public @Nullable Boolean strict;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
      * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
@@ -885,7 +886,7 @@ public interface Frame {
      * Whether to find an exact match: case-sensitive and whole-string. Default to false. Ignored when locating by a regular
      * expression. Note that exact match still trims whitespace.
      */
-    public Boolean exact;
+    public @Nullable Boolean exact;
 
     /**
      * Whether to find an exact match: case-sensitive and whole-string. Default to false. Ignored when locating by a regular
@@ -901,7 +902,7 @@ public interface Frame {
      * Whether to find an exact match: case-sensitive and whole-string. Default to false. Ignored when locating by a regular
      * expression. Note that exact match still trims whitespace.
      */
-    public Boolean exact;
+    public @Nullable Boolean exact;
 
     /**
      * Whether to find an exact match: case-sensitive and whole-string. Default to false. Ignored when locating by a regular
@@ -917,7 +918,7 @@ public interface Frame {
      * Whether to find an exact match: case-sensitive and whole-string. Default to false. Ignored when locating by a regular
      * expression. Note that exact match still trims whitespace.
      */
-    public Boolean exact;
+    public @Nullable Boolean exact;
 
     /**
      * Whether to find an exact match: case-sensitive and whole-string. Default to false. Ignored when locating by a regular
@@ -934,65 +935,65 @@ public interface Frame {
      *
      * <p> Learn more about <a href="https://www.w3.org/TR/wai-aria-1.2/#aria-checked">{@code aria-checked}</a>.
      */
-    public Boolean checked;
+    public @Nullable Boolean checked;
     /**
      * Option to match the <a href="https://w3c.github.io/accname/#dfn-accessible-description">accessible description</a>. By
      * default, matching is case-insensitive and searches for a substring, use {@code exact} to control this behavior.
      *
      * <p> Learn more about <a href="https://w3c.github.io/accname/#dfn-accessible-description">accessible description</a>.
      */
-    public Object description;
+    public @Nullable Object description;
     /**
      * An attribute that is usually set by {@code aria-disabled} or {@code disabled}.
      *
      * <p> <strong>NOTE:</strong> Unlike most other attributes, {@code disabled} is inherited through the DOM hierarchy. Learn more about <a
      * href="https://www.w3.org/TR/wai-aria-1.2/#aria-disabled">{@code aria-disabled}</a>.
      */
-    public Boolean disabled;
+    public @Nullable Boolean disabled;
     /**
      * Whether {@code name} and {@code description} are matched exactly: case-sensitive and whole-string. Defaults to false.
      * Ignored when the value is a regular expression. Note that exact match still trims whitespace.
      */
-    public Boolean exact;
+    public @Nullable Boolean exact;
     /**
      * An attribute that is usually set by {@code aria-expanded}.
      *
      * <p> Learn more about <a href="https://www.w3.org/TR/wai-aria-1.2/#aria-expanded">{@code aria-expanded}</a>.
      */
-    public Boolean expanded;
+    public @Nullable Boolean expanded;
     /**
      * Option that controls whether hidden elements are matched. By default, only non-hidden elements, as <a
      * href="https://www.w3.org/TR/wai-aria-1.2/#tree_exclusion">defined by ARIA</a>, are matched by role selector.
      *
      * <p> Learn more about <a href="https://www.w3.org/TR/wai-aria-1.2/#aria-hidden">{@code aria-hidden}</a>.
      */
-    public Boolean includeHidden;
+    public @Nullable Boolean includeHidden;
     /**
      * A number attribute that is usually present for roles {@code heading}, {@code listitem}, {@code row}, {@code treeitem},
      * with default values for {@code <h1>-<h6>} elements.
      *
      * <p> Learn more about <a href="https://www.w3.org/TR/wai-aria-1.2/#aria-level">{@code aria-level}</a>.
      */
-    public Integer level;
+    public @Nullable Integer level;
     /**
      * Option to match the <a href="https://w3c.github.io/accname/#dfn-accessible-name">accessible name</a>. By default,
      * matching is case-insensitive and searches for a substring, use {@code exact} to control this behavior.
      *
      * <p> Learn more about <a href="https://w3c.github.io/accname/#dfn-accessible-name">accessible name</a>.
      */
-    public Object name;
+    public @Nullable Object name;
     /**
      * An attribute that is usually set by {@code aria-pressed}.
      *
      * <p> Learn more about <a href="https://www.w3.org/TR/wai-aria-1.2/#aria-pressed">{@code aria-pressed}</a>.
      */
-    public Boolean pressed;
+    public @Nullable Boolean pressed;
     /**
      * An attribute that is usually set by {@code aria-selected}.
      *
      * <p> Learn more about <a href="https://www.w3.org/TR/wai-aria-1.2/#aria-selected">{@code aria-selected}</a>.
      */
-    public Boolean selected;
+    public @Nullable Boolean selected;
 
     /**
      * An attribute that is usually set by {@code aria-checked} or native {@code <input type=checkbox>} controls.
@@ -1114,7 +1115,7 @@ public interface Frame {
      * Whether to find an exact match: case-sensitive and whole-string. Default to false. Ignored when locating by a regular
      * expression. Note that exact match still trims whitespace.
      */
-    public Boolean exact;
+    public @Nullable Boolean exact;
 
     /**
      * Whether to find an exact match: case-sensitive and whole-string. Default to false. Ignored when locating by a regular
@@ -1130,7 +1131,7 @@ public interface Frame {
      * Whether to find an exact match: case-sensitive and whole-string. Default to false. Ignored when locating by a regular
      * expression. Note that exact match still trims whitespace.
      */
-    public Boolean exact;
+    public @Nullable Boolean exact;
 
     /**
      * Whether to find an exact match: case-sensitive and whole-string. Default to false. Ignored when locating by a regular
@@ -1146,7 +1147,7 @@ public interface Frame {
      * Referer header value. If provided it will take preference over the referer header value set by {@link
      * com.microsoft.playwright.Page#setExtraHTTPHeaders Page.setExtraHTTPHeaders()}.
      */
-    public String referer;
+    public @Nullable String referer;
     /**
      * Maximum operation time in milliseconds, defaults to 30 seconds, pass {@code 0} to disable timeout. The default value can
      * be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultNavigationTimeout
@@ -1155,7 +1156,7 @@ public interface Frame {
      * Page.setDefaultNavigationTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
     /**
      * When to consider operation succeeded, defaults to {@code load}. Events can be either:
      * <ul>
@@ -1166,7 +1167,7 @@ public interface Frame {
      * <li> {@code "commit"} - consider operation to be finished when network response is received and the document started loading.</li>
      * </ul>
      */
-    public WaitUntilState waitUntil;
+    public @Nullable WaitUntilState waitUntil;
 
     /**
      * Referer header value. If provided it will take preference over the referer header value set by {@link
@@ -1208,48 +1209,48 @@ public interface Frame {
      * Whether to bypass the <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks. Defaults to
      * {@code false}.
      */
-    public Boolean force;
+    public @Nullable Boolean force;
     /**
      * Modifier keys to press. Ensures that only these modifiers are pressed during the operation, and then restores current
      * modifiers back. If not specified, currently pressed modifiers are used. "ControlOrMeta" resolves to "Control" on Windows
      * and Linux and to "Meta" on macOS.
      */
-    public List<KeyboardModifier> modifiers;
+    public @Nullable List<KeyboardModifier> modifiers;
     /**
      * @deprecated This option has no effect.
      */
-    public Boolean noWaitAfter;
+    public @Nullable Boolean noWaitAfter;
     /**
      * A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the
      * element.
      */
-    public Position position;
+    public @Nullable Position position;
     /**
      * Controls whether Playwright scrolls the element into view before performing the action. Defaults to {@code "auto"},
      * which scrolls the element into view when necessary, including scrolling nested scrollable containers. When set to {@code
      * "none"}, Playwright does not scroll the element and the action fails if the element is not already in the viewport. This
      * is useful to assert that an element is reachable by the user without additional scrolling.
      */
-    public ScrollMode scroll;
+    public @Nullable ScrollMode scroll;
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
-    public Boolean strict;
+    public @Nullable Boolean strict;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
      * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
     /**
      * When set, this method only performs the <a href="https://playwright.dev/java/docs/actionability">actionability</a>
      * checks and skips the action. Defaults to {@code false}. Useful to wait until the element is ready for the action without
      * performing it. Note that keyboard {@code modifiers} will be pressed regardless of {@code trial} to allow testing
      * elements which are only visible when those keys are pressed.
      */
-    public Boolean trial;
+    public @Nullable Boolean trial;
 
     /**
      * Whether to bypass the <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks. Defaults to
@@ -1334,14 +1335,14 @@ public interface Frame {
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
-    public Boolean strict;
+    public @Nullable Boolean strict;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
      * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
@@ -1367,14 +1368,14 @@ public interface Frame {
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
-    public Boolean strict;
+    public @Nullable Boolean strict;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
      * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
@@ -1400,14 +1401,14 @@ public interface Frame {
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
-    public Boolean strict;
+    public @Nullable Boolean strict;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
      * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
@@ -1433,14 +1434,14 @@ public interface Frame {
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
-    public Boolean strict;
+    public @Nullable Boolean strict;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
      * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
@@ -1466,14 +1467,14 @@ public interface Frame {
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
-    public Boolean strict;
+    public @Nullable Boolean strict;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
      * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
@@ -1499,14 +1500,14 @@ public interface Frame {
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
-    public Boolean strict;
+    public @Nullable Boolean strict;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
      * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
@@ -1532,14 +1533,14 @@ public interface Frame {
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
-    public Boolean strict;
+    public @Nullable Boolean strict;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
      * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
@@ -1565,12 +1566,12 @@ public interface Frame {
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
-    public Boolean strict;
+    public @Nullable Boolean strict;
     /**
      * @deprecated This option is ignored. {@link com.microsoft.playwright.Frame#isHidden Frame.isHidden()} does not wait for the element
      * to become hidden and returns immediately.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
@@ -1594,12 +1595,12 @@ public interface Frame {
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
-    public Boolean strict;
+    public @Nullable Boolean strict;
     /**
      * @deprecated This option is ignored. {@link com.microsoft.playwright.Frame#isVisible Frame.isVisible()} does not wait for the element
      * to become visible and returns immediately.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
@@ -1631,7 +1632,7 @@ public interface Frame {
      *
      * <p> Note that outer and inner locators must belong to the same frame. Inner locator must not contain {@code FrameLocator}s.
      */
-    public Locator has;
+    public @Nullable Locator has;
     /**
      * Matches elements that do not contain an element that matches an inner locator. Inner locator is queried against the
      * outer one. For example, {@code article} that does not have {@code div} matches {@code
@@ -1639,18 +1640,18 @@ public interface Frame {
      *
      * <p> Note that outer and inner locators must belong to the same frame. Inner locator must not contain {@code FrameLocator}s.
      */
-    public Locator hasNot;
+    public @Nullable Locator hasNot;
     /**
      * Matches elements that do not contain specified text somewhere inside, possibly in a child or a descendant element. When
      * passed a [string], matching is case-insensitive and searches for a substring.
      */
-    public Object hasNotText;
+    public @Nullable Object hasNotText;
     /**
      * Matches elements containing specified text somewhere inside, possibly in a child or a descendant element. When passed a
      * [string], matching is case-insensitive and searches for a substring. For example, {@code "Playwright"} matches {@code
      * <article><div>Playwright</div></article>}.
      */
-    public Object hasText;
+    public @Nullable Object hasText;
 
     /**
      * Narrows down the results of the method to those which contain elements matching this relative locator. For example,
@@ -1718,23 +1719,23 @@ public interface Frame {
     /**
      * Time to wait between {@code keydown} and {@code keyup} in milliseconds. Defaults to 0.
      */
-    public Double delay;
+    public @Nullable Double delay;
     /**
      * @deprecated This option will default to {@code true} in the future.
      */
-    public Boolean noWaitAfter;
+    public @Nullable Boolean noWaitAfter;
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
-    public Boolean strict;
+    public @Nullable Boolean strict;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
      * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * Time to wait between {@code keydown} and {@code keyup} in milliseconds. Defaults to 0.
@@ -1774,7 +1775,7 @@ public interface Frame {
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
-    public Boolean strict;
+    public @Nullable Boolean strict;
 
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
@@ -1790,23 +1791,23 @@ public interface Frame {
      * Whether to bypass the <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks. Defaults to
      * {@code false}.
      */
-    public Boolean force;
+    public @Nullable Boolean force;
     /**
      * @deprecated This option has no effect.
      */
-    public Boolean noWaitAfter;
+    public @Nullable Boolean noWaitAfter;
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
-    public Boolean strict;
+    public @Nullable Boolean strict;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
      * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * Whether to bypass the <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks. Defaults to
@@ -1847,41 +1848,41 @@ public interface Frame {
      * Whether to bypass the <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks. Defaults to
      * {@code false}.
      */
-    public Boolean force;
+    public @Nullable Boolean force;
     /**
      * @deprecated This option has no effect.
      */
-    public Boolean noWaitAfter;
+    public @Nullable Boolean noWaitAfter;
     /**
      * A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the
      * element.
      */
-    public Position position;
+    public @Nullable Position position;
     /**
      * Controls whether Playwright scrolls the element into view before performing the action. Defaults to {@code "auto"},
      * which scrolls the element into view when necessary, including scrolling nested scrollable containers. When set to {@code
      * "none"}, Playwright does not scroll the element and the action fails if the element is not already in the viewport. This
      * is useful to assert that an element is reachable by the user without additional scrolling.
      */
-    public ScrollMode scroll;
+    public @Nullable ScrollMode scroll;
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
-    public Boolean strict;
+    public @Nullable Boolean strict;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
      * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
     /**
      * When set, this method only performs the <a href="https://playwright.dev/java/docs/actionability">actionability</a>
      * checks and skips the action. Defaults to {@code false}. Useful to wait until the element is ready for the action without
      * performing it.
      */
-    public Boolean trial;
+    public @Nullable Boolean trial;
 
     /**
      * Whether to bypass the <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks. Defaults to
@@ -1960,7 +1961,7 @@ public interface Frame {
      * Page.setDefaultNavigationTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
     /**
      * When to consider operation succeeded, defaults to {@code load}. Events can be either:
      * <ul>
@@ -1971,7 +1972,7 @@ public interface Frame {
      * <li> {@code "commit"} - consider operation to be finished when network response is received and the document started loading.</li>
      * </ul>
      */
-    public WaitUntilState waitUntil;
+    public @Nullable WaitUntilState waitUntil;
 
     /**
      * Maximum operation time in milliseconds, defaults to 30 seconds, pass {@code 0} to disable timeout. The default value can
@@ -2004,19 +2005,19 @@ public interface Frame {
     /**
      * @deprecated This option has no effect.
      */
-    public Boolean noWaitAfter;
+    public @Nullable Boolean noWaitAfter;
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
-    public Boolean strict;
+    public @Nullable Boolean strict;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
      * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * @deprecated This option has no effect.
@@ -2049,48 +2050,48 @@ public interface Frame {
      * Whether to bypass the <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks. Defaults to
      * {@code false}.
      */
-    public Boolean force;
+    public @Nullable Boolean force;
     /**
      * Modifier keys to press. Ensures that only these modifiers are pressed during the operation, and then restores current
      * modifiers back. If not specified, currently pressed modifiers are used. "ControlOrMeta" resolves to "Control" on Windows
      * and Linux and to "Meta" on macOS.
      */
-    public List<KeyboardModifier> modifiers;
+    public @Nullable List<KeyboardModifier> modifiers;
     /**
      * @deprecated This option has no effect.
      */
-    public Boolean noWaitAfter;
+    public @Nullable Boolean noWaitAfter;
     /**
      * A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the
      * element.
      */
-    public Position position;
+    public @Nullable Position position;
     /**
      * Controls whether Playwright scrolls the element into view before performing the action. Defaults to {@code "auto"},
      * which scrolls the element into view when necessary, including scrolling nested scrollable containers. When set to {@code
      * "none"}, Playwright does not scroll the element and the action fails if the element is not already in the viewport. This
      * is useful to assert that an element is reachable by the user without additional scrolling.
      */
-    public ScrollMode scroll;
+    public @Nullable ScrollMode scroll;
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
-    public Boolean strict;
+    public @Nullable Boolean strict;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
      * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
     /**
      * When set, this method only performs the <a href="https://playwright.dev/java/docs/actionability">actionability</a>
      * checks and skips the action. Defaults to {@code false}. Useful to wait until the element is ready for the action without
      * performing it. Note that keyboard {@code modifiers} will be pressed regardless of {@code trial} to allow testing
      * elements which are only visible when those keys are pressed.
      */
-    public Boolean trial;
+    public @Nullable Boolean trial;
 
     /**
      * Whether to bypass the <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks. Defaults to
@@ -2175,14 +2176,14 @@ public interface Frame {
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
-    public Boolean strict;
+    public @Nullable Boolean strict;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
      * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
@@ -2207,23 +2208,23 @@ public interface Frame {
     /**
      * Time to wait between key presses in milliseconds. Defaults to 0.
      */
-    public Double delay;
+    public @Nullable Double delay;
     /**
      * @deprecated This option has no effect.
      */
-    public Boolean noWaitAfter;
+    public @Nullable Boolean noWaitAfter;
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
-    public Boolean strict;
+    public @Nullable Boolean strict;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
      * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * Time to wait between key presses in milliseconds. Defaults to 0.
@@ -2263,41 +2264,41 @@ public interface Frame {
      * Whether to bypass the <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks. Defaults to
      * {@code false}.
      */
-    public Boolean force;
+    public @Nullable Boolean force;
     /**
      * @deprecated This option has no effect.
      */
-    public Boolean noWaitAfter;
+    public @Nullable Boolean noWaitAfter;
     /**
      * A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the
      * element.
      */
-    public Position position;
+    public @Nullable Position position;
     /**
      * Controls whether Playwright scrolls the element into view before performing the action. Defaults to {@code "auto"},
      * which scrolls the element into view when necessary, including scrolling nested scrollable containers. When set to {@code
      * "none"}, Playwright does not scroll the element and the action fails if the element is not already in the viewport. This
      * is useful to assert that an element is reachable by the user without additional scrolling.
      */
-    public ScrollMode scroll;
+    public @Nullable ScrollMode scroll;
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
-    public Boolean strict;
+    public @Nullable Boolean strict;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
      * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
     /**
      * When set, this method only performs the <a href="https://playwright.dev/java/docs/actionability">actionability</a>
      * checks and skips the action. Defaults to {@code false}. Useful to wait until the element is ready for the action without
      * performing it.
      */
-    public Boolean trial;
+    public @Nullable Boolean trial;
 
     /**
      * Whether to bypass the <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks. Defaults to
@@ -2372,14 +2373,14 @@ public interface Frame {
      * If specified, then it is treated as an interval in milliseconds at which the function would be executed. By default if
      * the option is not specified {@code expression} is executed in {@code requestAnimationFrame} callback.
      */
-    public Double pollingInterval;
+    public @Nullable Double pollingInterval;
     /**
      * Maximum time to wait for in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The
      * default value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * If specified, then it is treated as an interval in milliseconds at which the function would be executed. By default if
@@ -2409,7 +2410,7 @@ public interface Frame {
      * Page.setDefaultNavigationTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * Maximum operation time in milliseconds, defaults to 30 seconds, pass {@code 0} to disable timeout. The default value can
@@ -2433,13 +2434,13 @@ public interface Frame {
      * Page.setDefaultNavigationTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
     /**
      * A glob pattern, regex pattern, or predicate receiving [URL] to match while waiting for the navigation. Note that if the
      * parameter is a string without wildcard characters, the method will wait for navigation to URL that is exactly equal to
      * the string.
      */
-    public Object url;
+    public @Nullable Object url;
     /**
      * When to consider operation succeeded, defaults to {@code load}. Events can be either:
      * <ul>
@@ -2450,7 +2451,7 @@ public interface Frame {
      * <li> {@code "commit"} - consider operation to be finished when network response is received and the document started loading.</li>
      * </ul>
      */
-    public WaitUntilState waitUntil;
+    public @Nullable WaitUntilState waitUntil;
 
     /**
      * Maximum operation time in milliseconds, defaults to 30 seconds, pass {@code 0} to disable timeout. The default value can
@@ -2518,19 +2519,19 @@ public interface Frame {
      * visibility:hidden}. This is opposite to the {@code "visible"} option.</li>
      * </ul>
      */
-    public WaitForSelectorState state;
+    public @Nullable WaitForSelectorState state;
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
-    public Boolean strict;
+    public @Nullable Boolean strict;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
      * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * Defaults to {@code "visible"}. Can be either:
@@ -2575,7 +2576,7 @@ public interface Frame {
      * Page.setDefaultNavigationTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
     /**
      * When to consider operation succeeded, defaults to {@code load}. Events can be either:
      * <ul>
@@ -2586,7 +2587,7 @@ public interface Frame {
      * <li> {@code "commit"} - consider operation to be finished when network response is received and the document started loading.</li>
      * </ul>
      */
-    public WaitUntilState waitUntil;
+    public @Nullable WaitUntilState waitUntil;
 
     /**
      * Maximum operation time in milliseconds, defaults to 30 seconds, pass {@code 0} to disable timeout. The default value can
@@ -2632,7 +2633,7 @@ public interface Frame {
    *
    * @since v1.8
    */
-  ElementHandle addScriptTag(AddScriptTagOptions options);
+  ElementHandle addScriptTag(@Nullable AddScriptTagOptions options);
   /**
    * Returns the added tag when the stylesheet's onload fires or when the CSS content was injected into frame.
    *
@@ -2652,7 +2653,7 @@ public interface Frame {
    *
    * @since v1.8
    */
-  ElementHandle addStyleTag(AddStyleTagOptions options);
+  ElementHandle addStyleTag(@Nullable AddStyleTagOptions options);
   /**
    * This method checks an element matching {@code selector} by performing the following steps:
    * <ol>
@@ -2694,7 +2695,7 @@ public interface Frame {
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used.
    * @since v1.8
    */
-  void check(String selector, CheckOptions options);
+  void check(String selector, @Nullable CheckOptions options);
   /**
    *
    *
@@ -2740,7 +2741,7 @@ public interface Frame {
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used.
    * @since v1.8
    */
-  void click(String selector, ClickOptions options);
+  void click(String selector, @Nullable ClickOptions options);
   /**
    * Gets the full HTML contents of the frame, including the doctype.
    *
@@ -2790,7 +2791,7 @@ public interface Frame {
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used.
    * @since v1.8
    */
-  void dblclick(String selector, DblclickOptions options);
+  void dblclick(String selector, @Nullable DblclickOptions options);
   /**
    * The snippet below dispatches the {@code click} event on the element. Regardless of the visibility state of the element,
    * {@code click} is dispatched. This is equivalent to calling <a
@@ -2834,7 +2835,7 @@ public interface Frame {
    * @param eventInit Optional event-specific initialization properties.
    * @since v1.8
    */
-  default void dispatchEvent(String selector, String type, Object eventInit) {
+  default void dispatchEvent(String selector, String type, @Nullable Object eventInit) {
     dispatchEvent(selector, type, eventInit, null);
   }
   /**
@@ -2925,7 +2926,7 @@ public interface Frame {
    * @param eventInit Optional event-specific initialization properties.
    * @since v1.8
    */
-  void dispatchEvent(String selector, String type, Object eventInit, DispatchEventOptions options);
+  void dispatchEvent(String selector, String type, @Nullable Object eventInit, @Nullable DispatchEventOptions options);
   /**
    *
    *
@@ -2947,7 +2948,7 @@ public interface Frame {
    * be used.
    * @since v1.13
    */
-  void dragAndDrop(String source, String target, DragAndDropOptions options);
+  void dragAndDrop(String source, String target, @Nullable DragAndDropOptions options);
   /**
    * Returns the return value of {@code expression}.
    *
@@ -2972,7 +2973,7 @@ public interface Frame {
    * @param arg Optional argument to pass to {@code expression}.
    * @since v1.9
    */
-  default Object evalOnSelector(String selector, String expression, Object arg) {
+  default @Nullable Object evalOnSelector(String selector, String expression, @Nullable Object arg) {
     return evalOnSelector(selector, expression, arg, null);
   }
   /**
@@ -2998,7 +2999,7 @@ public interface Frame {
    * automatically invoked.
    * @since v1.9
    */
-  default Object evalOnSelector(String selector, String expression) {
+  default @Nullable Object evalOnSelector(String selector, String expression) {
     return evalOnSelector(selector, expression, null);
   }
   /**
@@ -3025,7 +3026,7 @@ public interface Frame {
    * @param arg Optional argument to pass to {@code expression}.
    * @since v1.9
    */
-  Object evalOnSelector(String selector, String expression, Object arg, EvalOnSelectorOptions options);
+  @Nullable Object evalOnSelector(String selector, String expression, @Nullable Object arg, @Nullable EvalOnSelectorOptions options);
   /**
    * Returns the return value of {@code expression}.
    *
@@ -3047,7 +3048,7 @@ public interface Frame {
    * automatically invoked.
    * @since v1.9
    */
-  default Object evalOnSelectorAll(String selector, String expression) {
+  default @Nullable Object evalOnSelectorAll(String selector, String expression) {
     return evalOnSelectorAll(selector, expression, null);
   }
   /**
@@ -3072,7 +3073,7 @@ public interface Frame {
    * @param arg Optional argument to pass to {@code expression}.
    * @since v1.9
    */
-  Object evalOnSelectorAll(String selector, String expression, Object arg);
+  @Nullable Object evalOnSelectorAll(String selector, String expression, @Nullable Object arg);
   /**
    * Returns the return value of {@code expression}.
    *
@@ -3110,7 +3111,7 @@ public interface Frame {
    * automatically invoked.
    * @since v1.8
    */
-  default Object evaluate(String expression) {
+  default @Nullable Object evaluate(String expression) {
     return evaluate(expression, null);
   }
   /**
@@ -3151,7 +3152,7 @@ public interface Frame {
    * @param arg Optional argument to pass to {@code expression}.
    * @since v1.8
    */
-  Object evaluate(String expression, Object arg);
+  @Nullable Object evaluate(String expression, @Nullable Object arg);
   /**
    * Returns the return value of {@code expression} as a {@code JSHandle}.
    *
@@ -3228,7 +3229,7 @@ public interface Frame {
    * @param arg Optional argument to pass to {@code expression}.
    * @since v1.8
    */
-  JSHandle evaluateHandle(String expression, Object arg);
+  JSHandle evaluateHandle(String expression, @Nullable Object arg);
   /**
    * This method waits for an element matching {@code selector}, waits for <a
    * href="https://playwright.dev/java/docs/actionability">actionability</a> checks, focuses the element, fills it and
@@ -3266,7 +3267,7 @@ public interface Frame {
    * @param value Value to fill for the {@code <input>}, {@code <textarea>} or {@code [contenteditable]} element.
    * @since v1.8
    */
-  void fill(String selector, String value, FillOptions options);
+  void fill(String selector, String value, @Nullable FillOptions options);
   /**
    * This method fetches an element with {@code selector} and focuses it. If there's no element matching {@code selector},
    * the method waits until a matching element appears in the DOM.
@@ -3284,7 +3285,7 @@ public interface Frame {
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used.
    * @since v1.8
    */
-  void focus(String selector, FocusOptions options);
+  void focus(String selector, @Nullable FocusOptions options);
   /**
    * Returns the {@code frame} or {@code iframe} element handle which corresponds to this frame.
    *
@@ -3358,7 +3359,7 @@ public interface Frame {
    * inside it.
    * @since v1.17
    */
-  FrameLocator frameLocator(String selector);
+  FrameLocator frameLocator(@Nullable String selector);
   /**
    * Returns element attribute value.
    *
@@ -3366,7 +3367,7 @@ public interface Frame {
    * @param name Attribute name to get the value for.
    * @since v1.8
    */
-  default String getAttribute(String selector, String name) {
+  default @Nullable String getAttribute(String selector, String name) {
     return getAttribute(selector, name, null);
   }
   /**
@@ -3376,7 +3377,7 @@ public interface Frame {
    * @param name Attribute name to get the value for.
    * @since v1.8
    */
-  String getAttribute(String selector, String name, GetAttributeOptions options);
+  @Nullable String getAttribute(String selector, String name, @Nullable GetAttributeOptions options);
   /**
    * Allows locating elements by their alt text.
    *
@@ -3406,7 +3407,7 @@ public interface Frame {
    * @param text Text to locate the element for.
    * @since v1.27
    */
-  Locator getByAltText(String text, GetByAltTextOptions options);
+  Locator getByAltText(String text, @Nullable GetByAltTextOptions options);
   /**
    * Allows locating elements by their alt text.
    *
@@ -3436,7 +3437,7 @@ public interface Frame {
    * @param text Text to locate the element for.
    * @since v1.27
    */
-  Locator getByAltText(Pattern text, GetByAltTextOptions options);
+  Locator getByAltText(Pattern text, @Nullable GetByAltTextOptions options);
   /**
    * Allows locating input elements by the text of the associated {@code <label>} or {@code aria-labelledby} element, or by
    * the {@code aria-label} attribute.
@@ -3470,7 +3471,7 @@ public interface Frame {
    * @param text Text to locate the element for.
    * @since v1.27
    */
-  Locator getByLabel(String text, GetByLabelOptions options);
+  Locator getByLabel(String text, @Nullable GetByLabelOptions options);
   /**
    * Allows locating input elements by the text of the associated {@code <label>} or {@code aria-labelledby} element, or by
    * the {@code aria-label} attribute.
@@ -3504,7 +3505,7 @@ public interface Frame {
    * @param text Text to locate the element for.
    * @since v1.27
    */
-  Locator getByLabel(Pattern text, GetByLabelOptions options);
+  Locator getByLabel(Pattern text, @Nullable GetByLabelOptions options);
   /**
    * Allows locating input elements by the placeholder text.
    *
@@ -3538,7 +3539,7 @@ public interface Frame {
    * @param text Text to locate the element for.
    * @since v1.27
    */
-  Locator getByPlaceholder(String text, GetByPlaceholderOptions options);
+  Locator getByPlaceholder(String text, @Nullable GetByPlaceholderOptions options);
   /**
    * Allows locating input elements by the placeholder text.
    *
@@ -3572,7 +3573,7 @@ public interface Frame {
    * @param text Text to locate the element for.
    * @since v1.27
    */
-  Locator getByPlaceholder(Pattern text, GetByPlaceholderOptions options);
+  Locator getByPlaceholder(Pattern text, @Nullable GetByPlaceholderOptions options);
   /**
    * Allows locating elements by their <a href="https://www.w3.org/TR/wai-aria-1.2/#roles">ARIA role</a>, <a
    * href="https://www.w3.org/TR/wai-aria-1.2/#aria-attributes">ARIA attributes</a> and <a
@@ -3656,7 +3657,7 @@ public interface Frame {
    * @param role Required aria role.
    * @since v1.27
    */
-  Locator getByRole(AriaRole role, GetByRoleOptions options);
+  Locator getByRole(AriaRole role, @Nullable GetByRoleOptions options);
   /**
    * Locate element by the test id.
    *
@@ -3782,7 +3783,7 @@ public interface Frame {
    * @param text Text to locate the element for.
    * @since v1.27
    */
-  Locator getByText(String text, GetByTextOptions options);
+  Locator getByText(String text, @Nullable GetByTextOptions options);
   /**
    * Allows locating elements that contain given text.
    *
@@ -3864,7 +3865,7 @@ public interface Frame {
    * @param text Text to locate the element for.
    * @since v1.27
    */
-  Locator getByText(Pattern text, GetByTextOptions options);
+  Locator getByText(Pattern text, @Nullable GetByTextOptions options);
   /**
    * Allows locating elements by their title attribute.
    *
@@ -3898,7 +3899,7 @@ public interface Frame {
    * @param text Text to locate the element for.
    * @since v1.27
    */
-  Locator getByTitle(String text, GetByTitleOptions options);
+  Locator getByTitle(String text, @Nullable GetByTitleOptions options);
   /**
    * Allows locating elements by their title attribute.
    *
@@ -3932,7 +3933,7 @@ public interface Frame {
    * @param text Text to locate the element for.
    * @since v1.27
    */
-  Locator getByTitle(Pattern text, GetByTitleOptions options);
+  Locator getByTitle(Pattern text, @Nullable GetByTitleOptions options);
   /**
    * Returns the main resource response. In case of multiple redirects, the navigation will resolve with the response of the
    * last redirect.
@@ -3959,7 +3960,7 @@ public interface Frame {
    * @param url URL to navigate frame to. The url should include scheme, e.g. {@code https://}.
    * @since v1.8
    */
-  default Response navigate(String url) {
+  default @Nullable Response navigate(String url) {
     return navigate(url, null);
   }
   /**
@@ -3988,7 +3989,7 @@ public interface Frame {
    * @param url URL to navigate frame to. The url should include scheme, e.g. {@code https://}.
    * @since v1.8
    */
-  Response navigate(String url, NavigateOptions options);
+  @Nullable Response navigate(String url, @Nullable NavigateOptions options);
   /**
    * This method hovers over an element matching {@code selector} by performing the following steps:
    * <ol>
@@ -4026,7 +4027,7 @@ public interface Frame {
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used.
    * @since v1.8
    */
-  void hover(String selector, HoverOptions options);
+  void hover(String selector, @Nullable HoverOptions options);
   /**
    * Returns {@code element.innerHTML}.
    *
@@ -4042,7 +4043,7 @@ public interface Frame {
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used.
    * @since v1.8
    */
-  String innerHTML(String selector, InnerHTMLOptions options);
+  String innerHTML(String selector, @Nullable InnerHTMLOptions options);
   /**
    * Returns {@code element.innerText}.
    *
@@ -4058,7 +4059,7 @@ public interface Frame {
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used.
    * @since v1.8
    */
-  String innerText(String selector, InnerTextOptions options);
+  String innerText(String selector, @Nullable InnerTextOptions options);
   /**
    * Returns {@code input.value} for the selected {@code <input>} or {@code <textarea>} or {@code <select>} element.
    *
@@ -4082,7 +4083,7 @@ public interface Frame {
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used.
    * @since v1.13
    */
-  String inputValue(String selector, InputValueOptions options);
+  String inputValue(String selector, @Nullable InputValueOptions options);
   /**
    * Returns whether the element is checked. Throws if the element is not a checkbox or radio input.
    *
@@ -4098,7 +4099,7 @@ public interface Frame {
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used.
    * @since v1.8
    */
-  boolean isChecked(String selector, IsCheckedOptions options);
+  boolean isChecked(String selector, @Nullable IsCheckedOptions options);
   /**
    * Returns {@code true} if the frame has been detached, or {@code false} otherwise.
    *
@@ -4122,7 +4123,7 @@ public interface Frame {
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used.
    * @since v1.8
    */
-  boolean isDisabled(String selector, IsDisabledOptions options);
+  boolean isDisabled(String selector, @Nullable IsDisabledOptions options);
   /**
    * Returns whether the element is <a href="https://playwright.dev/java/docs/actionability#editable">editable</a>.
    *
@@ -4138,7 +4139,7 @@ public interface Frame {
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used.
    * @since v1.8
    */
-  boolean isEditable(String selector, IsEditableOptions options);
+  boolean isEditable(String selector, @Nullable IsEditableOptions options);
   /**
    * Returns whether the element is <a href="https://playwright.dev/java/docs/actionability#enabled">enabled</a>.
    *
@@ -4154,7 +4155,7 @@ public interface Frame {
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used.
    * @since v1.8
    */
-  boolean isEnabled(String selector, IsEnabledOptions options);
+  boolean isEnabled(String selector, @Nullable IsEnabledOptions options);
   /**
    * Returns whether the element is hidden, the opposite of <a
    * href="https://playwright.dev/java/docs/actionability#visible">visible</a>.  {@code selector} that does not match any
@@ -4174,7 +4175,7 @@ public interface Frame {
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used.
    * @since v1.8
    */
-  boolean isHidden(String selector, IsHiddenOptions options);
+  boolean isHidden(String selector, @Nullable IsHiddenOptions options);
   /**
    * Returns whether the element is <a href="https://playwright.dev/java/docs/actionability#visible">visible</a>. {@code
    * selector} that does not match any elements is considered not visible.
@@ -4192,7 +4193,7 @@ public interface Frame {
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used.
    * @since v1.8
    */
-  boolean isVisible(String selector, IsVisibleOptions options);
+  boolean isVisible(String selector, @Nullable IsVisibleOptions options);
   /**
    * The method returns an element locator that can be used to perform actions on this page / frame. Locator is resolved to
    * the element immediately before performing an action, so a series of actions on the same locator can in fact be performed
@@ -4220,7 +4221,7 @@ public interface Frame {
    * @param selector A selector to use when resolving DOM element.
    * @since v1.14
    */
-  Locator locator(String selector, LocatorOptions options);
+  Locator locator(String selector, @Nullable LocatorOptions options);
   /**
    * Returns frame's name attribute as specified in the tag.
    *
@@ -4242,7 +4243,7 @@ public interface Frame {
    *
    * @since v1.8
    */
-  Frame parentFrame();
+  @Nullable Frame parentFrame();
   /**
    * {@code key} can specify the intended <a
    * href="https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key">keyboardEvent.key</a> value or a single
@@ -4300,7 +4301,7 @@ public interface Frame {
    * @param key Name of the key to press or a character to generate, such as {@code ArrowLeft} or {@code a}.
    * @since v1.8
    */
-  void press(String selector, String key, PressOptions options);
+  void press(String selector, String key, @Nullable PressOptions options);
   /**
    * Returns the ElementHandle pointing to the frame element.
    *
@@ -4312,7 +4313,7 @@ public interface Frame {
    * @param selector A selector to query for.
    * @since v1.9
    */
-  default ElementHandle querySelector(String selector) {
+  default @Nullable ElementHandle querySelector(String selector) {
     return querySelector(selector, null);
   }
   /**
@@ -4326,7 +4327,7 @@ public interface Frame {
    * @param selector A selector to query for.
    * @since v1.9
    */
-  ElementHandle querySelector(String selector, QuerySelectorOptions options);
+  @Nullable ElementHandle querySelector(String selector, @Nullable QuerySelectorOptions options);
   /**
    * Returns the ElementHandles pointing to the frame elements.
    *
@@ -4402,7 +4403,7 @@ public interface Frame {
    * and labels. Option is considered matching if all specified properties match.
    * @since v1.8
    */
-  List<String> selectOption(String selector, String values, SelectOptionOptions options);
+  List<String> selectOption(String selector, String values, @Nullable SelectOptionOptions options);
   /**
    * This method waits for an element matching {@code selector}, waits for <a
    * href="https://playwright.dev/java/docs/actionability">actionability</a> checks, waits until all specified options are
@@ -4466,7 +4467,7 @@ public interface Frame {
    * and labels. Option is considered matching if all specified properties match.
    * @since v1.8
    */
-  List<String> selectOption(String selector, ElementHandle values, SelectOptionOptions options);
+  List<String> selectOption(String selector, ElementHandle values, @Nullable SelectOptionOptions options);
   /**
    * This method waits for an element matching {@code selector}, waits for <a
    * href="https://playwright.dev/java/docs/actionability">actionability</a> checks, waits until all specified options are
@@ -4530,7 +4531,7 @@ public interface Frame {
    * and labels. Option is considered matching if all specified properties match.
    * @since v1.8
    */
-  List<String> selectOption(String selector, String[] values, SelectOptionOptions options);
+  List<String> selectOption(String selector, String[] values, @Nullable SelectOptionOptions options);
   /**
    * This method waits for an element matching {@code selector}, waits for <a
    * href="https://playwright.dev/java/docs/actionability">actionability</a> checks, waits until all specified options are
@@ -4594,7 +4595,7 @@ public interface Frame {
    * and labels. Option is considered matching if all specified properties match.
    * @since v1.8
    */
-  List<String> selectOption(String selector, SelectOption values, SelectOptionOptions options);
+  List<String> selectOption(String selector, SelectOption values, @Nullable SelectOptionOptions options);
   /**
    * This method waits for an element matching {@code selector}, waits for <a
    * href="https://playwright.dev/java/docs/actionability">actionability</a> checks, waits until all specified options are
@@ -4658,7 +4659,7 @@ public interface Frame {
    * and labels. Option is considered matching if all specified properties match.
    * @since v1.8
    */
-  List<String> selectOption(String selector, ElementHandle[] values, SelectOptionOptions options);
+  List<String> selectOption(String selector, ElementHandle[] values, @Nullable SelectOptionOptions options);
   /**
    * This method waits for an element matching {@code selector}, waits for <a
    * href="https://playwright.dev/java/docs/actionability">actionability</a> checks, waits until all specified options are
@@ -4722,7 +4723,7 @@ public interface Frame {
    * and labels. Option is considered matching if all specified properties match.
    * @since v1.8
    */
-  List<String> selectOption(String selector, SelectOption[] values, SelectOptionOptions options);
+  List<String> selectOption(String selector, SelectOption[] values, @Nullable SelectOptionOptions options);
   /**
    * This method checks or unchecks an element matching {@code selector} by performing the following steps:
    * <ol>
@@ -4766,7 +4767,7 @@ public interface Frame {
    * @param checked Whether to check or uncheck the checkbox.
    * @since v1.15
    */
-  void setChecked(String selector, boolean checked, SetCheckedOptions options);
+  void setChecked(String selector, boolean checked, @Nullable SetCheckedOptions options);
   /**
    * This method internally calls <a
    * href="https://developer.mozilla.org/en-US/docs/Web/API/Document/write">document.write()</a>, inheriting all its specific
@@ -4786,7 +4787,7 @@ public interface Frame {
    * @param html HTML markup to assign to the page.
    * @since v1.8
    */
-  void setContent(String html, SetContentOptions options);
+  void setContent(String html, @Nullable SetContentOptions options);
   /**
    * Sets the value of the file input to these file paths or files. If some of the {@code filePaths} are relative paths, then
    * they are resolved relative to the current working directory. For empty array, clears the selected files.
@@ -4816,7 +4817,7 @@ public interface Frame {
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used.
    * @since v1.8
    */
-  void setInputFiles(String selector, Path files, SetInputFilesOptions options);
+  void setInputFiles(String selector, Path files, @Nullable SetInputFilesOptions options);
   /**
    * Sets the value of the file input to these file paths or files. If some of the {@code filePaths} are relative paths, then
    * they are resolved relative to the current working directory. For empty array, clears the selected files.
@@ -4846,7 +4847,7 @@ public interface Frame {
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used.
    * @since v1.8
    */
-  void setInputFiles(String selector, Path[] files, SetInputFilesOptions options);
+  void setInputFiles(String selector, Path[] files, @Nullable SetInputFilesOptions options);
   /**
    * Sets the value of the file input to these file paths or files. If some of the {@code filePaths} are relative paths, then
    * they are resolved relative to the current working directory. For empty array, clears the selected files.
@@ -4876,7 +4877,7 @@ public interface Frame {
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used.
    * @since v1.8
    */
-  void setInputFiles(String selector, FilePayload files, SetInputFilesOptions options);
+  void setInputFiles(String selector, FilePayload files, @Nullable SetInputFilesOptions options);
   /**
    * Sets the value of the file input to these file paths or files. If some of the {@code filePaths} are relative paths, then
    * they are resolved relative to the current working directory. For empty array, clears the selected files.
@@ -4906,7 +4907,7 @@ public interface Frame {
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used.
    * @since v1.8
    */
-  void setInputFiles(String selector, FilePayload[] files, SetInputFilesOptions options);
+  void setInputFiles(String selector, FilePayload[] files, @Nullable SetInputFilesOptions options);
   /**
    * This method taps an element matching {@code selector} by performing the following steps:
    * <ol>
@@ -4948,14 +4949,14 @@ public interface Frame {
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used.
    * @since v1.8
    */
-  void tap(String selector, TapOptions options);
+  void tap(String selector, @Nullable TapOptions options);
   /**
    * Returns {@code element.textContent}.
    *
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used.
    * @since v1.8
    */
-  default String textContent(String selector) {
+  default @Nullable String textContent(String selector) {
     return textContent(selector, null);
   }
   /**
@@ -4964,7 +4965,7 @@ public interface Frame {
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used.
    * @since v1.8
    */
-  String textContent(String selector, TextContentOptions options);
+  @Nullable String textContent(String selector, @Nullable TextContentOptions options);
   /**
    * Returns the page title.
    *
@@ -4992,7 +4993,7 @@ public interface Frame {
    * @param text A text to type into a focused element.
    * @since v1.8
    */
-  void type(String selector, String text, TypeOptions options);
+  void type(String selector, String text, @Nullable TypeOptions options);
   /**
    * This method checks an element matching {@code selector} by performing the following steps:
    * <ol>
@@ -5034,7 +5035,7 @@ public interface Frame {
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used.
    * @since v1.8
    */
-  void uncheck(String selector, UncheckOptions options);
+  void uncheck(String selector, @Nullable UncheckOptions options);
   /**
    * Returns frame's url.
    *
@@ -5076,7 +5077,7 @@ public interface Frame {
    * @param arg Optional argument to pass to {@code expression}.
    * @since v1.8
    */
-  default JSHandle waitForFunction(String expression, Object arg) {
+  default JSHandle waitForFunction(String expression, @Nullable Object arg) {
     return waitForFunction(expression, arg, null);
   }
   /**
@@ -5151,7 +5152,7 @@ public interface Frame {
    * @param arg Optional argument to pass to {@code expression}.
    * @since v1.8
    */
-  JSHandle waitForFunction(String expression, Object arg, WaitForFunctionOptions options);
+  JSHandle waitForFunction(String expression, @Nullable Object arg, @Nullable WaitForFunctionOptions options);
   /**
    * Waits for the required load state to be reached.
    *
@@ -5177,7 +5178,7 @@ public interface Frame {
    * </ul>
    * @since v1.8
    */
-  default void waitForLoadState(LoadState state) {
+  default void waitForLoadState(@Nullable LoadState state) {
     waitForLoadState(state, null);
   }
   /**
@@ -5225,14 +5226,14 @@ public interface Frame {
    * </ul>
    * @since v1.8
    */
-  void waitForLoadState(LoadState state, WaitForLoadStateOptions options);
+  void waitForLoadState(@Nullable LoadState state, @Nullable WaitForLoadStateOptions options);
   /**
    * @deprecated This method is inherently racy, please use {@link com.microsoft.playwright.Frame#waitForURL Frame.waitForURL()} instead.
    *
    * @param callback Callback that performs the action triggering the event.
    * @since v1.8
    */
-  default Response waitForNavigation(Runnable callback) {
+  default @Nullable Response waitForNavigation(Runnable callback) {
     return waitForNavigation(null, callback);
   }
   /**
@@ -5241,7 +5242,7 @@ public interface Frame {
    * @param callback Callback that performs the action triggering the event.
    * @since v1.8
    */
-  Response waitForNavigation(WaitForNavigationOptions options, Runnable callback);
+  @Nullable Response waitForNavigation(@Nullable WaitForNavigationOptions options, Runnable callback);
   /**
    * Returns when element specified by selector satisfies {@code state} option. Returns {@code null} if waiting for {@code
    * hidden} or {@code detached}.
@@ -5280,7 +5281,7 @@ public interface Frame {
    * @param selector A selector to query for.
    * @since v1.8
    */
-  default ElementHandle waitForSelector(String selector) {
+  default @Nullable ElementHandle waitForSelector(String selector) {
     return waitForSelector(selector, null);
   }
   /**
@@ -5321,7 +5322,7 @@ public interface Frame {
    * @param selector A selector to query for.
    * @since v1.8
    */
-  ElementHandle waitForSelector(String selector, WaitForSelectorOptions options);
+  @Nullable ElementHandle waitForSelector(String selector, @Nullable WaitForSelectorOptions options);
   /**
    * Waits for the given {@code timeout} in milliseconds.
    *
@@ -5363,7 +5364,7 @@ public interface Frame {
    * the string.
    * @since v1.11
    */
-  void waitForURL(String url, WaitForURLOptions options);
+  void waitForURL(String url, @Nullable WaitForURLOptions options);
   /**
    * Waits for the frame to navigate to the given URL.
    *
@@ -5395,7 +5396,7 @@ public interface Frame {
    * the string.
    * @since v1.11
    */
-  void waitForURL(Pattern url, WaitForURLOptions options);
+  void waitForURL(Pattern url, @Nullable WaitForURLOptions options);
   /**
    * Waits for the frame to navigate to the given URL.
    *
@@ -5427,6 +5428,6 @@ public interface Frame {
    * the string.
    * @since v1.11
    */
-  void waitForURL(Predicate<String> url, WaitForURLOptions options);
+  void waitForURL(Predicate<String> url, @Nullable WaitForURLOptions options);
 }
 

--- a/playwright/src/main/java/com/microsoft/playwright/FrameLocator.java
+++ b/playwright/src/main/java/com/microsoft/playwright/FrameLocator.java
@@ -16,6 +16,7 @@
 
 package com.microsoft.playwright;
 
+import org.jspecify.annotations.Nullable;
 import com.microsoft.playwright.options.*;
 import java.util.regex.Pattern;
 
@@ -78,7 +79,7 @@ public interface FrameLocator {
      * Whether to find an exact match: case-sensitive and whole-string. Default to false. Ignored when locating by a regular
      * expression. Note that exact match still trims whitespace.
      */
-    public Boolean exact;
+    public @Nullable Boolean exact;
 
     /**
      * Whether to find an exact match: case-sensitive and whole-string. Default to false. Ignored when locating by a regular
@@ -94,7 +95,7 @@ public interface FrameLocator {
      * Whether to find an exact match: case-sensitive and whole-string. Default to false. Ignored when locating by a regular
      * expression. Note that exact match still trims whitespace.
      */
-    public Boolean exact;
+    public @Nullable Boolean exact;
 
     /**
      * Whether to find an exact match: case-sensitive and whole-string. Default to false. Ignored when locating by a regular
@@ -110,7 +111,7 @@ public interface FrameLocator {
      * Whether to find an exact match: case-sensitive and whole-string. Default to false. Ignored when locating by a regular
      * expression. Note that exact match still trims whitespace.
      */
-    public Boolean exact;
+    public @Nullable Boolean exact;
 
     /**
      * Whether to find an exact match: case-sensitive and whole-string. Default to false. Ignored when locating by a regular
@@ -127,65 +128,65 @@ public interface FrameLocator {
      *
      * <p> Learn more about <a href="https://www.w3.org/TR/wai-aria-1.2/#aria-checked">{@code aria-checked}</a>.
      */
-    public Boolean checked;
+    public @Nullable Boolean checked;
     /**
      * Option to match the <a href="https://w3c.github.io/accname/#dfn-accessible-description">accessible description</a>. By
      * default, matching is case-insensitive and searches for a substring, use {@code exact} to control this behavior.
      *
      * <p> Learn more about <a href="https://w3c.github.io/accname/#dfn-accessible-description">accessible description</a>.
      */
-    public Object description;
+    public @Nullable Object description;
     /**
      * An attribute that is usually set by {@code aria-disabled} or {@code disabled}.
      *
      * <p> <strong>NOTE:</strong> Unlike most other attributes, {@code disabled} is inherited through the DOM hierarchy. Learn more about <a
      * href="https://www.w3.org/TR/wai-aria-1.2/#aria-disabled">{@code aria-disabled}</a>.
      */
-    public Boolean disabled;
+    public @Nullable Boolean disabled;
     /**
      * Whether {@code name} and {@code description} are matched exactly: case-sensitive and whole-string. Defaults to false.
      * Ignored when the value is a regular expression. Note that exact match still trims whitespace.
      */
-    public Boolean exact;
+    public @Nullable Boolean exact;
     /**
      * An attribute that is usually set by {@code aria-expanded}.
      *
      * <p> Learn more about <a href="https://www.w3.org/TR/wai-aria-1.2/#aria-expanded">{@code aria-expanded}</a>.
      */
-    public Boolean expanded;
+    public @Nullable Boolean expanded;
     /**
      * Option that controls whether hidden elements are matched. By default, only non-hidden elements, as <a
      * href="https://www.w3.org/TR/wai-aria-1.2/#tree_exclusion">defined by ARIA</a>, are matched by role selector.
      *
      * <p> Learn more about <a href="https://www.w3.org/TR/wai-aria-1.2/#aria-hidden">{@code aria-hidden}</a>.
      */
-    public Boolean includeHidden;
+    public @Nullable Boolean includeHidden;
     /**
      * A number attribute that is usually present for roles {@code heading}, {@code listitem}, {@code row}, {@code treeitem},
      * with default values for {@code <h1>-<h6>} elements.
      *
      * <p> Learn more about <a href="https://www.w3.org/TR/wai-aria-1.2/#aria-level">{@code aria-level}</a>.
      */
-    public Integer level;
+    public @Nullable Integer level;
     /**
      * Option to match the <a href="https://w3c.github.io/accname/#dfn-accessible-name">accessible name</a>. By default,
      * matching is case-insensitive and searches for a substring, use {@code exact} to control this behavior.
      *
      * <p> Learn more about <a href="https://w3c.github.io/accname/#dfn-accessible-name">accessible name</a>.
      */
-    public Object name;
+    public @Nullable Object name;
     /**
      * An attribute that is usually set by {@code aria-pressed}.
      *
      * <p> Learn more about <a href="https://www.w3.org/TR/wai-aria-1.2/#aria-pressed">{@code aria-pressed}</a>.
      */
-    public Boolean pressed;
+    public @Nullable Boolean pressed;
     /**
      * An attribute that is usually set by {@code aria-selected}.
      *
      * <p> Learn more about <a href="https://www.w3.org/TR/wai-aria-1.2/#aria-selected">{@code aria-selected}</a>.
      */
-    public Boolean selected;
+    public @Nullable Boolean selected;
 
     /**
      * An attribute that is usually set by {@code aria-checked} or native {@code <input type=checkbox>} controls.
@@ -307,7 +308,7 @@ public interface FrameLocator {
      * Whether to find an exact match: case-sensitive and whole-string. Default to false. Ignored when locating by a regular
      * expression. Note that exact match still trims whitespace.
      */
-    public Boolean exact;
+    public @Nullable Boolean exact;
 
     /**
      * Whether to find an exact match: case-sensitive and whole-string. Default to false. Ignored when locating by a regular
@@ -323,7 +324,7 @@ public interface FrameLocator {
      * Whether to find an exact match: case-sensitive and whole-string. Default to false. Ignored when locating by a regular
      * expression. Note that exact match still trims whitespace.
      */
-    public Boolean exact;
+    public @Nullable Boolean exact;
 
     /**
      * Whether to find an exact match: case-sensitive and whole-string. Default to false. Ignored when locating by a regular
@@ -347,7 +348,7 @@ public interface FrameLocator {
      *
      * <p> Note that outer and inner locators must belong to the same frame. Inner locator must not contain {@code FrameLocator}s.
      */
-    public Locator has;
+    public @Nullable Locator has;
     /**
      * Matches elements that do not contain an element that matches an inner locator. Inner locator is queried against the
      * outer one. For example, {@code article} that does not have {@code div} matches {@code
@@ -355,18 +356,18 @@ public interface FrameLocator {
      *
      * <p> Note that outer and inner locators must belong to the same frame. Inner locator must not contain {@code FrameLocator}s.
      */
-    public Locator hasNot;
+    public @Nullable Locator hasNot;
     /**
      * Matches elements that do not contain specified text somewhere inside, possibly in a child or a descendant element. When
      * passed a [string], matching is case-insensitive and searches for a substring.
      */
-    public Object hasNotText;
+    public @Nullable Object hasNotText;
     /**
      * Matches elements containing specified text somewhere inside, possibly in a child or a descendant element. When passed a
      * [string], matching is case-insensitive and searches for a substring. For example, {@code "Playwright"} matches {@code
      * <article><div>Playwright</div></article>}.
      */
-    public Object hasText;
+    public @Nullable Object hasText;
 
     /**
      * Narrows down the results of the method to those which contain elements matching this relative locator. For example,
@@ -474,7 +475,7 @@ public interface FrameLocator {
    * @param text Text to locate the element for.
    * @since v1.27
    */
-  Locator getByAltText(String text, GetByAltTextOptions options);
+  Locator getByAltText(String text, @Nullable GetByAltTextOptions options);
   /**
    * Allows locating elements by their alt text.
    *
@@ -504,7 +505,7 @@ public interface FrameLocator {
    * @param text Text to locate the element for.
    * @since v1.27
    */
-  Locator getByAltText(Pattern text, GetByAltTextOptions options);
+  Locator getByAltText(Pattern text, @Nullable GetByAltTextOptions options);
   /**
    * Allows locating input elements by the text of the associated {@code <label>} or {@code aria-labelledby} element, or by
    * the {@code aria-label} attribute.
@@ -538,7 +539,7 @@ public interface FrameLocator {
    * @param text Text to locate the element for.
    * @since v1.27
    */
-  Locator getByLabel(String text, GetByLabelOptions options);
+  Locator getByLabel(String text, @Nullable GetByLabelOptions options);
   /**
    * Allows locating input elements by the text of the associated {@code <label>} or {@code aria-labelledby} element, or by
    * the {@code aria-label} attribute.
@@ -572,7 +573,7 @@ public interface FrameLocator {
    * @param text Text to locate the element for.
    * @since v1.27
    */
-  Locator getByLabel(Pattern text, GetByLabelOptions options);
+  Locator getByLabel(Pattern text, @Nullable GetByLabelOptions options);
   /**
    * Allows locating input elements by the placeholder text.
    *
@@ -606,7 +607,7 @@ public interface FrameLocator {
    * @param text Text to locate the element for.
    * @since v1.27
    */
-  Locator getByPlaceholder(String text, GetByPlaceholderOptions options);
+  Locator getByPlaceholder(String text, @Nullable GetByPlaceholderOptions options);
   /**
    * Allows locating input elements by the placeholder text.
    *
@@ -640,7 +641,7 @@ public interface FrameLocator {
    * @param text Text to locate the element for.
    * @since v1.27
    */
-  Locator getByPlaceholder(Pattern text, GetByPlaceholderOptions options);
+  Locator getByPlaceholder(Pattern text, @Nullable GetByPlaceholderOptions options);
   /**
    * Allows locating elements by their <a href="https://www.w3.org/TR/wai-aria-1.2/#roles">ARIA role</a>, <a
    * href="https://www.w3.org/TR/wai-aria-1.2/#aria-attributes">ARIA attributes</a> and <a
@@ -724,7 +725,7 @@ public interface FrameLocator {
    * @param role Required aria role.
    * @since v1.27
    */
-  Locator getByRole(AriaRole role, GetByRoleOptions options);
+  Locator getByRole(AriaRole role, @Nullable GetByRoleOptions options);
   /**
    * Locate element by the test id.
    *
@@ -850,7 +851,7 @@ public interface FrameLocator {
    * @param text Text to locate the element for.
    * @since v1.27
    */
-  Locator getByText(String text, GetByTextOptions options);
+  Locator getByText(String text, @Nullable GetByTextOptions options);
   /**
    * Allows locating elements that contain given text.
    *
@@ -932,7 +933,7 @@ public interface FrameLocator {
    * @param text Text to locate the element for.
    * @since v1.27
    */
-  Locator getByText(Pattern text, GetByTextOptions options);
+  Locator getByText(Pattern text, @Nullable GetByTextOptions options);
   /**
    * Allows locating elements by their title attribute.
    *
@@ -966,7 +967,7 @@ public interface FrameLocator {
    * @param text Text to locate the element for.
    * @since v1.27
    */
-  Locator getByTitle(String text, GetByTitleOptions options);
+  Locator getByTitle(String text, @Nullable GetByTitleOptions options);
   /**
    * Allows locating elements by their title attribute.
    *
@@ -1000,7 +1001,7 @@ public interface FrameLocator {
    * @param text Text to locate the element for.
    * @since v1.27
    */
-  Locator getByTitle(Pattern text, GetByTitleOptions options);
+  Locator getByTitle(Pattern text, @Nullable GetByTitleOptions options);
   /**
    * @deprecated Use {@link com.microsoft.playwright.Locator#last Locator.last()} followed by {@link
    * com.microsoft.playwright.Locator#contentFrame Locator.contentFrame()} instead.
@@ -1029,7 +1030,7 @@ public interface FrameLocator {
    * @param selectorOrLocator A selector or locator to use when resolving DOM element.
    * @since v1.17
    */
-  Locator locator(String selectorOrLocator, LocatorOptions options);
+  Locator locator(String selectorOrLocator, @Nullable LocatorOptions options);
   /**
    * The method finds an element matching the specified selector in the locator's subtree. It also accepts filter options,
    * similar to {@link com.microsoft.playwright.Locator#filter Locator.filter()} method.
@@ -1051,7 +1052,7 @@ public interface FrameLocator {
    * @param selectorOrLocator A selector or locator to use when resolving DOM element.
    * @since v1.17
    */
-  Locator locator(Locator selectorOrLocator, LocatorOptions options);
+  Locator locator(Locator selectorOrLocator, @Nullable LocatorOptions options);
   /**
    * @deprecated Use {@link com.microsoft.playwright.Locator#nth Locator.nth()} followed by {@link
    * com.microsoft.playwright.Locator#contentFrame Locator.contentFrame()} instead.

--- a/playwright/src/main/java/com/microsoft/playwright/JSHandle.java
+++ b/playwright/src/main/java/com/microsoft/playwright/JSHandle.java
@@ -16,6 +16,7 @@
 
 package com.microsoft.playwright;
 
+import org.jspecify.annotations.Nullable;
 import java.util.*;
 
 /**
@@ -40,7 +41,7 @@ public interface JSHandle {
    *
    * @since v1.8
    */
-  ElementHandle asElement();
+  @Nullable ElementHandle asElement();
   /**
    * The {@code jsHandle.dispose} method stops referencing the element handle.
    *
@@ -66,7 +67,7 @@ public interface JSHandle {
    * automatically invoked.
    * @since v1.8
    */
-  default Object evaluate(String expression) {
+  default @Nullable Object evaluate(String expression) {
     return evaluate(expression, null);
   }
   /**
@@ -89,7 +90,7 @@ public interface JSHandle {
    * @param arg Optional argument to pass to {@code expression}.
    * @since v1.8
    */
-  Object evaluate(String expression, Object arg);
+  @Nullable Object evaluate(String expression, @Nullable Object arg);
   /**
    * Returns the return value of {@code expression} as a {@code JSHandle}.
    *
@@ -130,7 +131,7 @@ public interface JSHandle {
    * @param arg Optional argument to pass to {@code expression}.
    * @since v1.8
    */
-  JSHandle evaluateHandle(String expression, Object arg);
+  JSHandle evaluateHandle(String expression, @Nullable Object arg);
   /**
    * The method returns a map with **own property names** as keys and JSHandle instances for the property values.
    *
@@ -161,6 +162,6 @@ public interface JSHandle {
    *
    * @since v1.8
    */
-  Object jsonValue();
+  @Nullable Object jsonValue();
 }
 

--- a/playwright/src/main/java/com/microsoft/playwright/Keyboard.java
+++ b/playwright/src/main/java/com/microsoft/playwright/Keyboard.java
@@ -16,6 +16,7 @@
 
 package com.microsoft.playwright;
 
+import org.jspecify.annotations.Nullable;
 import com.microsoft.playwright.options.*;
 
 /**
@@ -56,7 +57,7 @@ public interface Keyboard {
     /**
      * Time to wait between {@code keydown} and {@code keyup} in milliseconds. Defaults to 0.
      */
-    public Double delay;
+    public @Nullable Double delay;
 
     /**
      * Time to wait between {@code keydown} and {@code keyup} in milliseconds. Defaults to 0.
@@ -70,7 +71,7 @@ public interface Keyboard {
     /**
      * Time to wait between key presses in milliseconds. Defaults to 0.
      */
-    public Double delay;
+    public @Nullable Double delay;
 
     /**
      * Time to wait between key presses in milliseconds. Defaults to 0.
@@ -222,7 +223,7 @@ public interface Keyboard {
    * @param key Name of the key to press or a character to generate, such as {@code ArrowLeft} or {@code a}.
    * @since v1.8
    */
-  void press(String key, PressOptions options);
+  void press(String key, @Nullable PressOptions options);
   /**
    * <strong>NOTE:</strong> In most cases, you should use {@link com.microsoft.playwright.Locator#fill Locator.fill()} instead. You only need to
    * press keys one by one if there is special keyboard handling on the page - in this case use {@link
@@ -276,7 +277,7 @@ public interface Keyboard {
    * @param text A text to type into a focused element.
    * @since v1.8
    */
-  void type(String text, TypeOptions options);
+  void type(String text, @Nullable TypeOptions options);
   /**
    * Dispatches a {@code keyup} event.
    *

--- a/playwright/src/main/java/com/microsoft/playwright/Locator.java
+++ b/playwright/src/main/java/com/microsoft/playwright/Locator.java
@@ -16,6 +16,7 @@
 
 package com.microsoft.playwright;
 
+import org.jspecify.annotations.Nullable;
 import com.microsoft.playwright.options.*;
 import java.nio.file.Path;
 import java.util.*;
@@ -36,23 +37,23 @@ public interface Locator {
      * href="https://developer.mozilla.org/en-US/docs/Web/API/Element/getBoundingClientRect">{@code
      * Element.getBoundingClientRect()}</a>. Defaults to {@code false}.
      */
-    public Boolean boxes;
+    public @Nullable Boolean boxes;
     /**
      * When specified, limits the depth of the snapshot.
      */
-    public Integer depth;
+    public @Nullable Integer depth;
     /**
      * When set to {@code "ai"}, returns a snapshot optimized for AI consumption. Defaults to {@code "default"}. See details
      * for more information.
      */
-    public AriaSnapshotMode mode;
+    public @Nullable AriaSnapshotMode mode;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
      * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * When {@code true}, appends each element's bounding box as {@code [box=x,y,width,height]} to the snapshot. Coordinates
@@ -97,7 +98,7 @@ public interface Locator {
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
@@ -117,7 +118,7 @@ public interface Locator {
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
@@ -135,36 +136,36 @@ public interface Locator {
      * Whether to bypass the <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks. Defaults to
      * {@code false}.
      */
-    public Boolean force;
+    public @Nullable Boolean force;
     /**
      * @deprecated This option has no effect.
      */
-    public Boolean noWaitAfter;
+    public @Nullable Boolean noWaitAfter;
     /**
      * A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the
      * element.
      */
-    public Position position;
+    public @Nullable Position position;
     /**
      * Controls whether Playwright scrolls the element into view before performing the action. Defaults to {@code "auto"},
      * which scrolls the element into view when necessary, including scrolling nested scrollable containers. When set to {@code
      * "none"}, Playwright does not scroll the element and the action fails if the element is not already in the viewport. This
      * is useful to assert that an element is reachable by the user without additional scrolling.
      */
-    public ScrollMode scroll;
+    public @Nullable ScrollMode scroll;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
      * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
     /**
      * When set, this method only performs the <a href="https://playwright.dev/java/docs/actionability">actionability</a>
      * checks and skips the action. Defaults to {@code false}. Useful to wait until the element is ready for the action without
      * performing it.
      */
-    public Boolean trial;
+    public @Nullable Boolean trial;
 
     /**
      * Whether to bypass the <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks. Defaults to
@@ -231,18 +232,18 @@ public interface Locator {
      * Whether to bypass the <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks. Defaults to
      * {@code false}.
      */
-    public Boolean force;
+    public @Nullable Boolean force;
     /**
      * @deprecated This option has no effect.
      */
-    public Boolean noWaitAfter;
+    public @Nullable Boolean noWaitAfter;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
      * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * Whether to bypass the <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks. Defaults to
@@ -274,62 +275,62 @@ public interface Locator {
     /**
      * Defaults to {@code left}.
      */
-    public MouseButton button;
+    public @Nullable MouseButton button;
     /**
      * defaults to 1. See [UIEvent.detail].
      */
-    public Integer clickCount;
+    public @Nullable Integer clickCount;
     /**
      * Time to wait between {@code mousedown} and {@code mouseup} in milliseconds. Defaults to 0.
      */
-    public Double delay;
+    public @Nullable Double delay;
     /**
      * Whether to bypass the <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks. Defaults to
      * {@code false}.
      */
-    public Boolean force;
+    public @Nullable Boolean force;
     /**
      * Modifier keys to press. Ensures that only these modifiers are pressed during the operation, and then restores current
      * modifiers back. If not specified, currently pressed modifiers are used. "ControlOrMeta" resolves to "Control" on Windows
      * and Linux and to "Meta" on macOS.
      */
-    public List<KeyboardModifier> modifiers;
+    public @Nullable List<KeyboardModifier> modifiers;
     /**
      * @deprecated This option will default to {@code true} in the future.
      */
-    public Boolean noWaitAfter;
+    public @Nullable Boolean noWaitAfter;
     /**
      * A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the
      * element.
      */
-    public Position position;
+    public @Nullable Position position;
     /**
      * Controls whether Playwright scrolls the element into view before performing the action. Defaults to {@code "auto"},
      * which scrolls the element into view when necessary, including scrolling nested scrollable containers. When set to {@code
      * "none"}, Playwright does not scroll the element and the action fails if the element is not already in the viewport. This
      * is useful to assert that an element is reachable by the user without additional scrolling.
      */
-    public ScrollMode scroll;
+    public @Nullable ScrollMode scroll;
     /**
      * Defaults to 1. Sends {@code n} interpolated {@code mousemove} events to represent travel between Playwright's current
      * cursor position and the provided destination. When set to 1, emits a single {@code mousemove} event at the destination
      * location.
      */
-    public Integer steps;
+    public @Nullable Integer steps;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
      * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
     /**
      * When set, this method only performs the <a href="https://playwright.dev/java/docs/actionability">actionability</a>
      * checks and skips the action. Defaults to {@code false}. Useful to wait until the element is ready for the action without
      * performing it. Note that keyboard {@code modifiers} will be pressed regardless of {@code trial} to allow testing
      * elements which are only visible when those keys are pressed.
      */
-    public Boolean trial;
+    public @Nullable Boolean trial;
 
     /**
      * Defaults to {@code left}.
@@ -435,58 +436,58 @@ public interface Locator {
     /**
      * Defaults to {@code left}.
      */
-    public MouseButton button;
+    public @Nullable MouseButton button;
     /**
      * Time to wait between {@code mousedown} and {@code mouseup} in milliseconds. Defaults to 0.
      */
-    public Double delay;
+    public @Nullable Double delay;
     /**
      * Whether to bypass the <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks. Defaults to
      * {@code false}.
      */
-    public Boolean force;
+    public @Nullable Boolean force;
     /**
      * Modifier keys to press. Ensures that only these modifiers are pressed during the operation, and then restores current
      * modifiers back. If not specified, currently pressed modifiers are used. "ControlOrMeta" resolves to "Control" on Windows
      * and Linux and to "Meta" on macOS.
      */
-    public List<KeyboardModifier> modifiers;
+    public @Nullable List<KeyboardModifier> modifiers;
     /**
      * @deprecated This option has no effect.
      */
-    public Boolean noWaitAfter;
+    public @Nullable Boolean noWaitAfter;
     /**
      * A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the
      * element.
      */
-    public Position position;
+    public @Nullable Position position;
     /**
      * Controls whether Playwright scrolls the element into view before performing the action. Defaults to {@code "auto"},
      * which scrolls the element into view when necessary, including scrolling nested scrollable containers. When set to {@code
      * "none"}, Playwright does not scroll the element and the action fails if the element is not already in the viewport. This
      * is useful to assert that an element is reachable by the user without additional scrolling.
      */
-    public ScrollMode scroll;
+    public @Nullable ScrollMode scroll;
     /**
      * Defaults to 1. Sends {@code n} interpolated {@code mousemove} events to represent travel between Playwright's current
      * cursor position and the provided destination. When set to 1, emits a single {@code mousemove} event at the destination
      * location.
      */
-    public Integer steps;
+    public @Nullable Integer steps;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
      * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
     /**
      * When set, this method only performs the <a href="https://playwright.dev/java/docs/actionability">actionability</a>
      * checks and skips the action. Defaults to {@code false}. Useful to wait until the element is ready for the action without
      * performing it. Note that keyboard {@code modifiers} will be pressed regardless of {@code trial} to allow testing
      * elements which are only visible when those keys are pressed.
      */
-    public Boolean trial;
+    public @Nullable Boolean trial;
 
     /**
      * Defaults to {@code left}.
@@ -588,7 +589,7 @@ public interface Locator {
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
@@ -606,46 +607,46 @@ public interface Locator {
      * Whether to bypass the <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks. Defaults to
      * {@code false}.
      */
-    public Boolean force;
+    public @Nullable Boolean force;
     /**
      * @deprecated This option has no effect.
      */
-    public Boolean noWaitAfter;
+    public @Nullable Boolean noWaitAfter;
     /**
      * Controls whether Playwright scrolls the element into view before performing the action. Defaults to {@code "auto"},
      * which scrolls the element into view when necessary, including scrolling nested scrollable containers. When set to {@code
      * "none"}, Playwright does not scroll the element and the action fails if the element is not already in the viewport. This
      * is useful to assert that an element is reachable by the user without additional scrolling.
      */
-    public ScrollMode scroll;
+    public @Nullable ScrollMode scroll;
     /**
      * Clicks on the source element at this point relative to the top-left corner of the element's padding box. If not
      * specified, some visible point of the element is used.
      */
-    public Position sourcePosition;
+    public @Nullable Position sourcePosition;
     /**
      * Defaults to 1. Sends {@code n} interpolated {@code mousemove} events to represent travel between the {@code mousedown}
      * and {@code mouseup} of the drag. When set to 1, emits a single {@code mousemove} event at the destination location.
      */
-    public Integer steps;
+    public @Nullable Integer steps;
     /**
      * Drops on the target element at this point relative to the top-left corner of the element's padding box. If not
      * specified, some visible point of the element is used.
      */
-    public Position targetPosition;
+    public @Nullable Position targetPosition;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
      * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
     /**
      * When set, this method only performs the <a href="https://playwright.dev/java/docs/actionability">actionability</a>
      * checks and skips the action. Defaults to {@code false}. Useful to wait until the element is ready for the action without
      * performing it.
      */
-    public Boolean trial;
+    public @Nullable Boolean trial;
 
     /**
      * Whether to bypass the <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks. Defaults to
@@ -735,14 +736,14 @@ public interface Locator {
      * A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the
      * element.
      */
-    public Position position;
+    public @Nullable Position position;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
      * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the
@@ -777,7 +778,7 @@ public interface Locator {
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
@@ -795,7 +796,7 @@ public interface Locator {
      * Maximum time in milliseconds to wait for the locator before evaluating. Note that after locator is resolved, evaluation
      * itself is not limited by the timeout. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * Maximum time in milliseconds to wait for the locator before evaluating. Note that after locator is resolved, evaluation
@@ -811,7 +812,7 @@ public interface Locator {
      * Maximum time in milliseconds to wait for the locator before evaluating. Note that after locator is resolved, evaluation
      * itself is not limited by the timeout. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * Maximum time in milliseconds to wait for the locator before evaluating. Note that after locator is resolved, evaluation
@@ -827,18 +828,18 @@ public interface Locator {
      * Whether to bypass the <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks. Defaults to
      * {@code false}.
      */
-    public Boolean force;
+    public @Nullable Boolean force;
     /**
      * @deprecated This option has no effect.
      */
-    public Boolean noWaitAfter;
+    public @Nullable Boolean noWaitAfter;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
      * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * Whether to bypass the <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks. Defaults to
@@ -879,7 +880,7 @@ public interface Locator {
      *
      * <p> Note that outer and inner locators must belong to the same frame. Inner locator must not contain {@code FrameLocator}s.
      */
-    public Locator has;
+    public @Nullable Locator has;
     /**
      * Matches elements that do not contain an element that matches an inner locator. Inner locator is queried against the
      * outer one. For example, {@code article} that does not have {@code div} matches {@code
@@ -887,23 +888,23 @@ public interface Locator {
      *
      * <p> Note that outer and inner locators must belong to the same frame. Inner locator must not contain {@code FrameLocator}s.
      */
-    public Locator hasNot;
+    public @Nullable Locator hasNot;
     /**
      * Matches elements that do not contain specified text somewhere inside, possibly in a child or a descendant element. When
      * passed a [string], matching is case-insensitive and searches for a substring.
      */
-    public Object hasNotText;
+    public @Nullable Object hasNotText;
     /**
      * Matches elements containing specified text somewhere inside, possibly in a child or a descendant element. When passed a
      * [string], matching is case-insensitive and searches for a substring. For example, {@code "Playwright"} matches {@code
      * <article><div>Playwright</div></article>}.
      */
-    public Object hasText;
+    public @Nullable Object hasText;
     /**
      * Only matches visible or invisible elements. Prefer the {@link com.microsoft.playwright.Locator#visible
      * Locator.visible()} shortcut when matching only visible elements.
      */
-    public Boolean visible;
+    public @Nullable Boolean visible;
 
     /**
      * Narrows down the results of the method to those which contain elements matching this relative locator. For example,
@@ -982,7 +983,7 @@ public interface Locator {
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
@@ -1002,7 +1003,7 @@ public interface Locator {
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
@@ -1020,7 +1021,7 @@ public interface Locator {
      * Whether to find an exact match: case-sensitive and whole-string. Default to false. Ignored when locating by a regular
      * expression. Note that exact match still trims whitespace.
      */
-    public Boolean exact;
+    public @Nullable Boolean exact;
 
     /**
      * Whether to find an exact match: case-sensitive and whole-string. Default to false. Ignored when locating by a regular
@@ -1036,7 +1037,7 @@ public interface Locator {
      * Whether to find an exact match: case-sensitive and whole-string. Default to false. Ignored when locating by a regular
      * expression. Note that exact match still trims whitespace.
      */
-    public Boolean exact;
+    public @Nullable Boolean exact;
 
     /**
      * Whether to find an exact match: case-sensitive and whole-string. Default to false. Ignored when locating by a regular
@@ -1052,7 +1053,7 @@ public interface Locator {
      * Whether to find an exact match: case-sensitive and whole-string. Default to false. Ignored when locating by a regular
      * expression. Note that exact match still trims whitespace.
      */
-    public Boolean exact;
+    public @Nullable Boolean exact;
 
     /**
      * Whether to find an exact match: case-sensitive and whole-string. Default to false. Ignored when locating by a regular
@@ -1069,65 +1070,65 @@ public interface Locator {
      *
      * <p> Learn more about <a href="https://www.w3.org/TR/wai-aria-1.2/#aria-checked">{@code aria-checked}</a>.
      */
-    public Boolean checked;
+    public @Nullable Boolean checked;
     /**
      * Option to match the <a href="https://w3c.github.io/accname/#dfn-accessible-description">accessible description</a>. By
      * default, matching is case-insensitive and searches for a substring, use {@code exact} to control this behavior.
      *
      * <p> Learn more about <a href="https://w3c.github.io/accname/#dfn-accessible-description">accessible description</a>.
      */
-    public Object description;
+    public @Nullable Object description;
     /**
      * An attribute that is usually set by {@code aria-disabled} or {@code disabled}.
      *
      * <p> <strong>NOTE:</strong> Unlike most other attributes, {@code disabled} is inherited through the DOM hierarchy. Learn more about <a
      * href="https://www.w3.org/TR/wai-aria-1.2/#aria-disabled">{@code aria-disabled}</a>.
      */
-    public Boolean disabled;
+    public @Nullable Boolean disabled;
     /**
      * Whether {@code name} and {@code description} are matched exactly: case-sensitive and whole-string. Defaults to false.
      * Ignored when the value is a regular expression. Note that exact match still trims whitespace.
      */
-    public Boolean exact;
+    public @Nullable Boolean exact;
     /**
      * An attribute that is usually set by {@code aria-expanded}.
      *
      * <p> Learn more about <a href="https://www.w3.org/TR/wai-aria-1.2/#aria-expanded">{@code aria-expanded}</a>.
      */
-    public Boolean expanded;
+    public @Nullable Boolean expanded;
     /**
      * Option that controls whether hidden elements are matched. By default, only non-hidden elements, as <a
      * href="https://www.w3.org/TR/wai-aria-1.2/#tree_exclusion">defined by ARIA</a>, are matched by role selector.
      *
      * <p> Learn more about <a href="https://www.w3.org/TR/wai-aria-1.2/#aria-hidden">{@code aria-hidden}</a>.
      */
-    public Boolean includeHidden;
+    public @Nullable Boolean includeHidden;
     /**
      * A number attribute that is usually present for roles {@code heading}, {@code listitem}, {@code row}, {@code treeitem},
      * with default values for {@code <h1>-<h6>} elements.
      *
      * <p> Learn more about <a href="https://www.w3.org/TR/wai-aria-1.2/#aria-level">{@code aria-level}</a>.
      */
-    public Integer level;
+    public @Nullable Integer level;
     /**
      * Option to match the <a href="https://w3c.github.io/accname/#dfn-accessible-name">accessible name</a>. By default,
      * matching is case-insensitive and searches for a substring, use {@code exact} to control this behavior.
      *
      * <p> Learn more about <a href="https://w3c.github.io/accname/#dfn-accessible-name">accessible name</a>.
      */
-    public Object name;
+    public @Nullable Object name;
     /**
      * An attribute that is usually set by {@code aria-pressed}.
      *
      * <p> Learn more about <a href="https://www.w3.org/TR/wai-aria-1.2/#aria-pressed">{@code aria-pressed}</a>.
      */
-    public Boolean pressed;
+    public @Nullable Boolean pressed;
     /**
      * An attribute that is usually set by {@code aria-selected}.
      *
      * <p> Learn more about <a href="https://www.w3.org/TR/wai-aria-1.2/#aria-selected">{@code aria-selected}</a>.
      */
-    public Boolean selected;
+    public @Nullable Boolean selected;
 
     /**
      * An attribute that is usually set by {@code aria-checked} or native {@code <input type=checkbox>} controls.
@@ -1249,7 +1250,7 @@ public interface Locator {
      * Whether to find an exact match: case-sensitive and whole-string. Default to false. Ignored when locating by a regular
      * expression. Note that exact match still trims whitespace.
      */
-    public Boolean exact;
+    public @Nullable Boolean exact;
 
     /**
      * Whether to find an exact match: case-sensitive and whole-string. Default to false. Ignored when locating by a regular
@@ -1265,7 +1266,7 @@ public interface Locator {
      * Whether to find an exact match: case-sensitive and whole-string. Default to false. Ignored when locating by a regular
      * expression. Note that exact match still trims whitespace.
      */
-    public Boolean exact;
+    public @Nullable Boolean exact;
 
     /**
      * Whether to find an exact match: case-sensitive and whole-string. Default to false. Ignored when locating by a regular
@@ -1280,7 +1281,7 @@ public interface Locator {
     /**
      * Additional inline CSS applied to the highlight overlay, e.g. {@code "outline: 2px dashed red"}.
      */
-    public String style;
+    public @Nullable String style;
 
     /**
      * Additional inline CSS applied to the highlight overlay, e.g. {@code "outline: 2px dashed red"}.
@@ -1295,43 +1296,43 @@ public interface Locator {
      * Whether to bypass the <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks. Defaults to
      * {@code false}.
      */
-    public Boolean force;
+    public @Nullable Boolean force;
     /**
      * Modifier keys to press. Ensures that only these modifiers are pressed during the operation, and then restores current
      * modifiers back. If not specified, currently pressed modifiers are used. "ControlOrMeta" resolves to "Control" on Windows
      * and Linux and to "Meta" on macOS.
      */
-    public List<KeyboardModifier> modifiers;
+    public @Nullable List<KeyboardModifier> modifiers;
     /**
      * @deprecated This option has no effect.
      */
-    public Boolean noWaitAfter;
+    public @Nullable Boolean noWaitAfter;
     /**
      * A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the
      * element.
      */
-    public Position position;
+    public @Nullable Position position;
     /**
      * Controls whether Playwright scrolls the element into view before performing the action. Defaults to {@code "auto"},
      * which scrolls the element into view when necessary, including scrolling nested scrollable containers. When set to {@code
      * "none"}, Playwright does not scroll the element and the action fails if the element is not already in the viewport. This
      * is useful to assert that an element is reachable by the user without additional scrolling.
      */
-    public ScrollMode scroll;
+    public @Nullable ScrollMode scroll;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
      * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
     /**
      * When set, this method only performs the <a href="https://playwright.dev/java/docs/actionability">actionability</a>
      * checks and skips the action. Defaults to {@code false}. Useful to wait until the element is ready for the action without
      * performing it. Note that keyboard {@code modifiers} will be pressed regardless of {@code trial} to allow testing
      * elements which are only visible when those keys are pressed.
      */
-    public Boolean trial;
+    public @Nullable Boolean trial;
 
     /**
      * Whether to bypass the <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks. Defaults to
@@ -1410,7 +1411,7 @@ public interface Locator {
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
@@ -1430,7 +1431,7 @@ public interface Locator {
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
@@ -1450,7 +1451,7 @@ public interface Locator {
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
@@ -1470,7 +1471,7 @@ public interface Locator {
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
@@ -1490,7 +1491,7 @@ public interface Locator {
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
@@ -1510,7 +1511,7 @@ public interface Locator {
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
@@ -1530,7 +1531,7 @@ public interface Locator {
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
@@ -1548,7 +1549,7 @@ public interface Locator {
      * @deprecated This option is ignored. {@link com.microsoft.playwright.Locator#isHidden Locator.isHidden()} does not wait for the
      * element to become hidden and returns immediately.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * @deprecated This option is ignored. {@link com.microsoft.playwright.Locator#isHidden Locator.isHidden()} does not wait for the
@@ -1564,7 +1565,7 @@ public interface Locator {
      * @deprecated This option is ignored. {@link com.microsoft.playwright.Locator#isVisible Locator.isVisible()} does not wait for the
      * element to become visible and returns immediately.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * @deprecated This option is ignored. {@link com.microsoft.playwright.Locator#isVisible Locator.isVisible()} does not wait for the
@@ -1588,7 +1589,7 @@ public interface Locator {
      *
      * <p> Note that outer and inner locators must belong to the same frame. Inner locator must not contain {@code FrameLocator}s.
      */
-    public Locator has;
+    public @Nullable Locator has;
     /**
      * Matches elements that do not contain an element that matches an inner locator. Inner locator is queried against the
      * outer one. For example, {@code article} that does not have {@code div} matches {@code
@@ -1596,18 +1597,18 @@ public interface Locator {
      *
      * <p> Note that outer and inner locators must belong to the same frame. Inner locator must not contain {@code FrameLocator}s.
      */
-    public Locator hasNot;
+    public @Nullable Locator hasNot;
     /**
      * Matches elements that do not contain specified text somewhere inside, possibly in a child or a descendant element. When
      * passed a [string], matching is case-insensitive and searches for a substring.
      */
-    public Object hasNotText;
+    public @Nullable Object hasNotText;
     /**
      * Matches elements containing specified text somewhere inside, possibly in a child or a descendant element. When passed a
      * [string], matching is case-insensitive and searches for a substring. For example, {@code "Playwright"} matches {@code
      * <article><div>Playwright</div></article>}.
      */
-    public Object hasText;
+    public @Nullable Object hasText;
 
     /**
      * Narrows down the results of the method to those which contain elements matching this relative locator. For example,
@@ -1675,18 +1676,18 @@ public interface Locator {
     /**
      * Time to wait between {@code keydown} and {@code keyup} in milliseconds. Defaults to 0.
      */
-    public Double delay;
+    public @Nullable Double delay;
     /**
      * @deprecated This option will default to {@code true} in the future.
      */
-    public Boolean noWaitAfter;
+    public @Nullable Boolean noWaitAfter;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
      * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * Time to wait between {@code keydown} and {@code keyup} in milliseconds. Defaults to 0.
@@ -1717,18 +1718,18 @@ public interface Locator {
     /**
      * Time to wait between key presses in milliseconds. Defaults to 0.
      */
-    public Double delay;
+    public @Nullable Double delay;
     /**
      * @deprecated This option has no effect.
      */
-    public Boolean noWaitAfter;
+    public @Nullable Boolean noWaitAfter;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
      * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * Time to wait between key presses in milliseconds. Defaults to 0.
@@ -1766,42 +1767,42 @@ public interface Locator {
      *
      * <p> Defaults to {@code "allow"} that leaves animations untouched.
      */
-    public ScreenshotAnimations animations;
+    public @Nullable ScreenshotAnimations animations;
     /**
      * When set to {@code "hide"}, screenshot will hide text caret. When set to {@code "initial"}, text caret behavior will not
      * be changed.  Defaults to {@code "hide"}.
      */
-    public ScreenshotCaret caret;
+    public @Nullable ScreenshotCaret caret;
     /**
      * Specify locators that should be masked when the screenshot is taken. Masked elements will be overlaid with a pink box
      * {@code #FF00FF} (customized by {@code maskColor}) that completely covers its bounding box. The mask is also applied to
      * invisible elements, see <a href="https://playwright.dev/java/docs/locators#matching-only-visible-elements">Matching only
      * visible elements</a> to disable that.
      */
-    public List<Locator> mask;
+    public @Nullable List<Locator> mask;
     /**
      * Specify the color of the overlay box for masked elements, in <a
      * href="https://developer.mozilla.org/en-US/docs/Web/CSS/color_value">CSS color format</a>. Default color is pink {@code
      * #FF00FF}.
      */
-    public String maskColor;
+    public @Nullable String maskColor;
     /**
      * Hides default white background and allows capturing screenshots with transparency. Not applicable to {@code jpeg}
      * images. Defaults to {@code false}.
      */
-    public Boolean omitBackground;
+    public @Nullable Boolean omitBackground;
     /**
      * The file path to save the image to. The screenshot type will be inferred from file extension. If {@code path} is a
      * relative path, then it is resolved relative to the current working directory. If no path is provided, the image won't be
      * saved to the disk.
      */
-    public Path path;
+    public @Nullable Path path;
     /**
      * The quality of the image, between 0-100. Not applicable to {@code png} images. For {@code jpeg} the default is {@code
      * 80}. For {@code webp}, a quality of {@code 100} (the default) produces a lossless image, while lower values use lossy
      * compression.
      */
-    public Integer quality;
+    public @Nullable Integer quality;
     /**
      * When set to {@code "css"}, screenshot will have a single pixel per each css pixel on the page. For high-dpi devices,
      * this will keep screenshots small. Using {@code "device"} option will produce a single pixel per each device pixel, so
@@ -1809,24 +1810,24 @@ public interface Locator {
      *
      * <p> Defaults to {@code "device"}.
      */
-    public ScreenshotScale scale;
+    public @Nullable ScreenshotScale scale;
     /**
      * Text of the stylesheet to apply while making the screenshot. This is where you can hide dynamic elements, make elements
      * invisible or change their properties to help you creating repeatable screenshots. This stylesheet pierces the Shadow DOM
      * and applies to the inner frames.
      */
-    public String style;
+    public @Nullable String style;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
      * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
     /**
      * Specify screenshot type, defaults to {@code png}.
      */
-    public ScreenshotType type;
+    public @Nullable ScreenshotType type;
 
     /**
      * When set to {@code "disabled"}, stops CSS animations, CSS transitions and Web Animations. Animations get different
@@ -1940,7 +1941,7 @@ public interface Locator {
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
@@ -1958,18 +1959,18 @@ public interface Locator {
      * Whether to bypass the <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks. Defaults to
      * {@code false}.
      */
-    public Boolean force;
+    public @Nullable Boolean force;
     /**
      * @deprecated This option has no effect.
      */
-    public Boolean noWaitAfter;
+    public @Nullable Boolean noWaitAfter;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
      * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * Whether to bypass the <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks. Defaults to
@@ -2002,14 +2003,14 @@ public interface Locator {
      * Whether to bypass the <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks. Defaults to
      * {@code false}.
      */
-    public Boolean force;
+    public @Nullable Boolean force;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
      * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * Whether to bypass the <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks. Defaults to
@@ -2035,36 +2036,36 @@ public interface Locator {
      * Whether to bypass the <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks. Defaults to
      * {@code false}.
      */
-    public Boolean force;
+    public @Nullable Boolean force;
     /**
      * @deprecated This option has no effect.
      */
-    public Boolean noWaitAfter;
+    public @Nullable Boolean noWaitAfter;
     /**
      * A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the
      * element.
      */
-    public Position position;
+    public @Nullable Position position;
     /**
      * Controls whether Playwright scrolls the element into view before performing the action. Defaults to {@code "auto"},
      * which scrolls the element into view when necessary, including scrolling nested scrollable containers. When set to {@code
      * "none"}, Playwright does not scroll the element and the action fails if the element is not already in the viewport. This
      * is useful to assert that an element is reachable by the user without additional scrolling.
      */
-    public ScrollMode scroll;
+    public @Nullable ScrollMode scroll;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
      * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
     /**
      * When set, this method only performs the <a href="https://playwright.dev/java/docs/actionability">actionability</a>
      * checks and skips the action. Defaults to {@code false}. Useful to wait until the element is ready for the action without
      * performing it.
      */
-    public Boolean trial;
+    public @Nullable Boolean trial;
 
     /**
      * Whether to bypass the <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks. Defaults to
@@ -2130,14 +2131,14 @@ public interface Locator {
     /**
      * @deprecated This option has no effect.
      */
-    public Boolean noWaitAfter;
+    public @Nullable Boolean noWaitAfter;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
      * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * @deprecated This option has no effect.
@@ -2162,43 +2163,43 @@ public interface Locator {
      * Whether to bypass the <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks. Defaults to
      * {@code false}.
      */
-    public Boolean force;
+    public @Nullable Boolean force;
     /**
      * Modifier keys to press. Ensures that only these modifiers are pressed during the operation, and then restores current
      * modifiers back. If not specified, currently pressed modifiers are used. "ControlOrMeta" resolves to "Control" on Windows
      * and Linux and to "Meta" on macOS.
      */
-    public List<KeyboardModifier> modifiers;
+    public @Nullable List<KeyboardModifier> modifiers;
     /**
      * @deprecated This option has no effect.
      */
-    public Boolean noWaitAfter;
+    public @Nullable Boolean noWaitAfter;
     /**
      * A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the
      * element.
      */
-    public Position position;
+    public @Nullable Position position;
     /**
      * Controls whether Playwright scrolls the element into view before performing the action. Defaults to {@code "auto"},
      * which scrolls the element into view when necessary, including scrolling nested scrollable containers. When set to {@code
      * "none"}, Playwright does not scroll the element and the action fails if the element is not already in the viewport. This
      * is useful to assert that an element is reachable by the user without additional scrolling.
      */
-    public ScrollMode scroll;
+    public @Nullable ScrollMode scroll;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
      * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
     /**
      * When set, this method only performs the <a href="https://playwright.dev/java/docs/actionability">actionability</a>
      * checks and skips the action. Defaults to {@code false}. Useful to wait until the element is ready for the action without
      * performing it. Note that keyboard {@code modifiers} will be pressed regardless of {@code trial} to allow testing
      * elements which are only visible when those keys are pressed.
      */
-    public Boolean trial;
+    public @Nullable Boolean trial;
 
     /**
      * Whether to bypass the <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks. Defaults to
@@ -2277,7 +2278,7 @@ public interface Locator {
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
@@ -2294,18 +2295,18 @@ public interface Locator {
     /**
      * Time to wait between key presses in milliseconds. Defaults to 0.
      */
-    public Double delay;
+    public @Nullable Double delay;
     /**
      * @deprecated This option has no effect.
      */
-    public Boolean noWaitAfter;
+    public @Nullable Boolean noWaitAfter;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
      * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * Time to wait between key presses in milliseconds. Defaults to 0.
@@ -2337,36 +2338,36 @@ public interface Locator {
      * Whether to bypass the <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks. Defaults to
      * {@code false}.
      */
-    public Boolean force;
+    public @Nullable Boolean force;
     /**
      * @deprecated This option has no effect.
      */
-    public Boolean noWaitAfter;
+    public @Nullable Boolean noWaitAfter;
     /**
      * A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the
      * element.
      */
-    public Position position;
+    public @Nullable Position position;
     /**
      * Controls whether Playwright scrolls the element into view before performing the action. Defaults to {@code "auto"},
      * which scrolls the element into view when necessary, including scrolling nested scrollable containers. When set to {@code
      * "none"}, Playwright does not scroll the element and the action fails if the element is not already in the viewport. This
      * is useful to assert that an element is reachable by the user without additional scrolling.
      */
-    public ScrollMode scroll;
+    public @Nullable ScrollMode scroll;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
      * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
     /**
      * When set, this method only performs the <a href="https://playwright.dev/java/docs/actionability">actionability</a>
      * checks and skips the action. Defaults to {@code false}. Useful to wait until the element is ready for the action without
      * performing it.
      */
-    public Boolean trial;
+    public @Nullable Boolean trial;
 
     /**
      * Whether to bypass the <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks. Defaults to
@@ -2440,14 +2441,14 @@ public interface Locator {
      * visibility:hidden}. This is opposite to the {@code "visible"} option.</li>
      * </ul>
      */
-    public WaitForSelectorState state;
+    public @Nullable WaitForSelectorState state;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
      * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * Defaults to {@code "visible"}. Can be either:
@@ -2482,7 +2483,7 @@ public interface Locator {
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * Maximum time to wait for in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The
@@ -2627,7 +2628,7 @@ public interface Locator {
    *
    * @since v1.49
    */
-  String ariaSnapshot(AriaSnapshotOptions options);
+  String ariaSnapshot(@Nullable AriaSnapshotOptions options);
   /**
    * Calls <a href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/blur">blur</a> on the element.
    *
@@ -2641,7 +2642,7 @@ public interface Locator {
    *
    * @since v1.28
    */
-  void blur(BlurOptions options);
+  void blur(@Nullable BlurOptions options);
   /**
    * This method returns the bounding box of the element matching the locator, or {@code null} if the element is not visible.
    * The bounding box is calculated relative to the main frame viewport - which is usually the same as the browser window.
@@ -2666,7 +2667,7 @@ public interface Locator {
    *
    * @since v1.14
    */
-  default BoundingBox boundingBox() {
+  default @Nullable BoundingBox boundingBox() {
     return boundingBox(null);
   }
   /**
@@ -2693,7 +2694,7 @@ public interface Locator {
    *
    * @since v1.14
    */
-  BoundingBox boundingBox(BoundingBoxOptions options);
+  @Nullable BoundingBox boundingBox(@Nullable BoundingBoxOptions options);
   /**
    * Ensure that checkbox or radio element is checked.
    *
@@ -2753,7 +2754,7 @@ public interface Locator {
    *
    * @since v1.14
    */
-  void check(CheckOptions options);
+  void check(@Nullable CheckOptions options);
   /**
    * Clear the input field.
    *
@@ -2797,7 +2798,7 @@ public interface Locator {
    *
    * @since v1.28
    */
-  void clear(ClearOptions options);
+  void clear(@Nullable ClearOptions options);
   /**
    * Click an element.
    *
@@ -2875,7 +2876,7 @@ public interface Locator {
    *
    * @since v1.14
    */
-  void click(ClickOptions options);
+  void click(@Nullable ClickOptions options);
   /**
    * Returns the number of elements matching the locator.
    *
@@ -2940,7 +2941,7 @@ public interface Locator {
    *
    * @since v1.14
    */
-  void dblclick(DblclickOptions options);
+  void dblclick(@Nullable DblclickOptions options);
   /**
    * Describes the locator, description is used in the trace viewer and reports. Returns the locator pointing to the same
    * element.
@@ -2970,7 +2971,7 @@ public interface Locator {
    *
    * @since v1.57
    */
-  String description();
+  @Nullable String description();
   /**
    * Programmatically dispatch an event on the matching element.
    *
@@ -3016,7 +3017,7 @@ public interface Locator {
    * @param eventInit Optional event-specific initialization properties.
    * @since v1.14
    */
-  default void dispatchEvent(String type, Object eventInit) {
+  default void dispatchEvent(String type, @Nullable Object eventInit) {
     dispatchEvent(type, eventInit, null);
   }
   /**
@@ -3111,7 +3112,7 @@ public interface Locator {
    * @param eventInit Optional event-specific initialization properties.
    * @since v1.14
    */
-  void dispatchEvent(String type, Object eventInit, DispatchEventOptions options);
+  void dispatchEvent(String type, @Nullable Object eventInit, @Nullable DispatchEventOptions options);
   /**
    * Drag the source element towards the target element and drop it.
    *
@@ -3159,7 +3160,7 @@ public interface Locator {
    * @param target Locator of the element to drag to.
    * @since v1.18
    */
-  void dragTo(Locator target, DragToOptions options);
+  void dragTo(Locator target, @Nullable DragToOptions options);
   /**
    * Simulate an external drag-and-drop of files or clipboard-like data onto this locator.
    *
@@ -3207,7 +3208,7 @@ public interface Locator {
    * string map for clipboard-like content such as {@code text/plain}, {@code text/html}, {@code text/uri-list}), or both.
    * @since v1.60
    */
-  void drop(DropPayload payload, DropOptions options);
+  void drop(DropPayload payload, @Nullable DropOptions options);
   /**
    * Resolves given locator to the first matching DOM element. If there are no matching elements, waits for one. If multiple
    * elements match the locator, throws.
@@ -3223,7 +3224,7 @@ public interface Locator {
    *
    * @since v1.14
    */
-  ElementHandle elementHandle(ElementHandleOptions options);
+  ElementHandle elementHandle(@Nullable ElementHandleOptions options);
   /**
    * Resolves given locator to all matching DOM elements. If there are no matching elements, returns an empty list.
    *
@@ -3278,7 +3279,7 @@ public interface Locator {
    * @param arg Optional argument to pass to {@code expression}.
    * @since v1.14
    */
-  default Object evaluate(String expression, Object arg) {
+  default @Nullable Object evaluate(String expression, @Nullable Object arg) {
     return evaluate(expression, arg, null);
   }
   /**
@@ -3309,7 +3310,7 @@ public interface Locator {
    * automatically invoked.
    * @since v1.14
    */
-  default Object evaluate(String expression) {
+  default @Nullable Object evaluate(String expression) {
     return evaluate(expression, null);
   }
   /**
@@ -3341,7 +3342,7 @@ public interface Locator {
    * @param arg Optional argument to pass to {@code expression}.
    * @since v1.14
    */
-  Object evaluate(String expression, Object arg, EvaluateOptions options);
+  @Nullable Object evaluate(String expression, @Nullable Object arg, @Nullable EvaluateOptions options);
   /**
    * Execute JavaScript code in the page, taking all matching elements as an argument.
    *
@@ -3366,7 +3367,7 @@ public interface Locator {
    * automatically invoked.
    * @since v1.14
    */
-  default Object evaluateAll(String expression) {
+  default @Nullable Object evaluateAll(String expression) {
     return evaluateAll(expression, null);
   }
   /**
@@ -3394,7 +3395,7 @@ public interface Locator {
    * @param arg Optional argument to pass to {@code expression}.
    * @since v1.14
    */
-  Object evaluateAll(String expression, Object arg);
+  @Nullable Object evaluateAll(String expression, @Nullable Object arg);
   /**
    * Execute JavaScript code in the page, taking the matching element as an argument, and return a {@code JSHandle} with the
    * result.
@@ -3421,7 +3422,7 @@ public interface Locator {
    * @param arg Optional argument to pass to {@code expression}.
    * @since v1.14
    */
-  default JSHandle evaluateHandle(String expression, Object arg) {
+  default JSHandle evaluateHandle(String expression, @Nullable Object arg) {
     return evaluateHandle(expression, arg, null);
   }
   /**
@@ -3478,7 +3479,7 @@ public interface Locator {
    * @param arg Optional argument to pass to {@code expression}.
    * @since v1.14
    */
-  JSHandle evaluateHandle(String expression, Object arg, EvaluateHandleOptions options);
+  JSHandle evaluateHandle(String expression, @Nullable Object arg, @Nullable EvaluateHandleOptions options);
   /**
    * Set a value to the input field.
    *
@@ -3532,7 +3533,7 @@ public interface Locator {
    * @param value Value to set for the {@code <input>}, {@code <textarea>} or {@code [contenteditable]} element.
    * @since v1.14
    */
-  void fill(String value, FillOptions options);
+  void fill(String value, @Nullable FillOptions options);
   /**
    * This method narrows existing locator according to the options, for example filters by text. It can be chained to filter
    * multiple times.
@@ -3572,7 +3573,7 @@ public interface Locator {
    *
    * @since v1.22
    */
-  Locator filter(FilterOptions options);
+  Locator filter(@Nullable FilterOptions options);
   /**
    * Returns locator to the first matching element.
    *
@@ -3592,7 +3593,7 @@ public interface Locator {
    *
    * @since v1.14
    */
-  void focus(FocusOptions options);
+  void focus(@Nullable FocusOptions options);
   /**
    * When working with iframes, you can create a frame locator that will enter the iframe and allow locating elements in that
    * iframe:
@@ -3617,7 +3618,7 @@ public interface Locator {
    * @param name Attribute name to get the value for.
    * @since v1.14
    */
-  default String getAttribute(String name) {
+  default @Nullable String getAttribute(String name) {
     return getAttribute(name, null);
   }
   /**
@@ -3630,7 +3631,7 @@ public interface Locator {
    * @param name Attribute name to get the value for.
    * @since v1.14
    */
-  String getAttribute(String name, GetAttributeOptions options);
+  @Nullable String getAttribute(String name, @Nullable GetAttributeOptions options);
   /**
    * Allows locating elements by their alt text.
    *
@@ -3660,7 +3661,7 @@ public interface Locator {
    * @param text Text to locate the element for.
    * @since v1.27
    */
-  Locator getByAltText(String text, GetByAltTextOptions options);
+  Locator getByAltText(String text, @Nullable GetByAltTextOptions options);
   /**
    * Allows locating elements by their alt text.
    *
@@ -3690,7 +3691,7 @@ public interface Locator {
    * @param text Text to locate the element for.
    * @since v1.27
    */
-  Locator getByAltText(Pattern text, GetByAltTextOptions options);
+  Locator getByAltText(Pattern text, @Nullable GetByAltTextOptions options);
   /**
    * Allows locating input elements by the text of the associated {@code <label>} or {@code aria-labelledby} element, or by
    * the {@code aria-label} attribute.
@@ -3724,7 +3725,7 @@ public interface Locator {
    * @param text Text to locate the element for.
    * @since v1.27
    */
-  Locator getByLabel(String text, GetByLabelOptions options);
+  Locator getByLabel(String text, @Nullable GetByLabelOptions options);
   /**
    * Allows locating input elements by the text of the associated {@code <label>} or {@code aria-labelledby} element, or by
    * the {@code aria-label} attribute.
@@ -3758,7 +3759,7 @@ public interface Locator {
    * @param text Text to locate the element for.
    * @since v1.27
    */
-  Locator getByLabel(Pattern text, GetByLabelOptions options);
+  Locator getByLabel(Pattern text, @Nullable GetByLabelOptions options);
   /**
    * Allows locating input elements by the placeholder text.
    *
@@ -3792,7 +3793,7 @@ public interface Locator {
    * @param text Text to locate the element for.
    * @since v1.27
    */
-  Locator getByPlaceholder(String text, GetByPlaceholderOptions options);
+  Locator getByPlaceholder(String text, @Nullable GetByPlaceholderOptions options);
   /**
    * Allows locating input elements by the placeholder text.
    *
@@ -3826,7 +3827,7 @@ public interface Locator {
    * @param text Text to locate the element for.
    * @since v1.27
    */
-  Locator getByPlaceholder(Pattern text, GetByPlaceholderOptions options);
+  Locator getByPlaceholder(Pattern text, @Nullable GetByPlaceholderOptions options);
   /**
    * Allows locating elements by their <a href="https://www.w3.org/TR/wai-aria-1.2/#roles">ARIA role</a>, <a
    * href="https://www.w3.org/TR/wai-aria-1.2/#aria-attributes">ARIA attributes</a> and <a
@@ -3910,7 +3911,7 @@ public interface Locator {
    * @param role Required aria role.
    * @since v1.27
    */
-  Locator getByRole(AriaRole role, GetByRoleOptions options);
+  Locator getByRole(AriaRole role, @Nullable GetByRoleOptions options);
   /**
    * Locate element by the test id.
    *
@@ -4036,7 +4037,7 @@ public interface Locator {
    * @param text Text to locate the element for.
    * @since v1.27
    */
-  Locator getByText(String text, GetByTextOptions options);
+  Locator getByText(String text, @Nullable GetByTextOptions options);
   /**
    * Allows locating elements that contain given text.
    *
@@ -4118,7 +4119,7 @@ public interface Locator {
    * @param text Text to locate the element for.
    * @since v1.27
    */
-  Locator getByText(Pattern text, GetByTextOptions options);
+  Locator getByText(Pattern text, @Nullable GetByTextOptions options);
   /**
    * Allows locating elements by their title attribute.
    *
@@ -4152,7 +4153,7 @@ public interface Locator {
    * @param text Text to locate the element for.
    * @since v1.27
    */
-  Locator getByTitle(String text, GetByTitleOptions options);
+  Locator getByTitle(String text, @Nullable GetByTitleOptions options);
   /**
    * Allows locating elements by their title attribute.
    *
@@ -4186,7 +4187,7 @@ public interface Locator {
    * @param text Text to locate the element for.
    * @since v1.27
    */
-  Locator getByTitle(Pattern text, GetByTitleOptions options);
+  Locator getByTitle(Pattern text, @Nullable GetByTitleOptions options);
   /**
    * Hides the element highlight previously added by {@link com.microsoft.playwright.Locator#highlight Locator.highlight()}.
    *
@@ -4208,7 +4209,7 @@ public interface Locator {
    *
    * @since v1.20
    */
-  AutoCloseable highlight(HighlightOptions options);
+  AutoCloseable highlight(@Nullable HighlightOptions options);
   /**
    * Hover over the matching element.
    *
@@ -4264,7 +4265,7 @@ public interface Locator {
    *
    * @since v1.14
    */
-  void hover(HoverOptions options);
+  void hover(@Nullable HoverOptions options);
   /**
    * Returns the <a href="https://developer.mozilla.org/en-US/docs/Web/API/Element/innerHTML">{@code element.innerHTML}</a>.
    *
@@ -4278,7 +4279,7 @@ public interface Locator {
    *
    * @since v1.14
    */
-  String innerHTML(InnerHTMLOptions options);
+  String innerHTML(@Nullable InnerHTMLOptions options);
   /**
    * Returns the <a href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/innerText">{@code
    * element.innerText}</a>.
@@ -4302,7 +4303,7 @@ public interface Locator {
    *
    * @since v1.14
    */
-  String innerText(InnerTextOptions options);
+  String innerText(@Nullable InnerTextOptions options);
   /**
    * Returns the value for the matching {@code <input>} or {@code <textarea>} or {@code <select>} element.
    *
@@ -4348,7 +4349,7 @@ public interface Locator {
    *
    * @since v1.14
    */
-  String inputValue(InputValueOptions options);
+  String inputValue(@Nullable InputValueOptions options);
   /**
    * Returns whether the element is checked. Throws if the element is not a checkbox or radio input.
    *
@@ -4380,7 +4381,7 @@ public interface Locator {
    *
    * @since v1.14
    */
-  boolean isChecked(IsCheckedOptions options);
+  boolean isChecked(@Nullable IsCheckedOptions options);
   /**
    * Returns whether the element is disabled, the opposite of <a
    * href="https://playwright.dev/java/docs/actionability#enabled">enabled</a>.
@@ -4414,7 +4415,7 @@ public interface Locator {
    *
    * @since v1.14
    */
-  boolean isDisabled(IsDisabledOptions options);
+  boolean isDisabled(@Nullable IsDisabledOptions options);
   /**
    * Returns whether the element is <a href="https://playwright.dev/java/docs/actionability#editable">editable</a>. If the
    * target element is not an {@code <input>}, {@code <textarea>}, {@code <select>}, {@code [contenteditable]} and does not
@@ -4450,7 +4451,7 @@ public interface Locator {
    *
    * @since v1.14
    */
-  boolean isEditable(IsEditableOptions options);
+  boolean isEditable(@Nullable IsEditableOptions options);
   /**
    * Returns whether the element is <a href="https://playwright.dev/java/docs/actionability#enabled">enabled</a>.
    *
@@ -4482,7 +4483,7 @@ public interface Locator {
    *
    * @since v1.14
    */
-  boolean isEnabled(IsEnabledOptions options);
+  boolean isEnabled(@Nullable IsEnabledOptions options);
   /**
    * Returns whether the element is hidden, the opposite of <a
    * href="https://playwright.dev/java/docs/actionability#visible">visible</a>.
@@ -4516,7 +4517,7 @@ public interface Locator {
    *
    * @since v1.14
    */
-  boolean isHidden(IsHiddenOptions options);
+  boolean isHidden(@Nullable IsHiddenOptions options);
   /**
    * Returns whether the element is <a href="https://playwright.dev/java/docs/actionability#visible">visible</a>.
    *
@@ -4548,7 +4549,7 @@ public interface Locator {
    *
    * @since v1.14
    */
-  boolean isVisible(IsVisibleOptions options);
+  boolean isVisible(@Nullable IsVisibleOptions options);
   /**
    * Returns locator to the last matching element.
    *
@@ -4581,7 +4582,7 @@ public interface Locator {
    * @param selectorOrLocator A selector or locator to use when resolving DOM element.
    * @since v1.14
    */
-  Locator locator(String selectorOrLocator, LocatorOptions options);
+  Locator locator(String selectorOrLocator, @Nullable LocatorOptions options);
   /**
    * The method finds an element matching the specified selector in the locator's subtree. It also accepts filter options,
    * similar to {@link com.microsoft.playwright.Locator#filter Locator.filter()} method.
@@ -4603,7 +4604,7 @@ public interface Locator {
    * @param selectorOrLocator A selector or locator to use when resolving DOM element.
    * @since v1.14
    */
-  Locator locator(Locator selectorOrLocator, LocatorOptions options);
+  Locator locator(Locator selectorOrLocator, @Nullable LocatorOptions options);
   /**
    * Returns a new locator that uses best practices for referencing the matched element, prioritizing test ids, aria roles,
    * and other user-facing attributes over CSS selectors. This is useful for converting implementation-detail selectors into
@@ -4735,7 +4736,7 @@ public interface Locator {
    * @param key Name of the key to press or a character to generate, such as {@code ArrowLeft} or {@code a}.
    * @since v1.14
    */
-  void press(String key, PressOptions options);
+  void press(String key, @Nullable PressOptions options);
   /**
    * <strong>NOTE:</strong> In most cases, you should use {@link com.microsoft.playwright.Locator#fill Locator.fill()} instead. You only need to
    * press keys one by one if there is special keyboard handling on the page.
@@ -4791,7 +4792,7 @@ public interface Locator {
    * @param text String of characters to sequentially press into a focused element.
    * @since v1.38
    */
-  void pressSequentially(String text, PressSequentiallyOptions options);
+  void pressSequentially(String text, @Nullable PressSequentiallyOptions options);
   /**
    * Take a screenshot of the element matching the locator.
    *
@@ -4851,7 +4852,7 @@ public interface Locator {
    *
    * @since v1.14
    */
-  byte[] screenshot(ScreenshotOptions options);
+  byte[] screenshot(@Nullable ScreenshotOptions options);
   /**
    * This method waits for <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks, then tries to
    * scroll element into view, unless it is completely visible as defined by <a
@@ -4875,7 +4876,7 @@ public interface Locator {
    *
    * @since v1.14
    */
-  void scrollIntoViewIfNeeded(ScrollIntoViewIfNeededOptions options);
+  void scrollIntoViewIfNeeded(@Nullable ScrollIntoViewIfNeededOptions options);
   /**
    * Selects option or options in {@code <select>}.
    *
@@ -4943,7 +4944,7 @@ public interface Locator {
    * and labels. Option is considered matching if all specified properties match.
    * @since v1.14
    */
-  List<String> selectOption(String values, SelectOptionOptions options);
+  List<String> selectOption(String values, @Nullable SelectOptionOptions options);
   /**
    * Selects option or options in {@code <select>}.
    *
@@ -5011,7 +5012,7 @@ public interface Locator {
    * and labels. Option is considered matching if all specified properties match.
    * @since v1.14
    */
-  List<String> selectOption(ElementHandle values, SelectOptionOptions options);
+  List<String> selectOption(ElementHandle values, @Nullable SelectOptionOptions options);
   /**
    * Selects option or options in {@code <select>}.
    *
@@ -5079,7 +5080,7 @@ public interface Locator {
    * and labels. Option is considered matching if all specified properties match.
    * @since v1.14
    */
-  List<String> selectOption(String[] values, SelectOptionOptions options);
+  List<String> selectOption(String[] values, @Nullable SelectOptionOptions options);
   /**
    * Selects option or options in {@code <select>}.
    *
@@ -5147,7 +5148,7 @@ public interface Locator {
    * and labels. Option is considered matching if all specified properties match.
    * @since v1.14
    */
-  List<String> selectOption(SelectOption values, SelectOptionOptions options);
+  List<String> selectOption(SelectOption values, @Nullable SelectOptionOptions options);
   /**
    * Selects option or options in {@code <select>}.
    *
@@ -5215,7 +5216,7 @@ public interface Locator {
    * and labels. Option is considered matching if all specified properties match.
    * @since v1.14
    */
-  List<String> selectOption(ElementHandle[] values, SelectOptionOptions options);
+  List<String> selectOption(ElementHandle[] values, @Nullable SelectOptionOptions options);
   /**
    * Selects option or options in {@code <select>}.
    *
@@ -5283,7 +5284,7 @@ public interface Locator {
    * and labels. Option is considered matching if all specified properties match.
    * @since v1.14
    */
-  List<String> selectOption(SelectOption[] values, SelectOptionOptions options);
+  List<String> selectOption(SelectOption[] values, @Nullable SelectOptionOptions options);
   /**
    * This method waits for <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks, then focuses
    * the element and selects all its text content.
@@ -5307,7 +5308,7 @@ public interface Locator {
    *
    * @since v1.14
    */
-  void selectText(SelectTextOptions options);
+  void selectText(@Nullable SelectTextOptions options);
   /**
    * Set the state of a checkbox or a radio element.
    *
@@ -5365,7 +5366,7 @@ public interface Locator {
    * @param checked Whether to check or uncheck the checkbox.
    * @since v1.15
    */
-  void setChecked(boolean checked, SetCheckedOptions options);
+  void setChecked(boolean checked, @Nullable SetCheckedOptions options);
   /**
    * Upload file or multiple files into {@code <input type=file>}. For inputs with a {@code [webkitdirectory]} attribute,
    * only a single directory path is supported.
@@ -5441,7 +5442,7 @@ public interface Locator {
    *
    * @since v1.14
    */
-  void setInputFiles(Path files, SetInputFilesOptions options);
+  void setInputFiles(Path files, @Nullable SetInputFilesOptions options);
   /**
    * Upload file or multiple files into {@code <input type=file>}. For inputs with a {@code [webkitdirectory]} attribute,
    * only a single directory path is supported.
@@ -5517,7 +5518,7 @@ public interface Locator {
    *
    * @since v1.14
    */
-  void setInputFiles(Path[] files, SetInputFilesOptions options);
+  void setInputFiles(Path[] files, @Nullable SetInputFilesOptions options);
   /**
    * Upload file or multiple files into {@code <input type=file>}. For inputs with a {@code [webkitdirectory]} attribute,
    * only a single directory path is supported.
@@ -5593,7 +5594,7 @@ public interface Locator {
    *
    * @since v1.14
    */
-  void setInputFiles(FilePayload files, SetInputFilesOptions options);
+  void setInputFiles(FilePayload files, @Nullable SetInputFilesOptions options);
   /**
    * Upload file or multiple files into {@code <input type=file>}. For inputs with a {@code [webkitdirectory]} attribute,
    * only a single directory path is supported.
@@ -5669,7 +5670,7 @@ public interface Locator {
    *
    * @since v1.14
    */
-  void setInputFiles(FilePayload[] files, SetInputFilesOptions options);
+  void setInputFiles(FilePayload[] files, @Nullable SetInputFilesOptions options);
   /**
    * Perform a tap gesture on the element matching the locator. For examples of emulating other gestures by manually
    * dispatching touch events, see the <a href="https://playwright.dev/java/docs/touch-events">emulating legacy touch
@@ -5723,7 +5724,7 @@ public interface Locator {
    *
    * @since v1.14
    */
-  void tap(TapOptions options);
+  void tap(@Nullable TapOptions options);
   /**
    * Returns the <a href="https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent">{@code node.textContent}</a>.
    *
@@ -5733,7 +5734,7 @@ public interface Locator {
    *
    * @since v1.14
    */
-  default String textContent() {
+  default @Nullable String textContent() {
     return textContent(null);
   }
   /**
@@ -5745,7 +5746,7 @@ public interface Locator {
    *
    * @since v1.14
    */
-  String textContent(TextContentOptions options);
+  @Nullable String textContent(@Nullable TextContentOptions options);
   /**
    * @deprecated In most cases, you should use {@link com.microsoft.playwright.Locator#fill Locator.fill()} instead. You only need to
    * press keys one by one if there is special keyboard handling on the page - in this case use {@link
@@ -5765,7 +5766,7 @@ public interface Locator {
    * @param text A text to type into a focused element.
    * @since v1.14
    */
-  void type(String text, TypeOptions options);
+  void type(String text, @Nullable TypeOptions options);
   /**
    * Ensure that checkbox or radio element is unchecked.
    *
@@ -5825,7 +5826,7 @@ public interface Locator {
    *
    * @since v1.14
    */
-  void uncheck(UncheckOptions options);
+  void uncheck(@Nullable UncheckOptions options);
   /**
    * Returns a locator that matches only <a href="https://playwright.dev/java/docs/actionability#visible">visible</a>
    * elements, ignoring the invisible ones. This is the recommended way to distinguish elements by visibility, as opposed to
@@ -5880,7 +5881,7 @@ public interface Locator {
    *
    * @since v1.16
    */
-  void waitFor(WaitForOptions options);
+  void waitFor(@Nullable WaitForOptions options);
   /**
    * Returns when {@code expression} returns a truthy value, called with the matching element as a first argument, and {@code
    * arg} as a second argument.
@@ -5905,7 +5906,7 @@ public interface Locator {
    * @param arg Optional argument to pass to {@code expression}.
    * @since v1.62
    */
-  default void waitForFunction(String expression, Object arg) {
+  default void waitForFunction(String expression, @Nullable Object arg) {
     waitForFunction(expression, arg, null);
   }
   /**
@@ -5958,6 +5959,6 @@ public interface Locator {
    * @param arg Optional argument to pass to {@code expression}.
    * @since v1.62
    */
-  void waitForFunction(String expression, Object arg, WaitForFunctionOptions options);
+  void waitForFunction(String expression, @Nullable Object arg, @Nullable WaitForFunctionOptions options);
 }
 

--- a/playwright/src/main/java/com/microsoft/playwright/Mouse.java
+++ b/playwright/src/main/java/com/microsoft/playwright/Mouse.java
@@ -16,6 +16,7 @@
 
 package com.microsoft.playwright;
 
+import org.jspecify.annotations.Nullable;
 import com.microsoft.playwright.options.*;
 
 /**
@@ -43,15 +44,15 @@ public interface Mouse {
     /**
      * Defaults to {@code left}.
      */
-    public MouseButton button;
+    public @Nullable MouseButton button;
     /**
      * defaults to 1. See [UIEvent.detail].
      */
-    public Integer clickCount;
+    public @Nullable Integer clickCount;
     /**
      * Time to wait between {@code mousedown} and {@code mouseup} in milliseconds. Defaults to 0.
      */
-    public Double delay;
+    public @Nullable Double delay;
 
     /**
      * Defaults to {@code left}.
@@ -79,11 +80,11 @@ public interface Mouse {
     /**
      * Defaults to {@code left}.
      */
-    public MouseButton button;
+    public @Nullable MouseButton button;
     /**
      * Time to wait between {@code mousedown} and {@code mouseup} in milliseconds. Defaults to 0.
      */
-    public Double delay;
+    public @Nullable Double delay;
 
     /**
      * Defaults to {@code left}.
@@ -104,11 +105,11 @@ public interface Mouse {
     /**
      * Defaults to {@code left}.
      */
-    public MouseButton button;
+    public @Nullable MouseButton button;
     /**
      * defaults to 1. See [UIEvent.detail].
      */
-    public Integer clickCount;
+    public @Nullable Integer clickCount;
 
     /**
      * Defaults to {@code left}.
@@ -131,7 +132,7 @@ public interface Mouse {
      * cursor position and the provided destination. When set to 1, emits a single {@code mousemove} event at the destination
      * location.
      */
-    public Integer steps;
+    public @Nullable Integer steps;
 
     /**
      * Defaults to 1. Sends {@code n} interpolated {@code mousemove} events to represent travel between Playwright's current
@@ -147,11 +148,11 @@ public interface Mouse {
     /**
      * Defaults to {@code left}.
      */
-    public MouseButton button;
+    public @Nullable MouseButton button;
     /**
      * defaults to 1. See [UIEvent.detail].
      */
-    public Integer clickCount;
+    public @Nullable Integer clickCount;
 
     /**
      * Defaults to {@code left}.
@@ -187,7 +188,7 @@ public interface Mouse {
    * @param y Y coordinate relative to the main frame's viewport in CSS pixels.
    * @since v1.8
    */
-  void click(double x, double y, ClickOptions options);
+  void click(double x, double y, @Nullable ClickOptions options);
   /**
    * Shortcut for {@link com.microsoft.playwright.Mouse#move Mouse.move()}, {@link com.microsoft.playwright.Mouse#down
    * Mouse.down()}, {@link com.microsoft.playwright.Mouse#up Mouse.up()}, {@link com.microsoft.playwright.Mouse#down
@@ -209,7 +210,7 @@ public interface Mouse {
    * @param y Y coordinate relative to the main frame's viewport in CSS pixels.
    * @since v1.8
    */
-  void dblclick(double x, double y, DblclickOptions options);
+  void dblclick(double x, double y, @Nullable DblclickOptions options);
   /**
    * Dispatches a {@code mousedown} event.
    *
@@ -223,7 +224,7 @@ public interface Mouse {
    *
    * @since v1.8
    */
-  void down(DownOptions options);
+  void down(@Nullable DownOptions options);
   /**
    * Dispatches a {@code mousemove} event.
    *
@@ -241,7 +242,7 @@ public interface Mouse {
    * @param y Y coordinate relative to the main frame's viewport in CSS pixels.
    * @since v1.8
    */
-  void move(double x, double y, MoveOptions options);
+  void move(double x, double y, @Nullable MoveOptions options);
   /**
    * Dispatches a {@code mouseup} event.
    *
@@ -255,7 +256,7 @@ public interface Mouse {
    *
    * @since v1.8
    */
-  void up(UpOptions options);
+  void up(@Nullable UpOptions options);
   /**
    * Dispatches a {@code wheel} event. This method is usually used to manually scroll the page. See <a
    * href="https://playwright.dev/java/docs/input#scrolling">scrolling</a> for alternative ways to scroll.

--- a/playwright/src/main/java/com/microsoft/playwright/Page.java
+++ b/playwright/src/main/java/com/microsoft/playwright/Page.java
@@ -16,6 +16,7 @@
 
 package com.microsoft.playwright;
 
+import org.jspecify.annotations.Nullable;
 import com.microsoft.playwright.options.*;
 import java.nio.file.Path;
 import java.util.*;
@@ -346,21 +347,21 @@ public interface Page extends AutoCloseable {
     /**
      * Raw JavaScript content to be injected into frame.
      */
-    public String content;
+    public @Nullable String content;
     /**
      * Path to the JavaScript file to be injected into frame. If {@code path} is a relative path, then it is resolved relative
      * to the current working directory.
      */
-    public Path path;
+    public @Nullable Path path;
     /**
      * Script type. Use 'module' in order to load a JavaScript ES6 module. See <a
      * href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script">script</a> for more details.
      */
-    public String type;
+    public @Nullable String type;
     /**
      * URL of a script to be added.
      */
-    public String url;
+    public @Nullable String url;
 
     /**
      * Raw JavaScript content to be injected into frame.
@@ -397,16 +398,16 @@ public interface Page extends AutoCloseable {
     /**
      * Raw CSS content to be injected into frame.
      */
-    public String content;
+    public @Nullable String content;
     /**
      * Path to the CSS file to be injected into frame. If {@code path} is a relative path, then it is resolved relative to the
      * current working directory.
      */
-    public Path path;
+    public @Nullable Path path;
     /**
      * URL of the {@code <link>} tag.
      */
-    public String url;
+    public @Nullable String url;
 
     /**
      * Raw CSS content to be injected into frame.
@@ -436,41 +437,41 @@ public interface Page extends AutoCloseable {
      * Whether to bypass the <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks. Defaults to
      * {@code false}.
      */
-    public Boolean force;
+    public @Nullable Boolean force;
     /**
      * @deprecated This option has no effect.
      */
-    public Boolean noWaitAfter;
+    public @Nullable Boolean noWaitAfter;
     /**
      * A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the
      * element.
      */
-    public Position position;
+    public @Nullable Position position;
     /**
      * Controls whether Playwright scrolls the element into view before performing the action. Defaults to {@code "auto"},
      * which scrolls the element into view when necessary, including scrolling nested scrollable containers. When set to {@code
      * "none"}, Playwright does not scroll the element and the action fails if the element is not already in the viewport. This
      * is useful to assert that an element is reachable by the user without additional scrolling.
      */
-    public ScrollMode scroll;
+    public @Nullable ScrollMode scroll;
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
-    public Boolean strict;
+    public @Nullable Boolean strict;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
      * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
     /**
      * When set, this method only performs the <a href="https://playwright.dev/java/docs/actionability">actionability</a>
      * checks and skips the action. Defaults to {@code false}. Useful to wait until the element is ready for the action without
      * performing it.
      */
-    public Boolean trial;
+    public @Nullable Boolean trial;
 
     /**
      * Whether to bypass the <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks. Defaults to
@@ -544,61 +545,61 @@ public interface Page extends AutoCloseable {
     /**
      * Defaults to {@code left}.
      */
-    public MouseButton button;
+    public @Nullable MouseButton button;
     /**
      * defaults to 1. See [UIEvent.detail].
      */
-    public Integer clickCount;
+    public @Nullable Integer clickCount;
     /**
      * Time to wait between {@code mousedown} and {@code mouseup} in milliseconds. Defaults to 0.
      */
-    public Double delay;
+    public @Nullable Double delay;
     /**
      * Whether to bypass the <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks. Defaults to
      * {@code false}.
      */
-    public Boolean force;
+    public @Nullable Boolean force;
     /**
      * Modifier keys to press. Ensures that only these modifiers are pressed during the operation, and then restores current
      * modifiers back. If not specified, currently pressed modifiers are used. "ControlOrMeta" resolves to "Control" on Windows
      * and Linux and to "Meta" on macOS.
      */
-    public List<KeyboardModifier> modifiers;
+    public @Nullable List<KeyboardModifier> modifiers;
     /**
      * @deprecated This option will default to {@code true} in the future.
      */
-    public Boolean noWaitAfter;
+    public @Nullable Boolean noWaitAfter;
     /**
      * A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the
      * element.
      */
-    public Position position;
+    public @Nullable Position position;
     /**
      * Controls whether Playwright scrolls the element into view before performing the action. Defaults to {@code "auto"},
      * which scrolls the element into view when necessary, including scrolling nested scrollable containers. When set to {@code
      * "none"}, Playwright does not scroll the element and the action fails if the element is not already in the viewport. This
      * is useful to assert that an element is reachable by the user without additional scrolling.
      */
-    public ScrollMode scroll;
+    public @Nullable ScrollMode scroll;
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
-    public Boolean strict;
+    public @Nullable Boolean strict;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
      * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
     /**
      * When set, this method only performs the <a href="https://playwright.dev/java/docs/actionability">actionability</a>
      * checks and skips the action. Defaults to {@code false}. Useful to wait until the element is ready for the action without
      * performing it. Note that keyboard {@code modifiers} will be pressed regardless of {@code trial} to allow testing
      * elements which are only visible when those keys are pressed.
      */
-    public Boolean trial;
+    public @Nullable Boolean trial;
 
     /**
      * Defaults to {@code left}.
@@ -703,12 +704,12 @@ public interface Page extends AutoCloseable {
     /**
      * The reason to be reported to the operations interrupted by the page closure.
      */
-    public String reason;
+    public @Nullable String reason;
     /**
      * Defaults to {@code false}. Whether to run the <a
      * href="https://developer.mozilla.org/en-US/docs/Web/Events/beforeunload">before unload</a> page handlers.
      */
-    public Boolean runBeforeUnload;
+    public @Nullable Boolean runBeforeUnload;
 
     /**
      * The reason to be reported to the operations interrupted by the page closure.
@@ -730,57 +731,57 @@ public interface Page extends AutoCloseable {
     /**
      * Defaults to {@code left}.
      */
-    public MouseButton button;
+    public @Nullable MouseButton button;
     /**
      * Time to wait between {@code mousedown} and {@code mouseup} in milliseconds. Defaults to 0.
      */
-    public Double delay;
+    public @Nullable Double delay;
     /**
      * Whether to bypass the <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks. Defaults to
      * {@code false}.
      */
-    public Boolean force;
+    public @Nullable Boolean force;
     /**
      * Modifier keys to press. Ensures that only these modifiers are pressed during the operation, and then restores current
      * modifiers back. If not specified, currently pressed modifiers are used. "ControlOrMeta" resolves to "Control" on Windows
      * and Linux and to "Meta" on macOS.
      */
-    public List<KeyboardModifier> modifiers;
+    public @Nullable List<KeyboardModifier> modifiers;
     /**
      * @deprecated This option has no effect.
      */
-    public Boolean noWaitAfter;
+    public @Nullable Boolean noWaitAfter;
     /**
      * A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the
      * element.
      */
-    public Position position;
+    public @Nullable Position position;
     /**
      * Controls whether Playwright scrolls the element into view before performing the action. Defaults to {@code "auto"},
      * which scrolls the element into view when necessary, including scrolling nested scrollable containers. When set to {@code
      * "none"}, Playwright does not scroll the element and the action fails if the element is not already in the viewport. This
      * is useful to assert that an element is reachable by the user without additional scrolling.
      */
-    public ScrollMode scroll;
+    public @Nullable ScrollMode scroll;
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
-    public Boolean strict;
+    public @Nullable Boolean strict;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
      * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
     /**
      * When set, this method only performs the <a href="https://playwright.dev/java/docs/actionability">actionability</a>
      * checks and skips the action. Defaults to {@code false}. Useful to wait until the element is ready for the action without
      * performing it. Note that keyboard {@code modifiers} will be pressed regardless of {@code trial} to allow testing
      * elements which are only visible when those keys are pressed.
      */
-    public Boolean trial;
+    public @Nullable Boolean trial;
 
     /**
      * Defaults to {@code left}.
@@ -879,14 +880,14 @@ public interface Page extends AutoCloseable {
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
-    public Boolean strict;
+    public @Nullable Boolean strict;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
      * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
@@ -912,51 +913,51 @@ public interface Page extends AutoCloseable {
      * Whether to bypass the <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks. Defaults to
      * {@code false}.
      */
-    public Boolean force;
+    public @Nullable Boolean force;
     /**
      * @deprecated This option has no effect.
      */
-    public Boolean noWaitAfter;
+    public @Nullable Boolean noWaitAfter;
     /**
      * Controls whether Playwright scrolls the element into view before performing the action. Defaults to {@code "auto"},
      * which scrolls the element into view when necessary, including scrolling nested scrollable containers. When set to {@code
      * "none"}, Playwright does not scroll the element and the action fails if the element is not already in the viewport. This
      * is useful to assert that an element is reachable by the user without additional scrolling.
      */
-    public ScrollMode scroll;
+    public @Nullable ScrollMode scroll;
     /**
      * Clicks on the source element at this point relative to the top-left corner of the element's padding box. If not
      * specified, some visible point of the element is used.
      */
-    public Position sourcePosition;
+    public @Nullable Position sourcePosition;
     /**
      * Defaults to 1. Sends {@code n} interpolated {@code mousemove} events to represent travel between the {@code mousedown}
      * and {@code mouseup} of the drag. When set to 1, emits a single {@code mousemove} event at the destination location.
      */
-    public Integer steps;
+    public @Nullable Integer steps;
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
-    public Boolean strict;
+    public @Nullable Boolean strict;
     /**
      * Drops on the target element at this point relative to the top-left corner of the element's padding box. If not
      * specified, some visible point of the element is used.
      */
-    public Position targetPosition;
+    public @Nullable Position targetPosition;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
      * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
     /**
      * When set, this method only performs the <a href="https://playwright.dev/java/docs/actionability">actionability</a>
      * checks and skips the action. Defaults to {@code false}. Useful to wait until the element is ready for the action without
      * performing it.
      */
-    public Boolean trial;
+    public @Nullable Boolean trial;
 
     /**
      * Whether to bypass the <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks. Defaults to
@@ -1056,27 +1057,27 @@ public interface Page extends AutoCloseable {
      * feature, supported values are {@code "light"} and {@code "dark"}. Passing {@code null} disables color scheme emulation.
      * {@code "no-preference"} is deprecated.
      */
-    public Optional<ColorScheme> colorScheme;
+    public @Nullable Optional<ColorScheme> colorScheme;
     /**
      * Emulates {@code "prefers-contrast"} media feature, supported values are {@code "no-preference"}, {@code "more"}. Passing
      * {@code null} disables contrast emulation.
      */
-    public Optional<Contrast> contrast;
+    public @Nullable Optional<Contrast> contrast;
     /**
      * Emulates {@code "forced-colors"} media feature, supported values are {@code "active"} and {@code "none"}. Passing {@code
      * null} disables forced colors emulation.
      */
-    public Optional<ForcedColors> forcedColors;
+    public @Nullable Optional<ForcedColors> forcedColors;
     /**
      * Changes the CSS media type of the page. The only allowed values are {@code "screen"}, {@code "print"} and {@code null}.
      * Passing {@code null} disables CSS media emulation.
      */
-    public Optional<Media> media;
+    public @Nullable Optional<Media> media;
     /**
      * Emulates {@code "prefers-reduced-motion"} media feature, supported values are {@code "reduce"}, {@code "no-preference"}.
      * Passing {@code null} disables reduced motion emulation.
      */
-    public Optional<ReducedMotion> reducedMotion;
+    public @Nullable Optional<ReducedMotion> reducedMotion;
 
     /**
      * Emulates <a
@@ -1084,7 +1085,7 @@ public interface Page extends AutoCloseable {
      * feature, supported values are {@code "light"} and {@code "dark"}. Passing {@code null} disables color scheme emulation.
      * {@code "no-preference"} is deprecated.
      */
-    public EmulateMediaOptions setColorScheme(ColorScheme colorScheme) {
+    public EmulateMediaOptions setColorScheme(@Nullable ColorScheme colorScheme) {
       this.colorScheme = Optional.ofNullable(colorScheme);
       return this;
     }
@@ -1092,7 +1093,7 @@ public interface Page extends AutoCloseable {
      * Emulates {@code "prefers-contrast"} media feature, supported values are {@code "no-preference"}, {@code "more"}. Passing
      * {@code null} disables contrast emulation.
      */
-    public EmulateMediaOptions setContrast(Contrast contrast) {
+    public EmulateMediaOptions setContrast(@Nullable Contrast contrast) {
       this.contrast = Optional.ofNullable(contrast);
       return this;
     }
@@ -1100,7 +1101,7 @@ public interface Page extends AutoCloseable {
      * Emulates {@code "forced-colors"} media feature, supported values are {@code "active"} and {@code "none"}. Passing {@code
      * null} disables forced colors emulation.
      */
-    public EmulateMediaOptions setForcedColors(ForcedColors forcedColors) {
+    public EmulateMediaOptions setForcedColors(@Nullable ForcedColors forcedColors) {
       this.forcedColors = Optional.ofNullable(forcedColors);
       return this;
     }
@@ -1108,7 +1109,7 @@ public interface Page extends AutoCloseable {
      * Changes the CSS media type of the page. The only allowed values are {@code "screen"}, {@code "print"} and {@code null}.
      * Passing {@code null} disables CSS media emulation.
      */
-    public EmulateMediaOptions setMedia(Media media) {
+    public EmulateMediaOptions setMedia(@Nullable Media media) {
       this.media = Optional.ofNullable(media);
       return this;
     }
@@ -1116,7 +1117,7 @@ public interface Page extends AutoCloseable {
      * Emulates {@code "prefers-reduced-motion"} media feature, supported values are {@code "reduce"}, {@code "no-preference"}.
      * Passing {@code null} disables reduced motion emulation.
      */
-    public EmulateMediaOptions setReducedMotion(ReducedMotion reducedMotion) {
+    public EmulateMediaOptions setReducedMotion(@Nullable ReducedMotion reducedMotion) {
       this.reducedMotion = Optional.ofNullable(reducedMotion);
       return this;
     }
@@ -1126,7 +1127,7 @@ public interface Page extends AutoCloseable {
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
-    public Boolean strict;
+    public @Nullable Boolean strict;
 
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
@@ -1142,23 +1143,23 @@ public interface Page extends AutoCloseable {
      * Whether to bypass the <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks. Defaults to
      * {@code false}.
      */
-    public Boolean force;
+    public @Nullable Boolean force;
     /**
      * @deprecated This option has no effect.
      */
-    public Boolean noWaitAfter;
+    public @Nullable Boolean noWaitAfter;
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
-    public Boolean strict;
+    public @Nullable Boolean strict;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
      * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * Whether to bypass the <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks. Defaults to
@@ -1199,14 +1200,14 @@ public interface Page extends AutoCloseable {
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
-    public Boolean strict;
+    public @Nullable Boolean strict;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
      * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
@@ -1232,14 +1233,14 @@ public interface Page extends AutoCloseable {
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
-    public Boolean strict;
+    public @Nullable Boolean strict;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
      * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
@@ -1265,7 +1266,7 @@ public interface Page extends AutoCloseable {
      * Whether to find an exact match: case-sensitive and whole-string. Default to false. Ignored when locating by a regular
      * expression. Note that exact match still trims whitespace.
      */
-    public Boolean exact;
+    public @Nullable Boolean exact;
 
     /**
      * Whether to find an exact match: case-sensitive and whole-string. Default to false. Ignored when locating by a regular
@@ -1281,7 +1282,7 @@ public interface Page extends AutoCloseable {
      * Whether to find an exact match: case-sensitive and whole-string. Default to false. Ignored when locating by a regular
      * expression. Note that exact match still trims whitespace.
      */
-    public Boolean exact;
+    public @Nullable Boolean exact;
 
     /**
      * Whether to find an exact match: case-sensitive and whole-string. Default to false. Ignored when locating by a regular
@@ -1297,7 +1298,7 @@ public interface Page extends AutoCloseable {
      * Whether to find an exact match: case-sensitive and whole-string. Default to false. Ignored when locating by a regular
      * expression. Note that exact match still trims whitespace.
      */
-    public Boolean exact;
+    public @Nullable Boolean exact;
 
     /**
      * Whether to find an exact match: case-sensitive and whole-string. Default to false. Ignored when locating by a regular
@@ -1314,65 +1315,65 @@ public interface Page extends AutoCloseable {
      *
      * <p> Learn more about <a href="https://www.w3.org/TR/wai-aria-1.2/#aria-checked">{@code aria-checked}</a>.
      */
-    public Boolean checked;
+    public @Nullable Boolean checked;
     /**
      * Option to match the <a href="https://w3c.github.io/accname/#dfn-accessible-description">accessible description</a>. By
      * default, matching is case-insensitive and searches for a substring, use {@code exact} to control this behavior.
      *
      * <p> Learn more about <a href="https://w3c.github.io/accname/#dfn-accessible-description">accessible description</a>.
      */
-    public Object description;
+    public @Nullable Object description;
     /**
      * An attribute that is usually set by {@code aria-disabled} or {@code disabled}.
      *
      * <p> <strong>NOTE:</strong> Unlike most other attributes, {@code disabled} is inherited through the DOM hierarchy. Learn more about <a
      * href="https://www.w3.org/TR/wai-aria-1.2/#aria-disabled">{@code aria-disabled}</a>.
      */
-    public Boolean disabled;
+    public @Nullable Boolean disabled;
     /**
      * Whether {@code name} and {@code description} are matched exactly: case-sensitive and whole-string. Defaults to false.
      * Ignored when the value is a regular expression. Note that exact match still trims whitespace.
      */
-    public Boolean exact;
+    public @Nullable Boolean exact;
     /**
      * An attribute that is usually set by {@code aria-expanded}.
      *
      * <p> Learn more about <a href="https://www.w3.org/TR/wai-aria-1.2/#aria-expanded">{@code aria-expanded}</a>.
      */
-    public Boolean expanded;
+    public @Nullable Boolean expanded;
     /**
      * Option that controls whether hidden elements are matched. By default, only non-hidden elements, as <a
      * href="https://www.w3.org/TR/wai-aria-1.2/#tree_exclusion">defined by ARIA</a>, are matched by role selector.
      *
      * <p> Learn more about <a href="https://www.w3.org/TR/wai-aria-1.2/#aria-hidden">{@code aria-hidden}</a>.
      */
-    public Boolean includeHidden;
+    public @Nullable Boolean includeHidden;
     /**
      * A number attribute that is usually present for roles {@code heading}, {@code listitem}, {@code row}, {@code treeitem},
      * with default values for {@code <h1>-<h6>} elements.
      *
      * <p> Learn more about <a href="https://www.w3.org/TR/wai-aria-1.2/#aria-level">{@code aria-level}</a>.
      */
-    public Integer level;
+    public @Nullable Integer level;
     /**
      * Option to match the <a href="https://w3c.github.io/accname/#dfn-accessible-name">accessible name</a>. By default,
      * matching is case-insensitive and searches for a substring, use {@code exact} to control this behavior.
      *
      * <p> Learn more about <a href="https://w3c.github.io/accname/#dfn-accessible-name">accessible name</a>.
      */
-    public Object name;
+    public @Nullable Object name;
     /**
      * An attribute that is usually set by {@code aria-pressed}.
      *
      * <p> Learn more about <a href="https://www.w3.org/TR/wai-aria-1.2/#aria-pressed">{@code aria-pressed}</a>.
      */
-    public Boolean pressed;
+    public @Nullable Boolean pressed;
     /**
      * An attribute that is usually set by {@code aria-selected}.
      *
      * <p> Learn more about <a href="https://www.w3.org/TR/wai-aria-1.2/#aria-selected">{@code aria-selected}</a>.
      */
-    public Boolean selected;
+    public @Nullable Boolean selected;
 
     /**
      * An attribute that is usually set by {@code aria-checked} or native {@code <input type=checkbox>} controls.
@@ -1494,7 +1495,7 @@ public interface Page extends AutoCloseable {
      * Whether to find an exact match: case-sensitive and whole-string. Default to false. Ignored when locating by a regular
      * expression. Note that exact match still trims whitespace.
      */
-    public Boolean exact;
+    public @Nullable Boolean exact;
 
     /**
      * Whether to find an exact match: case-sensitive and whole-string. Default to false. Ignored when locating by a regular
@@ -1510,7 +1511,7 @@ public interface Page extends AutoCloseable {
      * Whether to find an exact match: case-sensitive and whole-string. Default to false. Ignored when locating by a regular
      * expression. Note that exact match still trims whitespace.
      */
-    public Boolean exact;
+    public @Nullable Boolean exact;
 
     /**
      * Whether to find an exact match: case-sensitive and whole-string. Default to false. Ignored when locating by a regular
@@ -1530,7 +1531,7 @@ public interface Page extends AutoCloseable {
      * Page.setDefaultNavigationTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
     /**
      * When to consider operation succeeded, defaults to {@code load}. Events can be either:
      * <ul>
@@ -1541,7 +1542,7 @@ public interface Page extends AutoCloseable {
      * <li> {@code "commit"} - consider operation to be finished when network response is received and the document started loading.</li>
      * </ul>
      */
-    public WaitUntilState waitUntil;
+    public @Nullable WaitUntilState waitUntil;
 
     /**
      * Maximum operation time in milliseconds, defaults to 30 seconds, pass {@code 0} to disable timeout. The default value can
@@ -1579,7 +1580,7 @@ public interface Page extends AutoCloseable {
      * Page.setDefaultNavigationTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
     /**
      * When to consider operation succeeded, defaults to {@code load}. Events can be either:
      * <ul>
@@ -1590,7 +1591,7 @@ public interface Page extends AutoCloseable {
      * <li> {@code "commit"} - consider operation to be finished when network response is received and the document started loading.</li>
      * </ul>
      */
-    public WaitUntilState waitUntil;
+    public @Nullable WaitUntilState waitUntil;
 
     /**
      * Maximum operation time in milliseconds, defaults to 30 seconds, pass {@code 0} to disable timeout. The default value can
@@ -1624,7 +1625,7 @@ public interface Page extends AutoCloseable {
      * Referer header value. If provided it will take preference over the referer header value set by {@link
      * com.microsoft.playwright.Page#setExtraHTTPHeaders Page.setExtraHTTPHeaders()}.
      */
-    public String referer;
+    public @Nullable String referer;
     /**
      * Maximum operation time in milliseconds, defaults to 30 seconds, pass {@code 0} to disable timeout. The default value can
      * be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultNavigationTimeout
@@ -1633,7 +1634,7 @@ public interface Page extends AutoCloseable {
      * Page.setDefaultNavigationTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
     /**
      * When to consider operation succeeded, defaults to {@code load}. Events can be either:
      * <ul>
@@ -1644,7 +1645,7 @@ public interface Page extends AutoCloseable {
      * <li> {@code "commit"} - consider operation to be finished when network response is received and the document started loading.</li>
      * </ul>
      */
-    public WaitUntilState waitUntil;
+    public @Nullable WaitUntilState waitUntil;
 
     /**
      * Referer header value. If provided it will take preference over the referer header value set by {@link
@@ -1686,48 +1687,48 @@ public interface Page extends AutoCloseable {
      * Whether to bypass the <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks. Defaults to
      * {@code false}.
      */
-    public Boolean force;
+    public @Nullable Boolean force;
     /**
      * Modifier keys to press. Ensures that only these modifiers are pressed during the operation, and then restores current
      * modifiers back. If not specified, currently pressed modifiers are used. "ControlOrMeta" resolves to "Control" on Windows
      * and Linux and to "Meta" on macOS.
      */
-    public List<KeyboardModifier> modifiers;
+    public @Nullable List<KeyboardModifier> modifiers;
     /**
      * @deprecated This option has no effect.
      */
-    public Boolean noWaitAfter;
+    public @Nullable Boolean noWaitAfter;
     /**
      * A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the
      * element.
      */
-    public Position position;
+    public @Nullable Position position;
     /**
      * Controls whether Playwright scrolls the element into view before performing the action. Defaults to {@code "auto"},
      * which scrolls the element into view when necessary, including scrolling nested scrollable containers. When set to {@code
      * "none"}, Playwright does not scroll the element and the action fails if the element is not already in the viewport. This
      * is useful to assert that an element is reachable by the user without additional scrolling.
      */
-    public ScrollMode scroll;
+    public @Nullable ScrollMode scroll;
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
-    public Boolean strict;
+    public @Nullable Boolean strict;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
      * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
     /**
      * When set, this method only performs the <a href="https://playwright.dev/java/docs/actionability">actionability</a>
      * checks and skips the action. Defaults to {@code false}. Useful to wait until the element is ready for the action without
      * performing it. Note that keyboard {@code modifiers} will be pressed regardless of {@code trial} to allow testing
      * elements which are only visible when those keys are pressed.
      */
-    public Boolean trial;
+    public @Nullable Boolean trial;
 
     /**
      * Whether to bypass the <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks. Defaults to
@@ -1812,14 +1813,14 @@ public interface Page extends AutoCloseable {
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
-    public Boolean strict;
+    public @Nullable Boolean strict;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
      * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
@@ -1845,14 +1846,14 @@ public interface Page extends AutoCloseable {
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
-    public Boolean strict;
+    public @Nullable Boolean strict;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
      * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
@@ -1878,14 +1879,14 @@ public interface Page extends AutoCloseable {
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
-    public Boolean strict;
+    public @Nullable Boolean strict;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
      * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
@@ -1911,14 +1912,14 @@ public interface Page extends AutoCloseable {
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
-    public Boolean strict;
+    public @Nullable Boolean strict;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
      * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
@@ -1944,14 +1945,14 @@ public interface Page extends AutoCloseable {
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
-    public Boolean strict;
+    public @Nullable Boolean strict;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
      * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
@@ -1977,14 +1978,14 @@ public interface Page extends AutoCloseable {
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
-    public Boolean strict;
+    public @Nullable Boolean strict;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
      * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
@@ -2010,14 +2011,14 @@ public interface Page extends AutoCloseable {
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
-    public Boolean strict;
+    public @Nullable Boolean strict;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
      * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
@@ -2043,12 +2044,12 @@ public interface Page extends AutoCloseable {
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
-    public Boolean strict;
+    public @Nullable Boolean strict;
     /**
      * @deprecated This option is ignored. {@link com.microsoft.playwright.Page#isHidden Page.isHidden()} does not wait for the element to
      * become hidden and returns immediately.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
@@ -2072,12 +2073,12 @@ public interface Page extends AutoCloseable {
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
-    public Boolean strict;
+    public @Nullable Boolean strict;
     /**
      * @deprecated This option is ignored. {@link com.microsoft.playwright.Page#isVisible Page.isVisible()} does not wait for the element
      * to become visible and returns immediately.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
@@ -2100,7 +2101,7 @@ public interface Page extends AutoCloseable {
     /**
      * Controls which messages are returned:
      */
-    public ConsoleMessagesFilter filter;
+    public @Nullable ConsoleMessagesFilter filter;
 
     /**
      * Controls which messages are returned:
@@ -2123,7 +2124,7 @@ public interface Page extends AutoCloseable {
      *
      * <p> Note that outer and inner locators must belong to the same frame. Inner locator must not contain {@code FrameLocator}s.
      */
-    public Locator has;
+    public @Nullable Locator has;
     /**
      * Matches elements that do not contain an element that matches an inner locator. Inner locator is queried against the
      * outer one. For example, {@code article} that does not have {@code div} matches {@code
@@ -2131,18 +2132,18 @@ public interface Page extends AutoCloseable {
      *
      * <p> Note that outer and inner locators must belong to the same frame. Inner locator must not contain {@code FrameLocator}s.
      */
-    public Locator hasNot;
+    public @Nullable Locator hasNot;
     /**
      * Matches elements that do not contain specified text somewhere inside, possibly in a child or a descendant element. When
      * passed a [string], matching is case-insensitive and searches for a substring.
      */
-    public Object hasNotText;
+    public @Nullable Object hasNotText;
     /**
      * Matches elements containing specified text somewhere inside, possibly in a child or a descendant element. When passed a
      * [string], matching is case-insensitive and searches for a substring. For example, {@code "Playwright"} matches {@code
      * <article><div>Playwright</div></article>}.
      */
-    public Object hasText;
+    public @Nullable Object hasText;
 
     /**
      * Narrows down the results of the method to those which contain elements matching this relative locator. For example,
@@ -2210,15 +2211,15 @@ public interface Page extends AutoCloseable {
     /**
      * Display header and footer. Defaults to {@code false}.
      */
-    public Boolean displayHeaderFooter;
+    public @Nullable Boolean displayHeaderFooter;
     /**
      * HTML template for the print footer. Should use the same format as the {@code headerTemplate}.
      */
-    public String footerTemplate;
+    public @Nullable String footerTemplate;
     /**
      * Paper format. If set, takes priority over {@code width} or {@code height} options. Defaults to 'Letter'.
      */
-    public String format;
+    public @Nullable String format;
     /**
      * HTML template for the print header. Should be valid HTML markup with following classes used to inject printing values
      * into them:
@@ -2230,53 +2231,53 @@ public interface Page extends AutoCloseable {
      * <li> {@code "totalPages"} total pages in the document</li>
      * </ul>
      */
-    public String headerTemplate;
+    public @Nullable String headerTemplate;
     /**
      * Paper height, accepts values labeled with units.
      */
-    public String height;
+    public @Nullable String height;
     /**
      * Paper orientation. Defaults to {@code false}.
      */
-    public Boolean landscape;
+    public @Nullable Boolean landscape;
     /**
      * Paper margins, defaults to none.
      */
-    public Margin margin;
+    public @Nullable Margin margin;
     /**
      * Whether or not to embed the document outline into the PDF. Defaults to {@code false}.
      */
-    public Boolean outline;
+    public @Nullable Boolean outline;
     /**
      * Paper ranges to print, e.g., '1-5, 8, 11-13'. Defaults to the empty string, which means print all pages.
      */
-    public String pageRanges;
+    public @Nullable String pageRanges;
     /**
      * The file path to save the PDF to. If {@code path} is a relative path, then it is resolved relative to the current
      * working directory. If no path is provided, the PDF won't be saved to the disk.
      */
-    public Path path;
+    public @Nullable Path path;
     /**
      * Give any CSS {@code @page} size declared in the page priority over what is declared in {@code width} and {@code height}
      * or {@code format} options. Defaults to {@code false}, which will scale the content to fit the paper size.
      */
-    public Boolean preferCSSPageSize;
+    public @Nullable Boolean preferCSSPageSize;
     /**
      * Print background graphics. Defaults to {@code false}.
      */
-    public Boolean printBackground;
+    public @Nullable Boolean printBackground;
     /**
      * Scale of the webpage rendering. Defaults to {@code 1}. Scale amount must be between 0.1 and 2.
      */
-    public Double scale;
+    public @Nullable Double scale;
     /**
      * Whether or not to generate tagged (accessible) PDF. Defaults to {@code false}.
      */
-    public Boolean tagged;
+    public @Nullable Boolean tagged;
     /**
      * Paper width, accepts values labeled with units.
      */
-    public String width;
+    public @Nullable String width;
 
     /**
      * Display header and footer. Defaults to {@code false}.
@@ -2398,23 +2399,23 @@ public interface Page extends AutoCloseable {
     /**
      * Time to wait between {@code keydown} and {@code keyup} in milliseconds. Defaults to 0.
      */
-    public Double delay;
+    public @Nullable Double delay;
     /**
      * @deprecated This option will default to {@code true} in the future.
      */
-    public Boolean noWaitAfter;
+    public @Nullable Boolean noWaitAfter;
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
-    public Boolean strict;
+    public @Nullable Boolean strict;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
      * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * Time to wait between {@code keydown} and {@code keyup} in milliseconds. Defaults to 0.
@@ -2454,7 +2455,7 @@ public interface Page extends AutoCloseable {
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
-    public Boolean strict;
+    public @Nullable Boolean strict;
 
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
@@ -2471,11 +2472,11 @@ public interface Page extends AutoCloseable {
      * will continue with the action/assertion that triggered the handler. This option allows to opt-out of this behavior, so
      * that overlay can stay visible after the handler has run.
      */
-    public Boolean noWaitAfter;
+    public @Nullable Boolean noWaitAfter;
     /**
      * Specifies the maximum number of times this handler should be called. Unlimited by default.
      */
-    public Integer times;
+    public @Nullable Integer times;
 
     /**
      * By default, after calling the handler Playwright will wait until the overlay becomes hidden, and only then Playwright
@@ -2503,7 +2504,7 @@ public interface Page extends AutoCloseable {
      * Page.setDefaultNavigationTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
     /**
      * When to consider operation succeeded, defaults to {@code load}. Events can be either:
      * <ul>
@@ -2514,7 +2515,7 @@ public interface Page extends AutoCloseable {
      * <li> {@code "commit"} - consider operation to be finished when network response is received and the document started loading.</li>
      * </ul>
      */
-    public WaitUntilState waitUntil;
+    public @Nullable WaitUntilState waitUntil;
 
     /**
      * Maximum operation time in milliseconds, defaults to 30 seconds, pass {@code 0} to disable timeout. The default value can
@@ -2547,7 +2548,7 @@ public interface Page extends AutoCloseable {
     /**
      * How often a route should be used. By default it will be used every time.
      */
-    public Integer times;
+    public @Nullable Integer times;
 
     /**
      * How often a route should be used. By default it will be used every time.
@@ -2566,28 +2567,28 @@ public interface Page extends AutoCloseable {
      *
      * <p> Defaults to abort.
      */
-    public HarNotFound notFound;
+    public @Nullable HarNotFound notFound;
     /**
      * If specified, updates the given HAR with the actual network information instead of serving from file. The file is
      * written to disk when {@link com.microsoft.playwright.BrowserContext#close BrowserContext.close()} is called.
      */
-    public Boolean update;
+    public @Nullable Boolean update;
     /**
      * Optional setting to control resource content management. If {@code attach} is specified, resources are persisted as
      * separate files or entries in the ZIP archive. If {@code embed} is specified, content is stored inline the HAR file.
      */
-    public RouteFromHarUpdateContentPolicy updateContent;
+    public @Nullable RouteFromHarUpdateContentPolicy updateContent;
     /**
      * When set to {@code minimal}, only record information necessary for routing from HAR. This omits sizes, timing, page,
      * cookies, security and other types of HAR information that are not used when replaying from HAR. Defaults to {@code
      * minimal}.
      */
-    public HarMode updateMode;
+    public @Nullable HarMode updateMode;
     /**
      * A glob pattern, regular expression or predicate to match the request URL. Only requests with URL matching the pattern
      * will be served from the HAR file. If not specified, all requests are served from the HAR file.
      */
-    public Object url;
+    public @Nullable Object url;
 
     /**
      * <ul>
@@ -2654,51 +2655,51 @@ public interface Page extends AutoCloseable {
      *
      * <p> Defaults to {@code "allow"} that leaves animations untouched.
      */
-    public ScreenshotAnimations animations;
+    public @Nullable ScreenshotAnimations animations;
     /**
      * When set to {@code "hide"}, screenshot will hide text caret. When set to {@code "initial"}, text caret behavior will not
      * be changed.  Defaults to {@code "hide"}.
      */
-    public ScreenshotCaret caret;
+    public @Nullable ScreenshotCaret caret;
     /**
      * An object which specifies clipping of the resulting image.
      */
-    public Clip clip;
+    public @Nullable Clip clip;
     /**
      * When true, takes a screenshot of the full scrollable page, instead of the currently visible viewport. Defaults to {@code
      * false}.
      */
-    public Boolean fullPage;
+    public @Nullable Boolean fullPage;
     /**
      * Specify locators that should be masked when the screenshot is taken. Masked elements will be overlaid with a pink box
      * {@code #FF00FF} (customized by {@code maskColor}) that completely covers its bounding box. The mask is also applied to
      * invisible elements, see <a href="https://playwright.dev/java/docs/locators#matching-only-visible-elements">Matching only
      * visible elements</a> to disable that.
      */
-    public List<Locator> mask;
+    public @Nullable List<Locator> mask;
     /**
      * Specify the color of the overlay box for masked elements, in <a
      * href="https://developer.mozilla.org/en-US/docs/Web/CSS/color_value">CSS color format</a>. Default color is pink {@code
      * #FF00FF}.
      */
-    public String maskColor;
+    public @Nullable String maskColor;
     /**
      * Hides default white background and allows capturing screenshots with transparency. Not applicable to {@code jpeg}
      * images. Defaults to {@code false}.
      */
-    public Boolean omitBackground;
+    public @Nullable Boolean omitBackground;
     /**
      * The file path to save the image to. The screenshot type will be inferred from file extension. If {@code path} is a
      * relative path, then it is resolved relative to the current working directory. If no path is provided, the image won't be
      * saved to the disk.
      */
-    public Path path;
+    public @Nullable Path path;
     /**
      * The quality of the image, between 0-100. Not applicable to {@code png} images. For {@code jpeg} the default is {@code
      * 80}. For {@code webp}, a quality of {@code 100} (the default) produces a lossless image, while lower values use lossy
      * compression.
      */
-    public Integer quality;
+    public @Nullable Integer quality;
     /**
      * When set to {@code "css"}, screenshot will have a single pixel per each css pixel on the page. For high-dpi devices,
      * this will keep screenshots small. Using {@code "device"} option will produce a single pixel per each device pixel, so
@@ -2706,24 +2707,24 @@ public interface Page extends AutoCloseable {
      *
      * <p> Defaults to {@code "device"}.
      */
-    public ScreenshotScale scale;
+    public @Nullable ScreenshotScale scale;
     /**
      * Text of the stylesheet to apply while making the screenshot. This is where you can hide dynamic elements, make elements
      * invisible or change their properties to help you creating repeatable screenshots. This stylesheet pierces the Shadow DOM
      * and applies to the inner frames.
      */
-    public String style;
+    public @Nullable String style;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
      * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
     /**
      * Specify screenshot type, defaults to {@code png}.
      */
-    public ScreenshotType type;
+    public @Nullable ScreenshotType type;
 
     /**
      * When set to {@code "disabled"}, stops CSS animations, CSS transitions and Web Animations. Animations get different
@@ -2856,23 +2857,23 @@ public interface Page extends AutoCloseable {
      * Whether to bypass the <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks. Defaults to
      * {@code false}.
      */
-    public Boolean force;
+    public @Nullable Boolean force;
     /**
      * @deprecated This option has no effect.
      */
-    public Boolean noWaitAfter;
+    public @Nullable Boolean noWaitAfter;
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
-    public Boolean strict;
+    public @Nullable Boolean strict;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
      * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * Whether to bypass the <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks. Defaults to
@@ -2913,41 +2914,41 @@ public interface Page extends AutoCloseable {
      * Whether to bypass the <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks. Defaults to
      * {@code false}.
      */
-    public Boolean force;
+    public @Nullable Boolean force;
     /**
      * @deprecated This option has no effect.
      */
-    public Boolean noWaitAfter;
+    public @Nullable Boolean noWaitAfter;
     /**
      * A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the
      * element.
      */
-    public Position position;
+    public @Nullable Position position;
     /**
      * Controls whether Playwright scrolls the element into view before performing the action. Defaults to {@code "auto"},
      * which scrolls the element into view when necessary, including scrolling nested scrollable containers. When set to {@code
      * "none"}, Playwright does not scroll the element and the action fails if the element is not already in the viewport. This
      * is useful to assert that an element is reachable by the user without additional scrolling.
      */
-    public ScrollMode scroll;
+    public @Nullable ScrollMode scroll;
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
-    public Boolean strict;
+    public @Nullable Boolean strict;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
      * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
     /**
      * When set, this method only performs the <a href="https://playwright.dev/java/docs/actionability">actionability</a>
      * checks and skips the action. Defaults to {@code false}. Useful to wait until the element is ready for the action without
      * performing it.
      */
-    public Boolean trial;
+    public @Nullable Boolean trial;
 
     /**
      * Whether to bypass the <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks. Defaults to
@@ -3026,7 +3027,7 @@ public interface Page extends AutoCloseable {
      * Page.setDefaultNavigationTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
     /**
      * When to consider operation succeeded, defaults to {@code load}. Events can be either:
      * <ul>
@@ -3037,7 +3038,7 @@ public interface Page extends AutoCloseable {
      * <li> {@code "commit"} - consider operation to be finished when network response is received and the document started loading.</li>
      * </ul>
      */
-    public WaitUntilState waitUntil;
+    public @Nullable WaitUntilState waitUntil;
 
     /**
      * Maximum operation time in milliseconds, defaults to 30 seconds, pass {@code 0} to disable timeout. The default value can
@@ -3070,19 +3071,19 @@ public interface Page extends AutoCloseable {
     /**
      * @deprecated This option has no effect.
      */
-    public Boolean noWaitAfter;
+    public @Nullable Boolean noWaitAfter;
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
-    public Boolean strict;
+    public @Nullable Boolean strict;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
      * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * @deprecated This option has no effect.
@@ -3117,23 +3118,23 @@ public interface Page extends AutoCloseable {
      * href="https://developer.mozilla.org/en-US/docs/Web/API/Element/getBoundingClientRect">{@code
      * Element.getBoundingClientRect()}</a>. Defaults to {@code false}.
      */
-    public Boolean boxes;
+    public @Nullable Boolean boxes;
     /**
      * When specified, limits the depth of the snapshot.
      */
-    public Integer depth;
+    public @Nullable Integer depth;
     /**
      * When set to {@code "ai"}, returns a snapshot optimized for AI consumption: including element references like {@code
      * [ref=e2]} and snapshots of {@code <iframe>}s. Defaults to {@code "default"}.
      */
-    public AriaSnapshotMode mode;
+    public @Nullable AriaSnapshotMode mode;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
      * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * When {@code true}, appends each element's bounding box as {@code [box=x,y,width,height]} to the snapshot. Coordinates
@@ -3176,48 +3177,48 @@ public interface Page extends AutoCloseable {
      * Whether to bypass the <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks. Defaults to
      * {@code false}.
      */
-    public Boolean force;
+    public @Nullable Boolean force;
     /**
      * Modifier keys to press. Ensures that only these modifiers are pressed during the operation, and then restores current
      * modifiers back. If not specified, currently pressed modifiers are used. "ControlOrMeta" resolves to "Control" on Windows
      * and Linux and to "Meta" on macOS.
      */
-    public List<KeyboardModifier> modifiers;
+    public @Nullable List<KeyboardModifier> modifiers;
     /**
      * @deprecated This option has no effect.
      */
-    public Boolean noWaitAfter;
+    public @Nullable Boolean noWaitAfter;
     /**
      * A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the
      * element.
      */
-    public Position position;
+    public @Nullable Position position;
     /**
      * Controls whether Playwright scrolls the element into view before performing the action. Defaults to {@code "auto"},
      * which scrolls the element into view when necessary, including scrolling nested scrollable containers. When set to {@code
      * "none"}, Playwright does not scroll the element and the action fails if the element is not already in the viewport. This
      * is useful to assert that an element is reachable by the user without additional scrolling.
      */
-    public ScrollMode scroll;
+    public @Nullable ScrollMode scroll;
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
-    public Boolean strict;
+    public @Nullable Boolean strict;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
      * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
     /**
      * When set, this method only performs the <a href="https://playwright.dev/java/docs/actionability">actionability</a>
      * checks and skips the action. Defaults to {@code false}. Useful to wait until the element is ready for the action without
      * performing it. Note that keyboard {@code modifiers} will be pressed regardless of {@code trial} to allow testing
      * elements which are only visible when those keys are pressed.
      */
-    public Boolean trial;
+    public @Nullable Boolean trial;
 
     /**
      * Whether to bypass the <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks. Defaults to
@@ -3302,14 +3303,14 @@ public interface Page extends AutoCloseable {
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
-    public Boolean strict;
+    public @Nullable Boolean strict;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
      * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
@@ -3334,23 +3335,23 @@ public interface Page extends AutoCloseable {
     /**
      * Time to wait between key presses in milliseconds. Defaults to 0.
      */
-    public Double delay;
+    public @Nullable Double delay;
     /**
      * @deprecated This option has no effect.
      */
-    public Boolean noWaitAfter;
+    public @Nullable Boolean noWaitAfter;
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
-    public Boolean strict;
+    public @Nullable Boolean strict;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
      * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * Time to wait between key presses in milliseconds. Defaults to 0.
@@ -3390,41 +3391,41 @@ public interface Page extends AutoCloseable {
      * Whether to bypass the <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks. Defaults to
      * {@code false}.
      */
-    public Boolean force;
+    public @Nullable Boolean force;
     /**
      * @deprecated This option has no effect.
      */
-    public Boolean noWaitAfter;
+    public @Nullable Boolean noWaitAfter;
     /**
      * A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the
      * element.
      */
-    public Position position;
+    public @Nullable Position position;
     /**
      * Controls whether Playwright scrolls the element into view before performing the action. Defaults to {@code "auto"},
      * which scrolls the element into view when necessary, including scrolling nested scrollable containers. When set to {@code
      * "none"}, Playwright does not scroll the element and the action fails if the element is not already in the viewport. This
      * is useful to assert that an element is reachable by the user without additional scrolling.
      */
-    public ScrollMode scroll;
+    public @Nullable ScrollMode scroll;
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
-    public Boolean strict;
+    public @Nullable Boolean strict;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
      * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
     /**
      * When set, this method only performs the <a href="https://playwright.dev/java/docs/actionability">actionability</a>
      * checks and skips the action. Defaults to {@code false}. Useful to wait until the element is ready for the action without
      * performing it.
      */
-    public Boolean trial;
+    public @Nullable Boolean trial;
 
     /**
      * Whether to bypass the <a href="https://playwright.dev/java/docs/actionability">actionability</a> checks. Defaults to
@@ -3500,7 +3501,7 @@ public interface Page extends AutoCloseable {
      * default value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
      * BrowserContext.setDefaultTimeout()}.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * Maximum time to wait for in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The
@@ -3516,13 +3517,13 @@ public interface Page extends AutoCloseable {
     /**
      * Receives the {@code ConsoleMessage} object and resolves to truthy value when the waiting should resolve.
      */
-    public Predicate<ConsoleMessage> predicate;
+    public @Nullable Predicate<ConsoleMessage> predicate;
     /**
      * Maximum time to wait for in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The
      * default value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
      * BrowserContext.setDefaultTimeout()}.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * Receives the {@code ConsoleMessage} object and resolves to truthy value when the waiting should resolve.
@@ -3545,13 +3546,13 @@ public interface Page extends AutoCloseable {
     /**
      * Receives the {@code Download} object and resolves to truthy value when the waiting should resolve.
      */
-    public Predicate<Download> predicate;
+    public @Nullable Predicate<Download> predicate;
     /**
      * Maximum time to wait for in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The
      * default value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
      * BrowserContext.setDefaultTimeout()}.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * Receives the {@code Download} object and resolves to truthy value when the waiting should resolve.
@@ -3574,13 +3575,13 @@ public interface Page extends AutoCloseable {
     /**
      * Receives the {@code FileChooser} object and resolves to truthy value when the waiting should resolve.
      */
-    public Predicate<FileChooser> predicate;
+    public @Nullable Predicate<FileChooser> predicate;
     /**
      * Maximum time to wait for in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The
      * default value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
      * BrowserContext.setDefaultTimeout()}.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * Receives the {@code FileChooser} object and resolves to truthy value when the waiting should resolve.
@@ -3604,14 +3605,14 @@ public interface Page extends AutoCloseable {
      * If specified, then it is treated as an interval in milliseconds at which the function would be executed. By default if
      * the option is not specified {@code expression} is executed in {@code requestAnimationFrame} callback.
      */
-    public Double pollingInterval;
+    public @Nullable Double pollingInterval;
     /**
      * Maximum time to wait for in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The
      * default value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * If specified, then it is treated as an interval in milliseconds at which the function would be executed. By default if
@@ -3641,7 +3642,7 @@ public interface Page extends AutoCloseable {
      * Page.setDefaultNavigationTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * Maximum operation time in milliseconds, defaults to 30 seconds, pass {@code 0} to disable timeout. The default value can
@@ -3665,13 +3666,13 @@ public interface Page extends AutoCloseable {
      * Page.setDefaultNavigationTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
     /**
      * A glob pattern, regex pattern, or predicate receiving [URL] to match while waiting for the navigation. Note that if the
      * parameter is a string without wildcard characters, the method will wait for navigation to URL that is exactly equal to
      * the string.
      */
-    public Object url;
+    public @Nullable Object url;
     /**
      * When to consider operation succeeded, defaults to {@code load}. Events can be either:
      * <ul>
@@ -3682,7 +3683,7 @@ public interface Page extends AutoCloseable {
      * <li> {@code "commit"} - consider operation to be finished when network response is received and the document started loading.</li>
      * </ul>
      */
-    public WaitUntilState waitUntil;
+    public @Nullable WaitUntilState waitUntil;
 
     /**
      * Maximum operation time in milliseconds, defaults to 30 seconds, pass {@code 0} to disable timeout. The default value can
@@ -3742,13 +3743,13 @@ public interface Page extends AutoCloseable {
     /**
      * Receives the {@code Page} object and resolves to truthy value when the waiting should resolve.
      */
-    public Predicate<Page> predicate;
+    public @Nullable Predicate<Page> predicate;
     /**
      * Maximum time to wait for in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The
      * default value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
      * BrowserContext.setDefaultTimeout()}.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * Receives the {@code Page} object and resolves to truthy value when the waiting should resolve.
@@ -3772,7 +3773,7 @@ public interface Page extends AutoCloseable {
      * Maximum wait time in milliseconds, defaults to 30 seconds, pass {@code 0} to disable the timeout. The default value can
      * be changed by using the {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()} method.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * Maximum wait time in milliseconds, defaults to 30 seconds, pass {@code 0} to disable the timeout. The default value can
@@ -3787,13 +3788,13 @@ public interface Page extends AutoCloseable {
     /**
      * Receives the {@code Request} object and resolves to truthy value when the waiting should resolve.
      */
-    public Predicate<Request> predicate;
+    public @Nullable Predicate<Request> predicate;
     /**
      * Maximum time to wait for in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The
      * default value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
      * BrowserContext.setDefaultTimeout()}.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * Receives the {@code Request} object and resolves to truthy value when the waiting should resolve.
@@ -3819,7 +3820,7 @@ public interface Page extends AutoCloseable {
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * Maximum wait time in milliseconds, defaults to 30 seconds, pass {@code 0} to disable the timeout. The default value can
@@ -3844,19 +3845,19 @@ public interface Page extends AutoCloseable {
      * visibility:hidden}. This is opposite to the {@code "visible"} option.</li>
      * </ul>
      */
-    public WaitForSelectorState state;
+    public @Nullable WaitForSelectorState state;
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
-    public Boolean strict;
+    public @Nullable Boolean strict;
     /**
      * Maximum time in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The default
      * value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * Defaults to {@code "visible"}. Can be either:
@@ -3899,7 +3900,7 @@ public interface Page extends AutoCloseable {
      * BrowserContext.setDefaultTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * Maximum time to wait for in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The
@@ -3921,7 +3922,7 @@ public interface Page extends AutoCloseable {
      * Page.setDefaultNavigationTimeout()} or {@link com.microsoft.playwright.Page#setDefaultTimeout Page.setDefaultTimeout()}
      * methods.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
     /**
      * When to consider operation succeeded, defaults to {@code load}. Events can be either:
      * <ul>
@@ -3932,7 +3933,7 @@ public interface Page extends AutoCloseable {
      * <li> {@code "commit"} - consider operation to be finished when network response is received and the document started loading.</li>
      * </ul>
      */
-    public WaitUntilState waitUntil;
+    public @Nullable WaitUntilState waitUntil;
 
     /**
      * Maximum operation time in milliseconds, defaults to 30 seconds, pass {@code 0} to disable timeout. The default value can
@@ -3965,13 +3966,13 @@ public interface Page extends AutoCloseable {
     /**
      * Receives the {@code WebSocket} object and resolves to truthy value when the waiting should resolve.
      */
-    public Predicate<WebSocket> predicate;
+    public @Nullable Predicate<WebSocket> predicate;
     /**
      * Maximum time to wait for in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The
      * default value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
      * BrowserContext.setDefaultTimeout()}.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * Receives the {@code WebSocket} object and resolves to truthy value when the waiting should resolve.
@@ -3994,13 +3995,13 @@ public interface Page extends AutoCloseable {
     /**
      * Receives the {@code Worker} object and resolves to truthy value when the waiting should resolve.
      */
-    public Predicate<Worker> predicate;
+    public @Nullable Predicate<Worker> predicate;
     /**
      * Maximum time to wait for in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The
      * default value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
      * BrowserContext.setDefaultTimeout()}.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * Receives the {@code Worker} object and resolves to truthy value when the waiting should resolve.
@@ -4094,7 +4095,7 @@ public interface Page extends AutoCloseable {
    *
    * @since v1.8
    */
-  ElementHandle addScriptTag(AddScriptTagOptions options);
+  ElementHandle addScriptTag(@Nullable AddScriptTagOptions options);
   /**
    * Adds a {@code <link rel="stylesheet">} tag into the page with the desired url or a {@code <style type="text/css">} tag
    * with the content. Returns the added tag when the stylesheet's onload fires or when the CSS content was injected into
@@ -4112,7 +4113,7 @@ public interface Page extends AutoCloseable {
    *
    * @since v1.8
    */
-  ElementHandle addStyleTag(AddStyleTagOptions options);
+  ElementHandle addStyleTag(@Nullable AddStyleTagOptions options);
   /**
    * Brings page to front (activates tab).
    *
@@ -4167,7 +4168,7 @@ public interface Page extends AutoCloseable {
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used.
    * @since v1.8
    */
-  void check(String selector, CheckOptions options);
+  void check(String selector, @Nullable CheckOptions options);
   /**
    * This method clicks an element matching {@code selector} by performing the following steps:
    * <ol>
@@ -4207,7 +4208,7 @@ public interface Page extends AutoCloseable {
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used.
    * @since v1.8
    */
-  void click(String selector, ClickOptions options);
+  void click(String selector, @Nullable ClickOptions options);
   /**
    * If {@code runBeforeUnload} is {@code false}, does not run any unload handlers and waits for the page to be closed. If
    * {@code runBeforeUnload} is {@code true} the method will run unload handlers, but will **not** wait for the page to
@@ -4235,7 +4236,7 @@ public interface Page extends AutoCloseable {
    *
    * @since v1.8
    */
-  void close(CloseOptions options);
+  void close(@Nullable CloseOptions options);
   /**
    * Gets the full HTML contents of the page, including the doctype.
    *
@@ -4289,7 +4290,7 @@ public interface Page extends AutoCloseable {
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used.
    * @since v1.8
    */
-  void dblclick(String selector, DblclickOptions options);
+  void dblclick(String selector, @Nullable DblclickOptions options);
   /**
    * The snippet below dispatches the {@code click} event on the element. Regardless of the visibility state of the element,
    * {@code click} is dispatched. This is equivalent to calling <a
@@ -4333,7 +4334,7 @@ public interface Page extends AutoCloseable {
    * @param eventInit Optional event-specific initialization properties.
    * @since v1.8
    */
-  default void dispatchEvent(String selector, String type, Object eventInit) {
+  default void dispatchEvent(String selector, String type, @Nullable Object eventInit) {
     dispatchEvent(selector, type, eventInit, null);
   }
   /**
@@ -4424,7 +4425,7 @@ public interface Page extends AutoCloseable {
    * @param eventInit Optional event-specific initialization properties.
    * @since v1.8
    */
-  void dispatchEvent(String selector, String type, Object eventInit, DispatchEventOptions options);
+  void dispatchEvent(String selector, String type, @Nullable Object eventInit, @Nullable DispatchEventOptions options);
   /**
    * This method drags the source element to the target element. It will first move to the source element, perform a {@code
    * mousedown}, then move to the target element and perform a {@code mouseup}.
@@ -4464,7 +4465,7 @@ public interface Page extends AutoCloseable {
    * be used.
    * @since v1.13
    */
-  void dragAndDrop(String source, String target, DragAndDropOptions options);
+  void dragAndDrop(String source, String target, @Nullable DragAndDropOptions options);
   /**
    * This method changes the {@code CSS media type} through the {@code media} argument, and/or the {@code
    * "prefers-colors-scheme"} media feature, using the {@code colorScheme} argument.
@@ -4534,7 +4535,7 @@ public interface Page extends AutoCloseable {
    *
    * @since v1.8
    */
-  void emulateMedia(EmulateMediaOptions options);
+  void emulateMedia(@Nullable EmulateMediaOptions options);
   /**
    * The method finds an element matching the specified selector within the page and passes it as a first argument to {@code
    * expression}. If no elements match the selector, the method throws an error. Returns the value of {@code expression}.
@@ -4557,7 +4558,7 @@ public interface Page extends AutoCloseable {
    * @param arg Optional argument to pass to {@code expression}.
    * @since v1.9
    */
-  default Object evalOnSelector(String selector, String expression, Object arg) {
+  default @Nullable Object evalOnSelector(String selector, String expression, @Nullable Object arg) {
     return evalOnSelector(selector, expression, arg, null);
   }
   /**
@@ -4581,7 +4582,7 @@ public interface Page extends AutoCloseable {
    * automatically invoked.
    * @since v1.9
    */
-  default Object evalOnSelector(String selector, String expression) {
+  default @Nullable Object evalOnSelector(String selector, String expression) {
     return evalOnSelector(selector, expression, null);
   }
   /**
@@ -4606,7 +4607,7 @@ public interface Page extends AutoCloseable {
    * @param arg Optional argument to pass to {@code expression}.
    * @since v1.9
    */
-  Object evalOnSelector(String selector, String expression, Object arg, EvalOnSelectorOptions options);
+  @Nullable Object evalOnSelector(String selector, String expression, @Nullable Object arg, @Nullable EvalOnSelectorOptions options);
   /**
    * The method finds all elements matching the specified selector within the page and passes an array of matched elements as
    * a first argument to {@code expression}. Returns the result of {@code expression} invocation.
@@ -4626,7 +4627,7 @@ public interface Page extends AutoCloseable {
    * automatically invoked.
    * @since v1.9
    */
-  default Object evalOnSelectorAll(String selector, String expression) {
+  default @Nullable Object evalOnSelectorAll(String selector, String expression) {
     return evalOnSelectorAll(selector, expression, null);
   }
   /**
@@ -4649,7 +4650,7 @@ public interface Page extends AutoCloseable {
    * @param arg Optional argument to pass to {@code expression}.
    * @since v1.9
    */
-  Object evalOnSelectorAll(String selector, String expression, Object arg);
+  @Nullable Object evalOnSelectorAll(String selector, String expression, @Nullable Object arg);
   /**
    * Returns the value of the {@code expression} invocation.
    *
@@ -4689,7 +4690,7 @@ public interface Page extends AutoCloseable {
    * automatically invoked.
    * @since v1.8
    */
-  default Object evaluate(String expression) {
+  default @Nullable Object evaluate(String expression) {
     return evaluate(expression, null);
   }
   /**
@@ -4732,7 +4733,7 @@ public interface Page extends AutoCloseable {
    * @param arg Optional argument to pass to {@code expression}.
    * @since v1.8
    */
-  Object evaluate(String expression, Object arg);
+  @Nullable Object evaluate(String expression, @Nullable Object arg);
   /**
    * Returns the value of the {@code expression} invocation as a {@code JSHandle}.
    *
@@ -4809,7 +4810,7 @@ public interface Page extends AutoCloseable {
    * @param arg Optional argument to pass to {@code expression}.
    * @since v1.8
    */
-  JSHandle evaluateHandle(String expression, Object arg);
+  JSHandle evaluateHandle(String expression, @Nullable Object arg);
   /**
    * The method adds a function called {@code name} on the {@code window} object of every frame in this page. When called,
    * the function executes {@code callback} and returns a <a
@@ -4957,7 +4958,7 @@ public interface Page extends AutoCloseable {
    * @param value Value to fill for the {@code <input>}, {@code <textarea>} or {@code [contenteditable]} element.
    * @since v1.8
    */
-  void fill(String selector, String value, FillOptions options);
+  void fill(String selector, String value, @Nullable FillOptions options);
   /**
    * This method fetches an element with {@code selector} and focuses it. If there's no element matching {@code selector},
    * the method waits until a matching element appears in the DOM.
@@ -4975,7 +4976,7 @@ public interface Page extends AutoCloseable {
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used.
    * @since v1.8
    */
-  void focus(String selector, FocusOptions options);
+  void focus(String selector, @Nullable FocusOptions options);
   /**
    * Returns frame matching the specified criteria. Either {@code name} or {@code url} must be specified.
    *
@@ -4990,28 +4991,28 @@ public interface Page extends AutoCloseable {
    * @param name Frame name specified in the {@code iframe}'s {@code name} attribute.
    * @since v1.8
    */
-  Frame frame(String name);
+  @Nullable Frame frame(String name);
   /**
    * Returns frame with matching URL.
    *
    * @param url A glob pattern, regex pattern or predicate receiving frame's {@code url} as a [URL] object.
    * @since v1.9
    */
-  Frame frameByUrl(String url);
+  @Nullable Frame frameByUrl(String url);
   /**
    * Returns frame with matching URL.
    *
    * @param url A glob pattern, regex pattern or predicate receiving frame's {@code url} as a [URL] object.
    * @since v1.9
    */
-  Frame frameByUrl(Pattern url);
+  @Nullable Frame frameByUrl(Pattern url);
   /**
    * Returns frame with matching URL.
    *
    * @param url A glob pattern, regex pattern or predicate receiving frame's {@code url} as a [URL] object.
    * @since v1.9
    */
-  Frame frameByUrl(Predicate<String> url);
+  @Nullable Frame frameByUrl(Predicate<String> url);
   /**
    * When working with iframes, you can create a frame locator that will enter the iframe and allow selecting elements in
    * that iframe.
@@ -5066,7 +5067,7 @@ public interface Page extends AutoCloseable {
    * @param selector A selector that matches the frame element. When not specified, locator is matched in any frame on the page.
    * @since v1.17
    */
-  FrameLocator frameLocator(String selector);
+  FrameLocator frameLocator(@Nullable String selector);
   /**
    * An array of all frames attached to the page.
    *
@@ -5080,7 +5081,7 @@ public interface Page extends AutoCloseable {
    * @param name Attribute name to get the value for.
    * @since v1.8
    */
-  default String getAttribute(String selector, String name) {
+  default @Nullable String getAttribute(String selector, String name) {
     return getAttribute(selector, name, null);
   }
   /**
@@ -5090,7 +5091,7 @@ public interface Page extends AutoCloseable {
    * @param name Attribute name to get the value for.
    * @since v1.8
    */
-  String getAttribute(String selector, String name, GetAttributeOptions options);
+  @Nullable String getAttribute(String selector, String name, @Nullable GetAttributeOptions options);
   /**
    * Allows locating elements by their alt text.
    *
@@ -5120,7 +5121,7 @@ public interface Page extends AutoCloseable {
    * @param text Text to locate the element for.
    * @since v1.27
    */
-  Locator getByAltText(String text, GetByAltTextOptions options);
+  Locator getByAltText(String text, @Nullable GetByAltTextOptions options);
   /**
    * Allows locating elements by their alt text.
    *
@@ -5150,7 +5151,7 @@ public interface Page extends AutoCloseable {
    * @param text Text to locate the element for.
    * @since v1.27
    */
-  Locator getByAltText(Pattern text, GetByAltTextOptions options);
+  Locator getByAltText(Pattern text, @Nullable GetByAltTextOptions options);
   /**
    * Allows locating input elements by the text of the associated {@code <label>} or {@code aria-labelledby} element, or by
    * the {@code aria-label} attribute.
@@ -5184,7 +5185,7 @@ public interface Page extends AutoCloseable {
    * @param text Text to locate the element for.
    * @since v1.27
    */
-  Locator getByLabel(String text, GetByLabelOptions options);
+  Locator getByLabel(String text, @Nullable GetByLabelOptions options);
   /**
    * Allows locating input elements by the text of the associated {@code <label>} or {@code aria-labelledby} element, or by
    * the {@code aria-label} attribute.
@@ -5218,7 +5219,7 @@ public interface Page extends AutoCloseable {
    * @param text Text to locate the element for.
    * @since v1.27
    */
-  Locator getByLabel(Pattern text, GetByLabelOptions options);
+  Locator getByLabel(Pattern text, @Nullable GetByLabelOptions options);
   /**
    * Allows locating input elements by the placeholder text.
    *
@@ -5252,7 +5253,7 @@ public interface Page extends AutoCloseable {
    * @param text Text to locate the element for.
    * @since v1.27
    */
-  Locator getByPlaceholder(String text, GetByPlaceholderOptions options);
+  Locator getByPlaceholder(String text, @Nullable GetByPlaceholderOptions options);
   /**
    * Allows locating input elements by the placeholder text.
    *
@@ -5286,7 +5287,7 @@ public interface Page extends AutoCloseable {
    * @param text Text to locate the element for.
    * @since v1.27
    */
-  Locator getByPlaceholder(Pattern text, GetByPlaceholderOptions options);
+  Locator getByPlaceholder(Pattern text, @Nullable GetByPlaceholderOptions options);
   /**
    * Allows locating elements by their <a href="https://www.w3.org/TR/wai-aria-1.2/#roles">ARIA role</a>, <a
    * href="https://www.w3.org/TR/wai-aria-1.2/#aria-attributes">ARIA attributes</a> and <a
@@ -5370,7 +5371,7 @@ public interface Page extends AutoCloseable {
    * @param role Required aria role.
    * @since v1.27
    */
-  Locator getByRole(AriaRole role, GetByRoleOptions options);
+  Locator getByRole(AriaRole role, @Nullable GetByRoleOptions options);
   /**
    * Locate element by the test id.
    *
@@ -5496,7 +5497,7 @@ public interface Page extends AutoCloseable {
    * @param text Text to locate the element for.
    * @since v1.27
    */
-  Locator getByText(String text, GetByTextOptions options);
+  Locator getByText(String text, @Nullable GetByTextOptions options);
   /**
    * Allows locating elements that contain given text.
    *
@@ -5578,7 +5579,7 @@ public interface Page extends AutoCloseable {
    * @param text Text to locate the element for.
    * @since v1.27
    */
-  Locator getByText(Pattern text, GetByTextOptions options);
+  Locator getByText(Pattern text, @Nullable GetByTextOptions options);
   /**
    * Allows locating elements by their title attribute.
    *
@@ -5612,7 +5613,7 @@ public interface Page extends AutoCloseable {
    * @param text Text to locate the element for.
    * @since v1.27
    */
-  Locator getByTitle(String text, GetByTitleOptions options);
+  Locator getByTitle(String text, @Nullable GetByTitleOptions options);
   /**
    * Allows locating elements by their title attribute.
    *
@@ -5646,7 +5647,7 @@ public interface Page extends AutoCloseable {
    * @param text Text to locate the element for.
    * @since v1.27
    */
-  Locator getByTitle(Pattern text, GetByTitleOptions options);
+  Locator getByTitle(Pattern text, @Nullable GetByTitleOptions options);
   /**
    * Returns the main resource response. In case of multiple redirects, the navigation will resolve with the response of the
    * last redirect. If cannot go back, returns {@code null}.
@@ -5660,7 +5661,7 @@ public interface Page extends AutoCloseable {
    *
    * @since v1.8
    */
-  default Response goBack() {
+  default @Nullable Response goBack() {
     return goBack(null);
   }
   /**
@@ -5676,7 +5677,7 @@ public interface Page extends AutoCloseable {
    *
    * @since v1.8
    */
-  Response goBack(GoBackOptions options);
+  @Nullable Response goBack(@Nullable GoBackOptions options);
   /**
    * Returns the main resource response. In case of multiple redirects, the navigation will resolve with the response of the
    * last redirect. If cannot go forward, returns {@code null}.
@@ -5690,7 +5691,7 @@ public interface Page extends AutoCloseable {
    *
    * @since v1.8
    */
-  default Response goForward() {
+  default @Nullable Response goForward() {
     return goForward(null);
   }
   /**
@@ -5706,7 +5707,7 @@ public interface Page extends AutoCloseable {
    *
    * @since v1.8
    */
-  Response goForward(GoForwardOptions options);
+  @Nullable Response goForward(@Nullable GoForwardOptions options);
   /**
    * Request the page to perform garbage collection. Note that there is no guarantee that all unreachable objects will be
    * collected.
@@ -5754,7 +5755,7 @@ public interface Page extends AutoCloseable {
    * href="https://developer.mozilla.org/en-US/docs/Web/API/URL/URL">{@code new URL()}</a> constructor.
    * @since v1.8
    */
-  default Response navigate(String url) {
+  default @Nullable Response navigate(String url) {
     return navigate(url, null);
   }
   /**
@@ -5785,7 +5786,7 @@ public interface Page extends AutoCloseable {
    * href="https://developer.mozilla.org/en-US/docs/Web/API/URL/URL">{@code new URL()}</a> constructor.
    * @since v1.8
    */
-  Response navigate(String url, NavigateOptions options);
+  @Nullable Response navigate(String url, @Nullable NavigateOptions options);
   /**
    * Hide all locator highlight overlays previously added by {@link com.microsoft.playwright.Locator#highlight
    * Locator.highlight()} on this page.
@@ -5830,7 +5831,7 @@ public interface Page extends AutoCloseable {
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used.
    * @since v1.8
    */
-  void hover(String selector, HoverOptions options);
+  void hover(String selector, @Nullable HoverOptions options);
   /**
    * Returns {@code element.innerHTML}.
    *
@@ -5846,7 +5847,7 @@ public interface Page extends AutoCloseable {
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used.
    * @since v1.8
    */
-  String innerHTML(String selector, InnerHTMLOptions options);
+  String innerHTML(String selector, @Nullable InnerHTMLOptions options);
   /**
    * Returns {@code element.innerText}.
    *
@@ -5862,7 +5863,7 @@ public interface Page extends AutoCloseable {
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used.
    * @since v1.8
    */
-  String innerText(String selector, InnerTextOptions options);
+  String innerText(String selector, @Nullable InnerTextOptions options);
   /**
    * Returns {@code input.value} for the selected {@code <input>} or {@code <textarea>} or {@code <select>} element.
    *
@@ -5886,7 +5887,7 @@ public interface Page extends AutoCloseable {
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used.
    * @since v1.13
    */
-  String inputValue(String selector, InputValueOptions options);
+  String inputValue(String selector, @Nullable InputValueOptions options);
   /**
    * Returns whether the element is checked. Throws if the element is not a checkbox or radio input.
    *
@@ -5902,7 +5903,7 @@ public interface Page extends AutoCloseable {
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used.
    * @since v1.8
    */
-  boolean isChecked(String selector, IsCheckedOptions options);
+  boolean isChecked(String selector, @Nullable IsCheckedOptions options);
   /**
    * Indicates that the page has been closed.
    *
@@ -5926,7 +5927,7 @@ public interface Page extends AutoCloseable {
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used.
    * @since v1.8
    */
-  boolean isDisabled(String selector, IsDisabledOptions options);
+  boolean isDisabled(String selector, @Nullable IsDisabledOptions options);
   /**
    * Returns whether the element is <a href="https://playwright.dev/java/docs/actionability#editable">editable</a>.
    *
@@ -5942,7 +5943,7 @@ public interface Page extends AutoCloseable {
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used.
    * @since v1.8
    */
-  boolean isEditable(String selector, IsEditableOptions options);
+  boolean isEditable(String selector, @Nullable IsEditableOptions options);
   /**
    * Returns whether the element is <a href="https://playwright.dev/java/docs/actionability#enabled">enabled</a>.
    *
@@ -5958,7 +5959,7 @@ public interface Page extends AutoCloseable {
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used.
    * @since v1.8
    */
-  boolean isEnabled(String selector, IsEnabledOptions options);
+  boolean isEnabled(String selector, @Nullable IsEnabledOptions options);
   /**
    * Returns whether the element is hidden, the opposite of <a
    * href="https://playwright.dev/java/docs/actionability#visible">visible</a>.  {@code selector} that does not match any
@@ -5978,7 +5979,7 @@ public interface Page extends AutoCloseable {
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used.
    * @since v1.8
    */
-  boolean isHidden(String selector, IsHiddenOptions options);
+  boolean isHidden(String selector, @Nullable IsHiddenOptions options);
   /**
    * Returns whether the element is <a href="https://playwright.dev/java/docs/actionability#visible">visible</a>. {@code
    * selector} that does not match any elements is considered not visible.
@@ -5996,7 +5997,7 @@ public interface Page extends AutoCloseable {
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used.
    * @since v1.8
    */
-  boolean isVisible(String selector, IsVisibleOptions options);
+  boolean isVisible(String selector, @Nullable IsVisibleOptions options);
   /**
    *
    *
@@ -6044,7 +6045,7 @@ public interface Page extends AutoCloseable {
    *
    * @since v1.56
    */
-  List<ConsoleMessage> consoleMessages(ConsoleMessagesOptions options);
+  List<ConsoleMessage> consoleMessages(@Nullable ConsoleMessagesOptions options);
   /**
    * Returns up to (currently) 200 last page errors from this page. See {@link com.microsoft.playwright.Page#onPageError
    * Page.onPageError()} for more details.
@@ -6075,7 +6076,7 @@ public interface Page extends AutoCloseable {
    * @param selector A selector to use when resolving DOM element.
    * @since v1.14
    */
-  Locator locator(String selector, LocatorOptions options);
+  Locator locator(String selector, @Nullable LocatorOptions options);
   /**
    * The page's main frame. Page is guaranteed to have a main frame which persists during navigations.
    *
@@ -6133,7 +6134,7 @@ public interface Page extends AutoCloseable {
    *
    * @since v1.8
    */
-  Page opener();
+  @Nullable Page opener();
   /**
    * Pauses script execution. Playwright will stop executing the script and wait for the user to either press the 'Resume'
    * button in the page overlay or to call {@code playwright.resume()} in the DevTools console.
@@ -6259,7 +6260,7 @@ public interface Page extends AutoCloseable {
    *
    * @since v1.8
    */
-  byte[] pdf(PdfOptions options);
+  byte[] pdf(@Nullable PdfOptions options);
   /**
    * Enters pick locator mode where hovering over page elements highlights them and shows the corresponding locator. Once the
    * user clicks an element, the mode is deactivated and the {@code Locator} for the picked element is returned.
@@ -6360,7 +6361,7 @@ public interface Page extends AutoCloseable {
    * @param key Name of the key to press or a character to generate, such as {@code ArrowLeft} or {@code a}.
    * @since v1.8
    */
-  void press(String selector, String key, PressOptions options);
+  void press(String selector, String key, @Nullable PressOptions options);
   /**
    * The method finds an element matching the specified selector within the page. If no elements match the selector, the
    * return value resolves to {@code null}. To wait for an element on the page, use {@link
@@ -6369,7 +6370,7 @@ public interface Page extends AutoCloseable {
    * @param selector A selector to query for.
    * @since v1.9
    */
-  default ElementHandle querySelector(String selector) {
+  default @Nullable ElementHandle querySelector(String selector) {
     return querySelector(selector, null);
   }
   /**
@@ -6380,7 +6381,7 @@ public interface Page extends AutoCloseable {
    * @param selector A selector to query for.
    * @since v1.9
    */
-  ElementHandle querySelector(String selector, QuerySelectorOptions options);
+  @Nullable ElementHandle querySelector(String selector, @Nullable QuerySelectorOptions options);
   /**
    * The method finds all elements matching the specified selector within the page. If no elements match the selector, the
    * return value resolves to {@code []}.
@@ -6585,7 +6586,7 @@ public interface Page extends AutoCloseable {
    * actions like click.
    * @since v1.42
    */
-  void addLocatorHandler(Locator locator, Consumer<Locator> handler, AddLocatorHandlerOptions options);
+  void addLocatorHandler(Locator locator, Consumer<Locator> handler, @Nullable AddLocatorHandlerOptions options);
   /**
    * Removes all locator handlers added by {@link com.microsoft.playwright.Page#addLocatorHandler Page.addLocatorHandler()}
    * for a specific locator.
@@ -6600,7 +6601,7 @@ public interface Page extends AutoCloseable {
    *
    * @since v1.8
    */
-  default Response reload() {
+  default @Nullable Response reload() {
     return reload(null);
   }
   /**
@@ -6609,7 +6610,7 @@ public interface Page extends AutoCloseable {
    *
    * @since v1.8
    */
-  Response reload(ReloadOptions options);
+  @Nullable Response reload(@Nullable ReloadOptions options);
   /**
    * API testing helper associated with this page. This method returns the same instance as {@link
    * com.microsoft.playwright.BrowserContext#request BrowserContext.request()} on the page's context. See {@link
@@ -6737,7 +6738,7 @@ public interface Page extends AutoCloseable {
    * @param handler handler function to route the request.
    * @since v1.8
    */
-  AutoCloseable route(String url, Consumer<Route> handler, RouteOptions options);
+  AutoCloseable route(String url, Consumer<Route> handler, @Nullable RouteOptions options);
   /**
    * Routing provides the capability to modify network requests that are made by a page.
    *
@@ -6857,7 +6858,7 @@ public interface Page extends AutoCloseable {
    * @param handler handler function to route the request.
    * @since v1.8
    */
-  AutoCloseable route(Pattern url, Consumer<Route> handler, RouteOptions options);
+  AutoCloseable route(Pattern url, Consumer<Route> handler, @Nullable RouteOptions options);
   /**
    * Routing provides the capability to modify network requests that are made by a page.
    *
@@ -6977,7 +6978,7 @@ public interface Page extends AutoCloseable {
    * @param handler handler function to route the request.
    * @since v1.8
    */
-  AutoCloseable route(Predicate<String> url, Consumer<Route> handler, RouteOptions options);
+  AutoCloseable route(Predicate<String> url, Consumer<Route> handler, @Nullable RouteOptions options);
   /**
    * If specified the network requests that are made in the page will be served from the HAR file. Read more about <a
    * href="https://playwright.dev/java/docs/mock#replaying-from-har">Replaying from HAR</a>.
@@ -7005,7 +7006,7 @@ public interface Page extends AutoCloseable {
    * path} is a relative path, then it is resolved relative to the current working directory.
    * @since v1.23
    */
-  void routeFromHAR(Path har, RouteFromHAROptions options);
+  void routeFromHAR(Path har, @Nullable RouteFromHAROptions options);
   /**
    * This method allows to modify websocket connections that are made by the page.
    *
@@ -7102,7 +7103,7 @@ public interface Page extends AutoCloseable {
    *
    * @since v1.8
    */
-  byte[] screenshot(ScreenshotOptions options);
+  byte[] screenshot(@Nullable ScreenshotOptions options);
   /**
    * This method waits for an element matching {@code selector}, waits for <a
    * href="https://playwright.dev/java/docs/actionability">actionability</a> checks, waits until all specified options are
@@ -7166,7 +7167,7 @@ public interface Page extends AutoCloseable {
    * and labels. Option is considered matching if all specified properties match.
    * @since v1.8
    */
-  List<String> selectOption(String selector, String values, SelectOptionOptions options);
+  List<String> selectOption(String selector, String values, @Nullable SelectOptionOptions options);
   /**
    * This method waits for an element matching {@code selector}, waits for <a
    * href="https://playwright.dev/java/docs/actionability">actionability</a> checks, waits until all specified options are
@@ -7230,7 +7231,7 @@ public interface Page extends AutoCloseable {
    * and labels. Option is considered matching if all specified properties match.
    * @since v1.8
    */
-  List<String> selectOption(String selector, ElementHandle values, SelectOptionOptions options);
+  List<String> selectOption(String selector, ElementHandle values, @Nullable SelectOptionOptions options);
   /**
    * This method waits for an element matching {@code selector}, waits for <a
    * href="https://playwright.dev/java/docs/actionability">actionability</a> checks, waits until all specified options are
@@ -7294,7 +7295,7 @@ public interface Page extends AutoCloseable {
    * and labels. Option is considered matching if all specified properties match.
    * @since v1.8
    */
-  List<String> selectOption(String selector, String[] values, SelectOptionOptions options);
+  List<String> selectOption(String selector, String[] values, @Nullable SelectOptionOptions options);
   /**
    * This method waits for an element matching {@code selector}, waits for <a
    * href="https://playwright.dev/java/docs/actionability">actionability</a> checks, waits until all specified options are
@@ -7358,7 +7359,7 @@ public interface Page extends AutoCloseable {
    * and labels. Option is considered matching if all specified properties match.
    * @since v1.8
    */
-  List<String> selectOption(String selector, SelectOption values, SelectOptionOptions options);
+  List<String> selectOption(String selector, SelectOption values, @Nullable SelectOptionOptions options);
   /**
    * This method waits for an element matching {@code selector}, waits for <a
    * href="https://playwright.dev/java/docs/actionability">actionability</a> checks, waits until all specified options are
@@ -7422,7 +7423,7 @@ public interface Page extends AutoCloseable {
    * and labels. Option is considered matching if all specified properties match.
    * @since v1.8
    */
-  List<String> selectOption(String selector, ElementHandle[] values, SelectOptionOptions options);
+  List<String> selectOption(String selector, ElementHandle[] values, @Nullable SelectOptionOptions options);
   /**
    * This method waits for an element matching {@code selector}, waits for <a
    * href="https://playwright.dev/java/docs/actionability">actionability</a> checks, waits until all specified options are
@@ -7486,7 +7487,7 @@ public interface Page extends AutoCloseable {
    * and labels. Option is considered matching if all specified properties match.
    * @since v1.8
    */
-  List<String> selectOption(String selector, SelectOption[] values, SelectOptionOptions options);
+  List<String> selectOption(String selector, SelectOption[] values, @Nullable SelectOptionOptions options);
   /**
    * This method checks or unchecks an element matching {@code selector} by performing the following steps:
    * <ol>
@@ -7530,7 +7531,7 @@ public interface Page extends AutoCloseable {
    * @param checked Whether to check or uncheck the checkbox.
    * @since v1.15
    */
-  void setChecked(String selector, boolean checked, SetCheckedOptions options);
+  void setChecked(String selector, boolean checked, @Nullable SetCheckedOptions options);
   /**
    * This method internally calls <a
    * href="https://developer.mozilla.org/en-US/docs/Web/API/Document/write">document.write()</a>, inheriting all its specific
@@ -7550,7 +7551,7 @@ public interface Page extends AutoCloseable {
    * @param html HTML markup to assign to the page.
    * @since v1.8
    */
-  void setContent(String html, SetContentOptions options);
+  void setContent(String html, @Nullable SetContentOptions options);
   /**
    * This setting will change the default maximum navigation time for the following methods and related shortcuts:
    * <ul>
@@ -7623,7 +7624,7 @@ public interface Page extends AutoCloseable {
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used.
    * @since v1.8
    */
-  void setInputFiles(String selector, Path files, SetInputFilesOptions options);
+  void setInputFiles(String selector, Path files, @Nullable SetInputFilesOptions options);
   /**
    * Sets the value of the file input to these file paths or files. If some of the {@code filePaths} are relative paths, then
    * they are resolved relative to the current working directory. For empty array, clears the selected files. For inputs with
@@ -7655,7 +7656,7 @@ public interface Page extends AutoCloseable {
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used.
    * @since v1.8
    */
-  void setInputFiles(String selector, Path[] files, SetInputFilesOptions options);
+  void setInputFiles(String selector, Path[] files, @Nullable SetInputFilesOptions options);
   /**
    * Sets the value of the file input to these file paths or files. If some of the {@code filePaths} are relative paths, then
    * they are resolved relative to the current working directory. For empty array, clears the selected files. For inputs with
@@ -7687,7 +7688,7 @@ public interface Page extends AutoCloseable {
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used.
    * @since v1.8
    */
-  void setInputFiles(String selector, FilePayload files, SetInputFilesOptions options);
+  void setInputFiles(String selector, FilePayload files, @Nullable SetInputFilesOptions options);
   /**
    * Sets the value of the file input to these file paths or files. If some of the {@code filePaths} are relative paths, then
    * they are resolved relative to the current working directory. For empty array, clears the selected files. For inputs with
@@ -7719,7 +7720,7 @@ public interface Page extends AutoCloseable {
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used.
    * @since v1.8
    */
-  void setInputFiles(String selector, FilePayload[] files, SetInputFilesOptions options);
+  void setInputFiles(String selector, FilePayload[] files, @Nullable SetInputFilesOptions options);
   /**
    * In the case of multiple pages in a single browser, each page can have its own viewport size. However, {@link
    * com.microsoft.playwright.Browser#newContext Browser.newContext()} allows to set viewport size (and more) for all pages
@@ -7758,7 +7759,7 @@ public interface Page extends AutoCloseable {
    *
    * @since v1.59
    */
-  String ariaSnapshot(AriaSnapshotOptions options);
+  String ariaSnapshot(@Nullable AriaSnapshotOptions options);
   /**
    * This method taps an element matching {@code selector} by performing the following steps:
    * <ol>
@@ -7802,14 +7803,14 @@ public interface Page extends AutoCloseable {
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used.
    * @since v1.8
    */
-  void tap(String selector, TapOptions options);
+  void tap(String selector, @Nullable TapOptions options);
   /**
    * Returns {@code element.textContent}.
    *
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used.
    * @since v1.8
    */
-  default String textContent(String selector) {
+  default @Nullable String textContent(String selector) {
     return textContent(selector, null);
   }
   /**
@@ -7818,7 +7819,7 @@ public interface Page extends AutoCloseable {
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used.
    * @since v1.8
    */
-  String textContent(String selector, TextContentOptions options);
+  @Nullable String textContent(String selector, @Nullable TextContentOptions options);
   /**
    * Returns the page's title.
    *
@@ -7852,7 +7853,7 @@ public interface Page extends AutoCloseable {
    * @param text A text to type into a focused element.
    * @since v1.8
    */
-  void type(String selector, String text, TypeOptions options);
+  void type(String selector, String text, @Nullable TypeOptions options);
   /**
    * This method unchecks an element matching {@code selector} by performing the following steps:
    * <ol>
@@ -7894,7 +7895,7 @@ public interface Page extends AutoCloseable {
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used.
    * @since v1.8
    */
-  void uncheck(String selector, UncheckOptions options);
+  void uncheck(String selector, @Nullable UncheckOptions options);
   /**
    * Removes all routes created with {@link com.microsoft.playwright.Page#route Page.route()} and {@link
    * com.microsoft.playwright.Page#routeFromHAR Page.routeFromHAR()}.
@@ -7920,7 +7921,7 @@ public interface Page extends AutoCloseable {
    * @param handler Optional handler function to route the request.
    * @since v1.8
    */
-  void unroute(String url, Consumer<Route> handler);
+  void unroute(String url, @Nullable Consumer<Route> handler);
   /**
    * Removes a route created with {@link com.microsoft.playwright.Page#route Page.route()}. When {@code handler} is not
    * specified, removes all routes for the {@code url}.
@@ -7939,7 +7940,7 @@ public interface Page extends AutoCloseable {
    * @param handler Optional handler function to route the request.
    * @since v1.8
    */
-  void unroute(Pattern url, Consumer<Route> handler);
+  void unroute(Pattern url, @Nullable Consumer<Route> handler);
   /**
    * Removes a route created with {@link com.microsoft.playwright.Page#route Page.route()}. When {@code handler} is not
    * specified, removes all routes for the {@code url}.
@@ -7958,7 +7959,7 @@ public interface Page extends AutoCloseable {
    * @param handler Optional handler function to route the request.
    * @since v1.8
    */
-  void unroute(Predicate<String> url, Consumer<Route> handler);
+  void unroute(Predicate<String> url, @Nullable Consumer<Route> handler);
   /**
    *
    *
@@ -7971,13 +7972,13 @@ public interface Page extends AutoCloseable {
    *
    * @since v1.8
    */
-  Video video();
+  @Nullable Video video();
   /**
    *
    *
    * @since v1.8
    */
-  ViewportSize viewportSize();
+  @Nullable ViewportSize viewportSize();
   /**
    * Performs action and waits for the Page to close.
    *
@@ -7993,7 +7994,7 @@ public interface Page extends AutoCloseable {
    * @param callback Callback that performs the action triggering the event.
    * @since v1.11
    */
-  Page waitForClose(WaitForCloseOptions options, Runnable callback);
+  Page waitForClose(@Nullable WaitForCloseOptions options, Runnable callback);
   /**
    * Performs action and waits for a {@code ConsoleMessage} to be logged by in the page. If predicate is provided, it passes
    * {@code ConsoleMessage} value into the {@code predicate} function and waits for {@code predicate(message)} to return a
@@ -8015,7 +8016,7 @@ public interface Page extends AutoCloseable {
    * @param callback Callback that performs the action triggering the event.
    * @since v1.9
    */
-  ConsoleMessage waitForConsoleMessage(WaitForConsoleMessageOptions options, Runnable callback);
+  ConsoleMessage waitForConsoleMessage(@Nullable WaitForConsoleMessageOptions options, Runnable callback);
   /**
    * Performs action and waits for a new {@code Download}. If predicate is provided, it passes {@code Download} value into
    * the {@code predicate} function and waits for {@code predicate(download)} to return a truthy value. Will throw an error
@@ -8035,7 +8036,7 @@ public interface Page extends AutoCloseable {
    * @param callback Callback that performs the action triggering the event.
    * @since v1.9
    */
-  Download waitForDownload(WaitForDownloadOptions options, Runnable callback);
+  Download waitForDownload(@Nullable WaitForDownloadOptions options, Runnable callback);
   /**
    * Performs action and waits for a new {@code FileChooser} to be created. If predicate is provided, it passes {@code
    * FileChooser} value into the {@code predicate} function and waits for {@code predicate(fileChooser)} to return a truthy
@@ -8055,7 +8056,7 @@ public interface Page extends AutoCloseable {
    * @param callback Callback that performs the action triggering the event.
    * @since v1.9
    */
-  FileChooser waitForFileChooser(WaitForFileChooserOptions options, Runnable callback);
+  FileChooser waitForFileChooser(@Nullable WaitForFileChooserOptions options, Runnable callback);
   /**
    * Returns when the {@code expression} returns a truthy value. It resolves to a JSHandle of the truthy value.
    *
@@ -8092,7 +8093,7 @@ public interface Page extends AutoCloseable {
    * @param arg Optional argument to pass to {@code expression}.
    * @since v1.8
    */
-  default JSHandle waitForFunction(String expression, Object arg) {
+  default JSHandle waitForFunction(String expression, @Nullable Object arg) {
     return waitForFunction(expression, arg, null);
   }
   /**
@@ -8169,7 +8170,7 @@ public interface Page extends AutoCloseable {
    * @param arg Optional argument to pass to {@code expression}.
    * @since v1.8
    */
-  JSHandle waitForFunction(String expression, Object arg, WaitForFunctionOptions options);
+  JSHandle waitForFunction(String expression, @Nullable Object arg, @Nullable WaitForFunctionOptions options);
   /**
    * Returns when the required load state has been reached.
    *
@@ -8203,7 +8204,7 @@ public interface Page extends AutoCloseable {
    * </ul>
    * @since v1.8
    */
-  default void waitForLoadState(LoadState state) {
+  default void waitForLoadState(@Nullable LoadState state) {
     waitForLoadState(state, null);
   }
   /**
@@ -8267,14 +8268,14 @@ public interface Page extends AutoCloseable {
    * </ul>
    * @since v1.8
    */
-  void waitForLoadState(LoadState state, WaitForLoadStateOptions options);
+  void waitForLoadState(@Nullable LoadState state, @Nullable WaitForLoadStateOptions options);
   /**
    * @deprecated This method is inherently racy, please use {@link com.microsoft.playwright.Page#waitForURL Page.waitForURL()} instead.
    *
    * @param callback Callback that performs the action triggering the event.
    * @since v1.8
    */
-  default Response waitForNavigation(Runnable callback) {
+  default @Nullable Response waitForNavigation(Runnable callback) {
     return waitForNavigation(null, callback);
   }
   /**
@@ -8283,7 +8284,7 @@ public interface Page extends AutoCloseable {
    * @param callback Callback that performs the action triggering the event.
    * @since v1.8
    */
-  Response waitForNavigation(WaitForNavigationOptions options, Runnable callback);
+  @Nullable Response waitForNavigation(@Nullable WaitForNavigationOptions options, Runnable callback);
   /**
    * Performs action and waits for a popup {@code Page}. If predicate is provided, it passes [Popup] value into the {@code
    * predicate} function and waits for {@code predicate(page)} to return a truthy value. Will throw an error if the page is
@@ -8303,7 +8304,7 @@ public interface Page extends AutoCloseable {
    * @param callback Callback that performs the action triggering the event.
    * @since v1.9
    */
-  Page waitForPopup(WaitForPopupOptions options, Runnable callback);
+  Page waitForPopup(@Nullable WaitForPopupOptions options, Runnable callback);
   /**
    * Waits for the matching request and returns it. See <a
    * href="https://playwright.dev/java/docs/events#waiting-for-event">waiting for event</a> for more details about events.
@@ -8357,7 +8358,7 @@ public interface Page extends AutoCloseable {
    * @param callback Callback that performs the action triggering the event.
    * @since v1.8
    */
-  Request waitForRequest(String urlOrPredicate, WaitForRequestOptions options, Runnable callback);
+  Request waitForRequest(String urlOrPredicate, @Nullable WaitForRequestOptions options, Runnable callback);
   /**
    * Waits for the matching request and returns it. See <a
    * href="https://playwright.dev/java/docs/events#waiting-for-event">waiting for event</a> for more details about events.
@@ -8411,7 +8412,7 @@ public interface Page extends AutoCloseable {
    * @param callback Callback that performs the action triggering the event.
    * @since v1.8
    */
-  Request waitForRequest(Pattern urlOrPredicate, WaitForRequestOptions options, Runnable callback);
+  Request waitForRequest(Pattern urlOrPredicate, @Nullable WaitForRequestOptions options, Runnable callback);
   /**
    * Waits for the matching request and returns it. See <a
    * href="https://playwright.dev/java/docs/events#waiting-for-event">waiting for event</a> for more details about events.
@@ -8465,7 +8466,7 @@ public interface Page extends AutoCloseable {
    * @param callback Callback that performs the action triggering the event.
    * @since v1.8
    */
-  Request waitForRequest(Predicate<Request> urlOrPredicate, WaitForRequestOptions options, Runnable callback);
+  Request waitForRequest(Predicate<Request> urlOrPredicate, @Nullable WaitForRequestOptions options, Runnable callback);
   /**
    * Performs action and waits for a {@code Request} to finish loading. If predicate is provided, it passes {@code Request}
    * value into the {@code predicate} function and waits for {@code predicate(request)} to return a truthy value. Will throw
@@ -8487,7 +8488,7 @@ public interface Page extends AutoCloseable {
    * @param callback Callback that performs the action triggering the event.
    * @since v1.12
    */
-  Request waitForRequestFinished(WaitForRequestFinishedOptions options, Runnable callback);
+  Request waitForRequestFinished(@Nullable WaitForRequestFinishedOptions options, Runnable callback);
   /**
    * Returns the matched response. See <a href="https://playwright.dev/java/docs/events#waiting-for-event">waiting for
    * event</a> for more details about events.
@@ -8541,7 +8542,7 @@ public interface Page extends AutoCloseable {
    * @param callback Callback that performs the action triggering the event.
    * @since v1.8
    */
-  Response waitForResponse(String urlOrPredicate, WaitForResponseOptions options, Runnable callback);
+  Response waitForResponse(String urlOrPredicate, @Nullable WaitForResponseOptions options, Runnable callback);
   /**
    * Returns the matched response. See <a href="https://playwright.dev/java/docs/events#waiting-for-event">waiting for
    * event</a> for more details about events.
@@ -8595,7 +8596,7 @@ public interface Page extends AutoCloseable {
    * @param callback Callback that performs the action triggering the event.
    * @since v1.8
    */
-  Response waitForResponse(Pattern urlOrPredicate, WaitForResponseOptions options, Runnable callback);
+  Response waitForResponse(Pattern urlOrPredicate, @Nullable WaitForResponseOptions options, Runnable callback);
   /**
    * Returns the matched response. See <a href="https://playwright.dev/java/docs/events#waiting-for-event">waiting for
    * event</a> for more details about events.
@@ -8649,7 +8650,7 @@ public interface Page extends AutoCloseable {
    * @param callback Callback that performs the action triggering the event.
    * @since v1.8
    */
-  Response waitForResponse(Predicate<Response> urlOrPredicate, WaitForResponseOptions options, Runnable callback);
+  Response waitForResponse(Predicate<Response> urlOrPredicate, @Nullable WaitForResponseOptions options, Runnable callback);
   /**
    * Returns when element specified by selector satisfies {@code state} option. Returns {@code null} if waiting for {@code
    * hidden} or {@code detached}.
@@ -8688,7 +8689,7 @@ public interface Page extends AutoCloseable {
    * @param selector A selector to query for.
    * @since v1.8
    */
-  default ElementHandle waitForSelector(String selector) {
+  default @Nullable ElementHandle waitForSelector(String selector) {
     return waitForSelector(selector, null);
   }
   /**
@@ -8729,7 +8730,7 @@ public interface Page extends AutoCloseable {
    * @param selector A selector to query for.
    * @since v1.8
    */
-  ElementHandle waitForSelector(String selector, WaitForSelectorOptions options);
+  @Nullable ElementHandle waitForSelector(String selector, @Nullable WaitForSelectorOptions options);
   /**
    * The method will block until the condition returns true. All Playwright events will be dispatched while the method is
    * waiting for the condition.
@@ -8767,7 +8768,7 @@ public interface Page extends AutoCloseable {
    * @param condition Condition to wait for.
    * @since v1.32
    */
-  void waitForCondition(BooleanSupplier condition, WaitForConditionOptions options);
+  void waitForCondition(BooleanSupplier condition, @Nullable WaitForConditionOptions options);
   /**
    * Waits for the given {@code timeout} in milliseconds.
    *
@@ -8815,7 +8816,7 @@ public interface Page extends AutoCloseable {
    * the string.
    * @since v1.11
    */
-  void waitForURL(String url, WaitForURLOptions options);
+  void waitForURL(String url, @Nullable WaitForURLOptions options);
   /**
    * Waits for the main frame to navigate to the given URL.
    *
@@ -8847,7 +8848,7 @@ public interface Page extends AutoCloseable {
    * the string.
    * @since v1.11
    */
-  void waitForURL(Pattern url, WaitForURLOptions options);
+  void waitForURL(Pattern url, @Nullable WaitForURLOptions options);
   /**
    * Waits for the main frame to navigate to the given URL.
    *
@@ -8879,7 +8880,7 @@ public interface Page extends AutoCloseable {
    * the string.
    * @since v1.11
    */
-  void waitForURL(Predicate<String> url, WaitForURLOptions options);
+  void waitForURL(Predicate<String> url, @Nullable WaitForURLOptions options);
   /**
    * Performs action and waits for a new {@code WebSocket}. If predicate is provided, it passes {@code WebSocket} value into
    * the {@code predicate} function and waits for {@code predicate(webSocket)} to return a truthy value. Will throw an error
@@ -8899,7 +8900,7 @@ public interface Page extends AutoCloseable {
    * @param callback Callback that performs the action triggering the event.
    * @since v1.9
    */
-  WebSocket waitForWebSocket(WaitForWebSocketOptions options, Runnable callback);
+  WebSocket waitForWebSocket(@Nullable WaitForWebSocketOptions options, Runnable callback);
   /**
    * Performs action and waits for a new {@code Worker}. If predicate is provided, it passes {@code Worker} value into the
    * {@code predicate} function and waits for {@code predicate(worker)} to return a truthy value. Will throw an error if the
@@ -8919,7 +8920,7 @@ public interface Page extends AutoCloseable {
    * @param callback Callback that performs the action triggering the event.
    * @since v1.9
    */
-  Worker waitForWorker(WaitForWorkerOptions options, Runnable callback);
+  Worker waitForWorker(@Nullable WaitForWorkerOptions options, Runnable callback);
   /**
    * This method returns all of the dedicated <a
    * href="https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API">WebWorkers</a> associated with the page.

--- a/playwright/src/main/java/com/microsoft/playwright/Playwright.java
+++ b/playwright/src/main/java/com/microsoft/playwright/Playwright.java
@@ -16,6 +16,7 @@
 
 package com.microsoft.playwright;
 
+import org.jspecify.annotations.Nullable;
 import com.microsoft.playwright.impl.PlaywrightImpl;
 import java.util.*;
 
@@ -45,7 +46,7 @@ public interface Playwright extends AutoCloseable {
      * Additional environment variables that will be passed to the driver process. By default driver process inherits
      * environment variables of the Playwright process.
      */
-    public Map<String, String> env;
+    public @Nullable Map<String, String> env;
 
     /**
      * Additional environment variables that will be passed to the driver process. By default driver process inherits
@@ -106,7 +107,7 @@ public interface Playwright extends AutoCloseable {
    *
    * @since v1.10
    */
-  static Playwright create(CreateOptions options) {
+  static Playwright create(@Nullable CreateOptions options) {
     return PlaywrightImpl.create(options);
   }
 

--- a/playwright/src/main/java/com/microsoft/playwright/Request.java
+++ b/playwright/src/main/java/com/microsoft/playwright/Request.java
@@ -16,6 +16,7 @@
 
 package com.microsoft.playwright;
 
+import org.jspecify.annotations.Nullable;
 import com.microsoft.playwright.options.*;
 import java.util.*;
 
@@ -59,7 +60,7 @@ public interface Request {
    *
    * @since v1.8
    */
-  String failure();
+  @Nullable String failure();
   /**
    * Returns the {@code Frame} that initiated this request.
    *
@@ -104,7 +105,7 @@ public interface Request {
    * @param name Name of the header.
    * @since v1.15
    */
-  String headerValue(String name);
+  @Nullable String headerValue(String name);
   /**
    * Whether this request is driving frame's navigation.
    *
@@ -125,13 +126,13 @@ public interface Request {
    *
    * @since v1.8
    */
-  String postData();
+  @Nullable String postData();
   /**
    * Request's post body in a binary form, if any.
    *
    * @since v1.8
    */
-  byte[] postDataBuffer();
+  byte @Nullable [] postDataBuffer();
   /**
    * Request that was redirected by the server to this one, if any.
    *
@@ -155,7 +156,7 @@ public interface Request {
    *
    * @since v1.8
    */
-  Request redirectedFrom();
+  @Nullable Request redirectedFrom();
   /**
    * New request issued by the browser if the server responded with redirect.
    *
@@ -168,7 +169,7 @@ public interface Request {
    *
    * @since v1.8
    */
-  Request redirectedTo();
+  @Nullable Request redirectedTo();
   /**
    * Contains the request's resource type as it was perceived by the rendering engine. ResourceType will be one of the
    * following: {@code document}, {@code stylesheet}, {@code image}, {@code media}, {@code font}, {@code script}, {@code
@@ -182,7 +183,7 @@ public interface Request {
    *
    * @since v1.8
    */
-  Response response();
+  @Nullable Response response();
   /**
    * Returns the {@code Response} object if the response has already been received, {@code null} otherwise.
    *
@@ -192,7 +193,7 @@ public interface Request {
    *
    * @since v1.59
    */
-  Response existingResponse();
+  @Nullable Response existingResponse();
   /**
    * Returns resource size information for given request.
    *

--- a/playwright/src/main/java/com/microsoft/playwright/Response.java
+++ b/playwright/src/main/java/com/microsoft/playwright/Response.java
@@ -16,6 +16,7 @@
 
 package com.microsoft.playwright;
 
+import org.jspecify.annotations.Nullable;
 import com.microsoft.playwright.options.*;
 import java.util.*;
 
@@ -40,7 +41,7 @@ public interface Response {
    *
    * @since v1.8
    */
-  String finished();
+  @Nullable String finished();
   /**
    * Returns the {@code Frame} that initiated this response.
    *
@@ -78,7 +79,7 @@ public interface Response {
    * @param name Name of the header.
    * @since v1.15
    */
-  String headerValue(String name);
+  @Nullable String headerValue(String name);
   /**
    * Returns all values of the headers matching the name, for example {@code set-cookie}. The name is case-insensitive.
    *
@@ -109,13 +110,13 @@ public interface Response {
    *
    * @since v1.13
    */
-  SecurityDetails securityDetails();
+  @Nullable SecurityDetails securityDetails();
   /**
    * Returns the IP address and port of the server.
    *
    * @since v1.13
    */
-  ServerAddr serverAddr();
+  @Nullable ServerAddr serverAddr();
   /**
    * Contains the status code of the response (e.g., 200 for a success).
    *

--- a/playwright/src/main/java/com/microsoft/playwright/Route.java
+++ b/playwright/src/main/java/com/microsoft/playwright/Route.java
@@ -16,6 +16,7 @@
 
 package com.microsoft.playwright;
 
+import org.jspecify.annotations.Nullable;
 import java.nio.file.Path;
 import java.util.*;
 
@@ -31,19 +32,19 @@ public interface Route {
     /**
      * If set changes the request HTTP headers. Header values will be converted to a string.
      */
-    public Map<String, String> headers;
+    public @Nullable Map<String, String> headers;
     /**
      * If set changes the request method (e.g. GET or POST).
      */
-    public String method;
+    public @Nullable String method;
     /**
      * If set changes the post data of request.
      */
-    public Object postData;
+    public @Nullable Object postData;
     /**
      * If set changes the request URL. New URL must have same protocol as original one.
      */
-    public String url;
+    public @Nullable String url;
 
     /**
      * If set changes the request HTTP headers. Header values will be converted to a string.
@@ -85,20 +86,20 @@ public interface Route {
     /**
      * If set changes the request HTTP headers. Header values will be converted to a string.
      */
-    public Map<String, String> headers;
+    public @Nullable Map<String, String> headers;
     /**
      * If set changes the request method (e.g. GET or POST).
      */
-    public String method;
+    public @Nullable String method;
     /**
      * If set changes the post data of request.
      */
-    public Object postData;
+    public @Nullable Object postData;
     /**
      * If set changes the request URL. New URL must have same protocol as original one. Changing the URL won't affect the route
      * matching, all the routes are matched using the original request URL.
      */
-    public String url;
+    public @Nullable String url;
 
     /**
      * If set changes the request HTTP headers. Header values will be converted to a string.
@@ -141,34 +142,34 @@ public interface Route {
     /**
      * If set changes the request HTTP headers. Header values will be converted to a string.
      */
-    public Map<String, String> headers;
+    public @Nullable Map<String, String> headers;
     /**
      * Maximum number of request redirects that will be followed automatically. An error will be thrown if the number is
      * exceeded. Defaults to {@code 20}. Pass {@code 0} to not follow redirects.
      */
-    public Integer maxRedirects;
+    public @Nullable Integer maxRedirects;
     /**
      * Maximum number of times network errors should be retried. Currently only {@code ECONNRESET} error is retried. Does not
      * retry based on HTTP response codes. An error will be thrown if the limit is exceeded. Defaults to {@code 0} - no
      * retries.
      */
-    public Integer maxRetries;
+    public @Nullable Integer maxRetries;
     /**
      * If set changes the request method (e.g. GET or POST).
      */
-    public String method;
+    public @Nullable String method;
     /**
      * If set changes the post data of request.
      */
-    public Object postData;
+    public @Nullable Object postData;
     /**
      * Request timeout in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
     /**
      * If set changes the request URL. New URL must have same protocol as original one.
      */
-    public String url;
+    public @Nullable String url;
 
     /**
      * If set changes the request HTTP headers. Header values will be converted to a string.
@@ -234,33 +235,33 @@ public interface Route {
     /**
      * Optional response body as text.
      */
-    public String body;
+    public @Nullable String body;
     /**
      * Optional response body as raw bytes.
      */
-    public byte[] bodyBytes;
+    public byte @Nullable [] bodyBytes;
     /**
      * If set, equals to setting {@code Content-Type} response header.
      */
-    public String contentType;
+    public @Nullable String contentType;
     /**
      * Response headers. Header values will be converted to a string.
      */
-    public Map<String, String> headers;
+    public @Nullable Map<String, String> headers;
     /**
      * File path to respond with. The content type will be inferred from file extension. If {@code path} is a relative path,
      * then it is resolved relative to the current working directory.
      */
-    public Path path;
+    public @Nullable Path path;
     /**
      * {@code APIResponse} to fulfill route's request with. Individual fields of the response (such as headers) can be
      * overridden using fulfill options.
      */
-    public APIResponse response;
+    public @Nullable APIResponse response;
     /**
      * Response status code, defaults to {@code 200}.
      */
-    public Integer status;
+    public @Nullable Integer status;
 
     /**
      * Optional response body as text.
@@ -346,7 +347,7 @@ public interface Route {
    * </ul>
    * @since v1.8
    */
-  void abort(String errorCode);
+  void abort(@Nullable String errorCode);
   /**
    * Sends route's request to the network with optional overrides.
    *
@@ -410,7 +411,7 @@ public interface Route {
    *
    * @since v1.8
    */
-  void resume(ResumeOptions options);
+  void resume(@Nullable ResumeOptions options);
   /**
    * Continues route's request with optional overrides. The method is similar to {@link com.microsoft.playwright.Route#resume
    * Route.resume()} with the difference that other matching handlers will be invoked before sending the request.
@@ -550,7 +551,7 @@ public interface Route {
    *
    * @since v1.23
    */
-  void fallback(FallbackOptions options);
+  void fallback(@Nullable FallbackOptions options);
   /**
    * Performs the request and fetches result without fulfilling it, so that the response could be modified and then
    * fulfilled.
@@ -604,7 +605,7 @@ public interface Route {
    *
    * @since v1.29
    */
-  APIResponse fetch(FetchOptions options);
+  APIResponse fetch(@Nullable FetchOptions options);
   /**
    * Fulfills route's request with given response.
    *
@@ -654,7 +655,7 @@ public interface Route {
    *
    * @since v1.8
    */
-  void fulfill(FulfillOptions options);
+  void fulfill(@Nullable FulfillOptions options);
   /**
    * A request to be routed.
    *

--- a/playwright/src/main/java/com/microsoft/playwright/Screencast.java
+++ b/playwright/src/main/java/com/microsoft/playwright/Screencast.java
@@ -16,6 +16,7 @@
 
 package com.microsoft.playwright;
 
+import org.jspecify.annotations.Nullable;
 import com.microsoft.playwright.options.*;
 import java.nio.file.Path;
 import java.util.*;
@@ -29,22 +30,22 @@ public interface Screencast {
     /**
      * Callback that receives JPEG-encoded frame data along with the page viewport size at the time of capture.
      */
-    public Consumer<ScreencastFrame> onFrame;
+    public @Nullable Consumer<ScreencastFrame> onFrame;
     /**
      * Path where the video should be saved when the screencast is stopped. When provided, video recording is started.
      */
-    public Path path;
+    public @Nullable Path path;
     /**
      * The quality of the image, between 0-100.
      */
-    public Integer quality;
+    public @Nullable Integer quality;
     /**
      * Specifies the dimensions of screencast frames. The actual frame is scaled to preserve the page's aspect ratio and may be
      * smaller than these bounds. If a screencast is already active (e.g. started by tracing or video recording), the existing
      * configuration takes precedence and the frame size may exceed these bounds or this option may be ignored. If not
      * specified the size will be equal to page viewport scaled down to fit into 800×800.
      */
-    public Size size;
+    public @Nullable Size size;
 
     /**
      * Callback that receives JPEG-encoded frame data along with the page viewport size at the time of capture.
@@ -92,7 +93,7 @@ public interface Screencast {
      * Duration in milliseconds after which the overlay is automatically removed. Overlay stays until dismissed if not
      * provided.
      */
-    public Double duration;
+    public @Nullable Double duration;
 
     /**
      * Duration in milliseconds after which the overlay is automatically removed. Overlay stays until dismissed if not
@@ -107,11 +108,11 @@ public interface Screencast {
     /**
      * Optional description text displayed below the title.
      */
-    public String description;
+    public @Nullable String description;
     /**
      * Duration in milliseconds after which the overlay is automatically removed. Defaults to {@code 2000}.
      */
-    public Double duration;
+    public @Nullable Double duration;
 
     /**
      * Optional description text displayed below the title.
@@ -133,19 +134,19 @@ public interface Screencast {
      * Cursor decoration shown for pointer actions. {@code "pointer"} (the default) renders a mouse pointer that animates from
      * the previous action point to the next one. {@code "none"} disables the cursor decoration.
      */
-    public ScreencastCursor cursor;
+    public @Nullable ScreencastCursor cursor;
     /**
      * How long each annotation is displayed in milliseconds. Defaults to {@code 500}.
      */
-    public Double duration;
+    public @Nullable Double duration;
     /**
      * Font size of the action title in pixels. Defaults to {@code 24}.
      */
-    public Integer fontSize;
+    public @Nullable Integer fontSize;
     /**
      * Position of the action title overlay. Defaults to {@code "top-right"}.
      */
-    public AnnotatePosition position;
+    public @Nullable AnnotatePosition position;
 
     /**
      * Cursor decoration shown for pointer actions. {@code "pointer"} (the default) renders a mouse pointer that animates from
@@ -196,7 +197,7 @@ public interface Screencast {
    *
    * @since v1.59
    */
-  AutoCloseable start(StartOptions options);
+  AutoCloseable start(@Nullable StartOptions options);
   /**
    * Stops the screencast and video recording if active. If a video was being recorded, saves it to the path specified in
    * {@link com.microsoft.playwright.Screencast#start Screencast.start()}.
@@ -221,7 +222,7 @@ public interface Screencast {
    * @param html HTML content for the overlay.
    * @since v1.59
    */
-  AutoCloseable showOverlay(String html, ShowOverlayOptions options);
+  AutoCloseable showOverlay(String html, @Nullable ShowOverlayOptions options);
   /**
    * Shows a chapter overlay with a title and optional description, centered on the page with a blurred backdrop. Useful for
    * narrating video recordings. The overlay is removed after the specified duration, or 2000ms.
@@ -239,7 +240,7 @@ public interface Screencast {
    * @param title Title text displayed prominently in the overlay.
    * @since v1.59
    */
-  void showChapter(String title, ShowChapterOptions options);
+  void showChapter(String title, @Nullable ShowChapterOptions options);
   /**
    * Enables visual annotations on interacted elements. Returns a disposable that stops showing actions when disposed.
    *
@@ -253,7 +254,7 @@ public interface Screencast {
    *
    * @since v1.59
    */
-  AutoCloseable showActions(ShowActionsOptions options);
+  AutoCloseable showActions(@Nullable ShowActionsOptions options);
   /**
    * Shows overlays.
    *

--- a/playwright/src/main/java/com/microsoft/playwright/Selectors.java
+++ b/playwright/src/main/java/com/microsoft/playwright/Selectors.java
@@ -16,6 +16,7 @@
 
 package com.microsoft.playwright;
 
+import org.jspecify.annotations.Nullable;
 import java.nio.file.Path;
 
 /**
@@ -29,7 +30,7 @@ public interface Selectors {
      * not any JavaScript objects from the frame's scripts. Defaults to {@code false}. Note that running as a content script is
      * not guaranteed when this engine is used together with other registered engines.
      */
-    public Boolean contentScript;
+    public @Nullable Boolean contentScript;
 
     /**
      * Whether to run this selector engine in isolated JavaScript environment. This environment has access to the same DOM, but
@@ -118,7 +119,7 @@ public interface Selectors {
    * @param script Script that evaluates to a selector engine instance. The script is evaluated in the page context.
    * @since v1.8
    */
-  void register(String name, String script, RegisterOptions options);
+  void register(String name, String script, @Nullable RegisterOptions options);
   /**
    * Selectors must be registered before creating the page.
    *
@@ -196,7 +197,7 @@ public interface Selectors {
    * @param script Script that evaluates to a selector engine instance. The script is evaluated in the page context.
    * @since v1.8
    */
-  void register(String name, Path script, RegisterOptions options);
+  void register(String name, Path script, @Nullable RegisterOptions options);
   /**
    * Defines custom attribute name to be used in {@link com.microsoft.playwright.Page#getByTestId Page.getByTestId()}. {@code
    * data-testid} is used by default.

--- a/playwright/src/main/java/com/microsoft/playwright/Tracing.java
+++ b/playwright/src/main/java/com/microsoft/playwright/Tracing.java
@@ -16,6 +16,7 @@
 
 package com.microsoft.playwright;
 
+import org.jspecify.annotations.Nullable;
 import com.microsoft.playwright.options.*;
 import java.nio.file.Path;
 import java.util.regex.Pattern;
@@ -48,42 +49,42 @@ public interface Tracing {
     /**
      * Whether to capture aria snapshot of the page on every action.
      */
-    public Boolean ariaSnapshots;
+    public @Nullable Boolean ariaSnapshots;
     /**
      * When enabled, the trace is written to an unarchived file that is updated in real time as actions occur, instead of
      * caching changes and archiving them into a zip file at the end. This is useful for live trace viewing during test
      * execution.
      */
-    public Boolean live;
+    public @Nullable Boolean live;
     /**
      * If specified, intermediate trace files are going to be saved into the files with the given name prefix inside the {@code
      * tracesDir} directory specified in {@link com.microsoft.playwright.BrowserType#launch BrowserType.launch()}. To specify
      * the final trace zip file name, you need to pass {@code path} option to {@link com.microsoft.playwright.Tracing#stop
      * Tracing.stop()} instead.
      */
-    public String name;
+    public @Nullable String name;
     /**
      * Whether to capture screenshots during tracing. Screenshots are used to build a timeline preview.
      */
-    public Boolean screenshots;
+    public @Nullable Boolean screenshots;
     /**
      * Whether to capture a screenshot of the page on every action.
      */
-    public Boolean screenSnapshots;
+    public @Nullable Boolean screenSnapshots;
     /**
      * Whether to capture DOM snapshot and record network activity on every action.
      */
-    public Boolean snapshots;
+    public @Nullable Boolean snapshots;
     /**
      * Whether to include source files for trace actions. List of the directories with source code for the application must be
      * provided via {@code PLAYWRIGHT_JAVA_SRC} environment variable (the paths should be separated by ';' on Windows and by
      * ':' on other platforms).
      */
-    public Boolean sources;
+    public @Nullable Boolean sources;
     /**
      * Trace name to be shown in the Trace Viewer.
      */
-    public String title;
+    public @Nullable String title;
 
     /**
      * Whether to capture aria snapshot of the page on every action.
@@ -156,11 +157,11 @@ public interface Tracing {
      * the final trace zip file name, you need to pass {@code path} option to {@link com.microsoft.playwright.Tracing#stopChunk
      * Tracing.stopChunk()} instead.
      */
-    public String name;
+    public @Nullable String name;
     /**
      * Trace name to be shown in the Trace Viewer.
      */
-    public String title;
+    public @Nullable String title;
 
     /**
      * If specified, intermediate trace files are going to be saved into the files with the given name prefix inside the {@code
@@ -187,17 +188,17 @@ public interface Tracing {
      * is specified, content is stored inline the HAR file as per HAR specification. Defaults to {@code attach} for {@code
      * .zip} output files and to {@code embed} for all other file extensions.
      */
-    public HarContentPolicy content;
+    public @Nullable HarContentPolicy content;
     /**
      * When set to {@code minimal}, only record information necessary for routing from HAR. This omits sizes, timing, page,
      * cookies, security and other types of HAR information that are not used when replaying from HAR. Defaults to {@code
      * full}.
      */
-    public HarMode mode;
+    public @Nullable HarMode mode;
     /**
      * A glob or regex pattern to filter requests that are stored in the HAR. Defaults to none.
      */
-    public Object urlFilter;
+    public @Nullable Object urlFilter;
 
     /**
      * Optional setting to control resource content management. If {@code omit} is specified, content is not persisted. If
@@ -238,7 +239,7 @@ public interface Tracing {
      * Specifies a custom location for the group to be shown in the trace viewer. Defaults to the location of the {@link
      * com.microsoft.playwright.Tracing#group Tracing.group()} call.
      */
-    public Location location;
+    public @Nullable Location location;
 
     /**
      * Specifies a custom location for the group to be shown in the trace viewer. Defaults to the location of the {@link
@@ -260,7 +261,7 @@ public interface Tracing {
     /**
      * Export trace into the file with the given path.
      */
-    public Path path;
+    public @Nullable Path path;
 
     /**
      * Export trace into the file with the given path.
@@ -275,7 +276,7 @@ public interface Tracing {
      * Export trace collected since the last {@link com.microsoft.playwright.Tracing#startChunk Tracing.startChunk()} call into
      * the file with the given path.
      */
-    public Path path;
+    public @Nullable Path path;
 
     /**
      * Export trace collected since the last {@link com.microsoft.playwright.Tracing#startChunk Tracing.startChunk()} call into
@@ -333,7 +334,7 @@ public interface Tracing {
    *
    * @since v1.12
    */
-  void start(StartOptions options);
+  void start(@Nullable StartOptions options);
   /**
    * Start a new trace chunk. If you'd like to record multiple traces on the same {@code BrowserContext}, use {@link
    * com.microsoft.playwright.Tracing#start Tracing.start()} once, and then create multiple trace chunks with {@link
@@ -395,7 +396,7 @@ public interface Tracing {
    *
    * @since v1.15
    */
-  void startChunk(StartChunkOptions options);
+  void startChunk(@Nullable StartChunkOptions options);
   /**
    * Start recording a HAR (HTTP Archive) of network activity in this context. The HAR file is written to disk when {@link
    * com.microsoft.playwright.Tracing#stopHar Tracing.stopHar()} is called, or when the returned {@code Disposable} is
@@ -437,7 +438,7 @@ public interface Tracing {
    * archive with response bodies attached as separate files.
    * @since v1.60
    */
-  AutoCloseable startHar(Path path, StartHarOptions options);
+  AutoCloseable startHar(Path path, @Nullable StartHarOptions options);
   /**
    * <strong>NOTE:</strong> Use {@code test.step} instead when available.
    *
@@ -481,7 +482,7 @@ public interface Tracing {
    * @param name Group name shown in the trace viewer.
    * @since v1.49
    */
-  AutoCloseable group(String name, GroupOptions options);
+  AutoCloseable group(String name, @Nullable GroupOptions options);
   /**
    * Closes the last group created by {@link com.microsoft.playwright.Tracing#group Tracing.group()}.
    *
@@ -501,7 +502,7 @@ public interface Tracing {
    *
    * @since v1.12
    */
-  void stop(StopOptions options);
+  void stop(@Nullable StopOptions options);
   /**
    * Stop the trace chunk. See {@link com.microsoft.playwright.Tracing#startChunk Tracing.startChunk()} for more details
    * about multiple trace chunks.
@@ -517,7 +518,7 @@ public interface Tracing {
    *
    * @since v1.15
    */
-  void stopChunk(StopChunkOptions options);
+  void stopChunk(@Nullable StopChunkOptions options);
   /**
    * Stop HAR recording and save the HAR file to the path given to {@link com.microsoft.playwright.Tracing#startHar
    * Tracing.startHar()}.

--- a/playwright/src/main/java/com/microsoft/playwright/WebError.java
+++ b/playwright/src/main/java/com/microsoft/playwright/WebError.java
@@ -16,6 +16,7 @@
 
 package com.microsoft.playwright;
 
+import org.jspecify.annotations.Nullable;
 import com.microsoft.playwright.options.*;
 
 /**
@@ -37,7 +38,7 @@ public interface WebError {
    *
    * @since v1.38
    */
-  Page page();
+  @Nullable Page page();
   /**
    * Unhandled error that was thrown.
    *

--- a/playwright/src/main/java/com/microsoft/playwright/WebSocket.java
+++ b/playwright/src/main/java/com/microsoft/playwright/WebSocket.java
@@ -16,6 +16,7 @@
 
 package com.microsoft.playwright;
 
+import org.jspecify.annotations.Nullable;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 
@@ -67,13 +68,13 @@ public interface WebSocket {
     /**
      * Receives the {@code WebSocketFrame} object and resolves to truthy value when the waiting should resolve.
      */
-    public Predicate<WebSocketFrame> predicate;
+    public @Nullable Predicate<WebSocketFrame> predicate;
     /**
      * Maximum time to wait for in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The
      * default value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
      * BrowserContext.setDefaultTimeout()}.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * Receives the {@code WebSocketFrame} object and resolves to truthy value when the waiting should resolve.
@@ -96,13 +97,13 @@ public interface WebSocket {
     /**
      * Receives the {@code WebSocketFrame} object and resolves to truthy value when the waiting should resolve.
      */
-    public Predicate<WebSocketFrame> predicate;
+    public @Nullable Predicate<WebSocketFrame> predicate;
     /**
      * Maximum time to wait for in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The
      * default value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
      * BrowserContext.setDefaultTimeout()}.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * Receives the {@code WebSocketFrame} object and resolves to truthy value when the waiting should resolve.
@@ -152,7 +153,7 @@ public interface WebSocket {
    * @param callback Callback that performs the action triggering the event.
    * @since v1.10
    */
-  WebSocketFrame waitForFrameReceived(WaitForFrameReceivedOptions options, Runnable callback);
+  WebSocketFrame waitForFrameReceived(@Nullable WaitForFrameReceivedOptions options, Runnable callback);
   /**
    * Performs action and waits for a frame to be sent. If predicate is provided, it passes {@code WebSocketFrame} value into
    * the {@code predicate} function and waits for {@code predicate(webSocketFrame)} to return a truthy value. Will throw an
@@ -172,6 +173,6 @@ public interface WebSocket {
    * @param callback Callback that performs the action triggering the event.
    * @since v1.10
    */
-  WebSocketFrame waitForFrameSent(WaitForFrameSentOptions options, Runnable callback);
+  WebSocketFrame waitForFrameSent(@Nullable WaitForFrameSentOptions options, Runnable callback);
 }
 

--- a/playwright/src/main/java/com/microsoft/playwright/WebSocketFrame.java
+++ b/playwright/src/main/java/com/microsoft/playwright/WebSocketFrame.java
@@ -16,6 +16,7 @@
 
 package com.microsoft.playwright;
 
+import org.jspecify.annotations.Nullable;
 
 /**
  * The {@code WebSocketFrame} class represents frames sent over {@code WebSocket} connections in the page. Frame payload is
@@ -28,12 +29,12 @@ public interface WebSocketFrame {
    *
    * @since v1.9
    */
-  byte[] binary();
+  byte @Nullable [] binary();
   /**
    * Returns text payload.
    *
    * @since v1.9
    */
-  String text();
+  @Nullable String text();
 }
 

--- a/playwright/src/main/java/com/microsoft/playwright/WebSocketRoute.java
+++ b/playwright/src/main/java/com/microsoft/playwright/WebSocketRoute.java
@@ -16,6 +16,7 @@
 
 package com.microsoft.playwright;
 
+import org.jspecify.annotations.Nullable;
 import java.util.*;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
@@ -109,11 +110,11 @@ public interface WebSocketRoute {
     /**
      * Optional <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebSocket/close#code">close code</a>.
      */
-    public Integer code;
+    public @Nullable Integer code;
     /**
      * Optional <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebSocket/close#reason">close reason</a>.
      */
-    public String reason;
+    public @Nullable String reason;
 
     /**
      * Optional <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebSocket/close#code">close code</a>.
@@ -143,7 +144,7 @@ public interface WebSocketRoute {
    *
    * @since v1.48
    */
-  void close(CloseOptions options);
+  void close(@Nullable CloseOptions options);
   /**
    * By default, routed WebSocket does not connect to the server, so you can mock entire WebSocket communication. This method
    * connects to the actual WebSocket server, and returns the server-side {@code WebSocketRoute} instance, giving the ability

--- a/playwright/src/main/java/com/microsoft/playwright/WebStorage.java
+++ b/playwright/src/main/java/com/microsoft/playwright/WebStorage.java
@@ -16,6 +16,7 @@
 
 package com.microsoft.playwright;
 
+import org.jspecify.annotations.Nullable;
 import com.microsoft.playwright.options.*;
 import java.util.*;
 
@@ -47,7 +48,7 @@ public interface WebStorage {
    * @param name Name of the item to retrieve.
    * @since v1.61
    */
-  String getItem(String name);
+  @Nullable String getItem(String name);
   /**
    * Sets the value for the given {@code name}. Overwrites any existing value for that name.
    *

--- a/playwright/src/main/java/com/microsoft/playwright/Worker.java
+++ b/playwright/src/main/java/com/microsoft/playwright/Worker.java
@@ -16,6 +16,7 @@
 
 package com.microsoft.playwright;
 
+import org.jspecify.annotations.Nullable;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 
@@ -61,7 +62,7 @@ public interface Worker {
      * default value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
      * BrowserContext.setDefaultTimeout()}.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * Maximum time to wait for in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The
@@ -77,13 +78,13 @@ public interface Worker {
     /**
      * Receives the {@code ConsoleMessage} object and resolves to true when the waiting should resolve.
      */
-    public Predicate<ConsoleMessage> predicate;
+    public @Nullable Predicate<ConsoleMessage> predicate;
     /**
      * Maximum time to wait for in milliseconds. Defaults to {@code 30000} (30 seconds). Pass {@code 0} to disable timeout. The
      * default value can be changed by using the {@link com.microsoft.playwright.BrowserContext#setDefaultTimeout
      * BrowserContext.setDefaultTimeout()}.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * Receives the {@code ConsoleMessage} object and resolves to true when the waiting should resolve.
@@ -118,7 +119,7 @@ public interface Worker {
    * automatically invoked.
    * @since v1.8
    */
-  default Object evaluate(String expression) {
+  default @Nullable Object evaluate(String expression) {
     return evaluate(expression, null);
   }
   /**
@@ -138,7 +139,7 @@ public interface Worker {
    * @param arg Optional argument to pass to {@code expression}.
    * @since v1.8
    */
-  Object evaluate(String expression, Object arg);
+  @Nullable Object evaluate(String expression, @Nullable Object arg);
   /**
    * Returns the return value of {@code expression} as a {@code JSHandle}.
    *
@@ -175,7 +176,7 @@ public interface Worker {
    * @param arg Optional argument to pass to {@code expression}.
    * @since v1.8
    */
-  JSHandle evaluateHandle(String expression, Object arg);
+  JSHandle evaluateHandle(String expression, @Nullable Object arg);
   /**
    *
    *
@@ -197,7 +198,7 @@ public interface Worker {
    * @param callback Callback that performs the action triggering the event.
    * @since v1.10
    */
-  Worker waitForClose(WaitForCloseOptions options, Runnable callback);
+  Worker waitForClose(@Nullable WaitForCloseOptions options, Runnable callback);
   /**
    * Performs action and waits for a console message.
    *
@@ -213,6 +214,6 @@ public interface Worker {
    * @param callback Callback that performs the action triggering the event.
    * @since v1.57
    */
-  ConsoleMessage waitForConsoleMessage(WaitForConsoleMessageOptions options, Runnable callback);
+  ConsoleMessage waitForConsoleMessage(@Nullable WaitForConsoleMessageOptions options, Runnable callback);
 }
 

--- a/playwright/src/main/java/com/microsoft/playwright/assertions/LocatorAssertions.java
+++ b/playwright/src/main/java/com/microsoft/playwright/assertions/LocatorAssertions.java
@@ -16,6 +16,7 @@
 
 package com.microsoft.playwright.assertions;
 
+import org.jspecify.annotations.Nullable;
 import java.util.*;
 import java.util.regex.Pattern;
 import com.microsoft.playwright.options.AriaRole;
@@ -41,11 +42,11 @@ import com.microsoft.playwright.options.PseudoElement;
  */
 public interface LocatorAssertions {
   class IsAttachedOptions {
-    public Boolean attached;
+    public @Nullable Boolean attached;
     /**
      * Time to retry the assertion for in milliseconds. Defaults to {@code 5000}.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     public IsAttachedOptions setAttached(boolean attached) {
       this.attached = attached;
@@ -64,16 +65,16 @@ public interface LocatorAssertions {
      * Provides state to assert for. Asserts for input to be checked by default. This option can't be used when {@code
      * indeterminate} is set to true.
      */
-    public Boolean checked;
+    public @Nullable Boolean checked;
     /**
      * Asserts that the element is in the indeterminate (mixed) state. Only supported for checkboxes and radio buttons. This
      * option can't be true when {@code checked} is provided.
      */
-    public Boolean indeterminate;
+    public @Nullable Boolean indeterminate;
     /**
      * Time to retry the assertion for in milliseconds. Defaults to {@code 5000}.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * Provides state to assert for. Asserts for input to be checked by default. This option can't be used when {@code
@@ -103,7 +104,7 @@ public interface LocatorAssertions {
     /**
      * Time to retry the assertion for in milliseconds. Defaults to {@code 5000}.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * Time to retry the assertion for in milliseconds. Defaults to {@code 5000}.
@@ -114,11 +115,11 @@ public interface LocatorAssertions {
     }
   }
   class IsEditableOptions {
-    public Boolean editable;
+    public @Nullable Boolean editable;
     /**
      * Time to retry the assertion for in milliseconds. Defaults to {@code 5000}.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     public IsEditableOptions setEditable(boolean editable) {
       this.editable = editable;
@@ -136,7 +137,7 @@ public interface LocatorAssertions {
     /**
      * Time to retry the assertion for in milliseconds. Defaults to {@code 5000}.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * Time to retry the assertion for in milliseconds. Defaults to {@code 5000}.
@@ -147,11 +148,11 @@ public interface LocatorAssertions {
     }
   }
   class IsEnabledOptions {
-    public Boolean enabled;
+    public @Nullable Boolean enabled;
     /**
      * Time to retry the assertion for in milliseconds. Defaults to {@code 5000}.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     public IsEnabledOptions setEnabled(boolean enabled) {
       this.enabled = enabled;
@@ -169,7 +170,7 @@ public interface LocatorAssertions {
     /**
      * Time to retry the assertion for in milliseconds. Defaults to {@code 5000}.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * Time to retry the assertion for in milliseconds. Defaults to {@code 5000}.
@@ -183,7 +184,7 @@ public interface LocatorAssertions {
     /**
      * Time to retry the assertion for in milliseconds. Defaults to {@code 5000}.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * Time to retry the assertion for in milliseconds. Defaults to {@code 5000}.
@@ -198,11 +199,11 @@ public interface LocatorAssertions {
      * The minimal ratio of the element to intersect viewport. If equals to {@code 0}, then element should intersect viewport
      * at any positive ratio. Defaults to {@code 0}.
      */
-    public Double ratio;
+    public @Nullable Double ratio;
     /**
      * Time to retry the assertion for in milliseconds. Defaults to {@code 5000}.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * The minimal ratio of the element to intersect viewport. If equals to {@code 0}, then element should intersect viewport
@@ -224,8 +225,8 @@ public interface LocatorAssertions {
     /**
      * Time to retry the assertion for in milliseconds. Defaults to {@code 5000}.
      */
-    public Double timeout;
-    public Boolean visible;
+    public @Nullable Double timeout;
+    public @Nullable Boolean visible;
 
     /**
      * Time to retry the assertion for in milliseconds. Defaults to {@code 5000}.
@@ -243,7 +244,7 @@ public interface LocatorAssertions {
     /**
      * Time to retry the assertion for in milliseconds. Defaults to {@code 5000}.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * Time to retry the assertion for in milliseconds. Defaults to {@code 5000}.
@@ -258,15 +259,15 @@ public interface LocatorAssertions {
      * Whether to perform case-insensitive match. {@code ignoreCase} option takes precedence over the corresponding regular
      * expression flag if specified.
      */
-    public Boolean ignoreCase;
+    public @Nullable Boolean ignoreCase;
     /**
      * Time to retry the assertion for in milliseconds. Defaults to {@code 5000}.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
     /**
      * Whether to use {@code element.innerText} instead of {@code element.textContent} when retrieving DOM node text.
      */
-    public Boolean useInnerText;
+    public @Nullable Boolean useInnerText;
 
     /**
      * Whether to perform case-insensitive match. {@code ignoreCase} option takes precedence over the corresponding regular
@@ -296,11 +297,11 @@ public interface LocatorAssertions {
      * Whether to perform case-insensitive match. {@code ignoreCase} option takes precedence over the corresponding regular
      * expression flag if specified.
      */
-    public Boolean ignoreCase;
+    public @Nullable Boolean ignoreCase;
     /**
      * Time to retry the assertion for in milliseconds. Defaults to {@code 5000}.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * Whether to perform case-insensitive match. {@code ignoreCase} option takes precedence over the corresponding regular
@@ -323,11 +324,11 @@ public interface LocatorAssertions {
      * Whether to perform case-insensitive match. {@code ignoreCase} option takes precedence over the corresponding regular
      * expression flag if specified.
      */
-    public Boolean ignoreCase;
+    public @Nullable Boolean ignoreCase;
     /**
      * Time to retry the assertion for in milliseconds. Defaults to {@code 5000}.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * Whether to perform case-insensitive match. {@code ignoreCase} option takes precedence over the corresponding regular
@@ -350,11 +351,11 @@ public interface LocatorAssertions {
      * Whether to perform case-insensitive match. {@code ignoreCase} option takes precedence over the corresponding regular
      * expression flag if specified.
      */
-    public Boolean ignoreCase;
+    public @Nullable Boolean ignoreCase;
     /**
      * Time to retry the assertion for in milliseconds. Defaults to {@code 5000}.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * Whether to perform case-insensitive match. {@code ignoreCase} option takes precedence over the corresponding regular
@@ -377,11 +378,11 @@ public interface LocatorAssertions {
      * Whether to perform case-insensitive match. {@code ignoreCase} option takes precedence over the corresponding regular
      * expression flag if specified.
      */
-    public Boolean ignoreCase;
+    public @Nullable Boolean ignoreCase;
     /**
      * Time to retry the assertion for in milliseconds. Defaults to {@code 5000}.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * Whether to perform case-insensitive match. {@code ignoreCase} option takes precedence over the corresponding regular
@@ -403,7 +404,7 @@ public interface LocatorAssertions {
     /**
      * Time to retry the assertion for in milliseconds. Defaults to {@code 5000}.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * Time to retry the assertion for in milliseconds. Defaults to {@code 5000}.
@@ -417,7 +418,7 @@ public interface LocatorAssertions {
     /**
      * Time to retry the assertion for in milliseconds. Defaults to {@code 5000}.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * Time to retry the assertion for in milliseconds. Defaults to {@code 5000}.
@@ -431,11 +432,11 @@ public interface LocatorAssertions {
     /**
      * Pseudo-element to read computed styles from.
      */
-    public PseudoElement pseudo;
+    public @Nullable PseudoElement pseudo;
     /**
      * Time to retry the assertion for in milliseconds. Defaults to {@code 5000}.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * Pseudo-element to read computed styles from.
@@ -456,7 +457,7 @@ public interface LocatorAssertions {
     /**
      * Time to retry the assertion for in milliseconds. Defaults to {@code 5000}.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * Time to retry the assertion for in milliseconds. Defaults to {@code 5000}.
@@ -470,7 +471,7 @@ public interface LocatorAssertions {
     /**
      * Time to retry the assertion for in milliseconds. Defaults to {@code 5000}.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * Time to retry the assertion for in milliseconds. Defaults to {@code 5000}.
@@ -484,7 +485,7 @@ public interface LocatorAssertions {
     /**
      * Time to retry the assertion for in milliseconds. Defaults to {@code 5000}.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * Time to retry the assertion for in milliseconds. Defaults to {@code 5000}.
@@ -499,15 +500,15 @@ public interface LocatorAssertions {
      * Whether to perform case-insensitive match. {@code ignoreCase} option takes precedence over the corresponding regular
      * expression flag if specified.
      */
-    public Boolean ignoreCase;
+    public @Nullable Boolean ignoreCase;
     /**
      * Time to retry the assertion for in milliseconds. Defaults to {@code 5000}.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
     /**
      * Whether to use {@code element.innerText} instead of {@code element.textContent} when retrieving DOM node text.
      */
-    public Boolean useInnerText;
+    public @Nullable Boolean useInnerText;
 
     /**
      * Whether to perform case-insensitive match. {@code ignoreCase} option takes precedence over the corresponding regular
@@ -536,7 +537,7 @@ public interface LocatorAssertions {
     /**
      * Time to retry the assertion for in milliseconds. Defaults to {@code 5000}.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * Time to retry the assertion for in milliseconds. Defaults to {@code 5000}.
@@ -550,7 +551,7 @@ public interface LocatorAssertions {
     /**
      * Time to retry the assertion for in milliseconds. Defaults to {@code 5000}.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * Time to retry the assertion for in milliseconds. Defaults to {@code 5000}.
@@ -564,7 +565,7 @@ public interface LocatorAssertions {
     /**
      * Time to retry the assertion for in milliseconds. Defaults to {@code 5000}.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * Time to retry the assertion for in milliseconds. Defaults to {@code 5000}.
@@ -612,7 +613,7 @@ public interface LocatorAssertions {
    *
    * @since v1.33
    */
-  void isAttached(IsAttachedOptions options);
+  void isAttached(@Nullable IsAttachedOptions options);
   /**
    * Ensures the {@code Locator} points to a checked input.
    *
@@ -636,7 +637,7 @@ public interface LocatorAssertions {
    *
    * @since v1.20
    */
-  void isChecked(IsCheckedOptions options);
+  void isChecked(@Nullable IsCheckedOptions options);
   /**
    * Ensures the {@code Locator} points to a disabled element. Element is disabled if it has "disabled" attribute or is
    * disabled via <a
@@ -670,7 +671,7 @@ public interface LocatorAssertions {
    *
    * @since v1.20
    */
-  void isDisabled(IsDisabledOptions options);
+  void isDisabled(@Nullable IsDisabledOptions options);
   /**
    * Ensures the {@code Locator} points to an editable element.
    *
@@ -694,7 +695,7 @@ public interface LocatorAssertions {
    *
    * @since v1.20
    */
-  void isEditable(IsEditableOptions options);
+  void isEditable(@Nullable IsEditableOptions options);
   /**
    * Ensures the {@code Locator} points to an empty editable element or to a DOM node that has no text.
    *
@@ -718,7 +719,7 @@ public interface LocatorAssertions {
    *
    * @since v1.20
    */
-  void isEmpty(IsEmptyOptions options);
+  void isEmpty(@Nullable IsEmptyOptions options);
   /**
    * Ensures the {@code Locator} points to an enabled element.
    *
@@ -742,7 +743,7 @@ public interface LocatorAssertions {
    *
    * @since v1.20
    */
-  void isEnabled(IsEnabledOptions options);
+  void isEnabled(@Nullable IsEnabledOptions options);
   /**
    * Ensures the {@code Locator} points to a focused DOM node.
    *
@@ -766,7 +767,7 @@ public interface LocatorAssertions {
    *
    * @since v1.20
    */
-  void isFocused(IsFocusedOptions options);
+  void isFocused(@Nullable IsFocusedOptions options);
   /**
    * Ensures that {@code Locator} either does not resolve to any DOM node, or resolves to a <a
    * href="https://playwright.dev/java/docs/actionability#visible">non-visible</a> one.
@@ -792,7 +793,7 @@ public interface LocatorAssertions {
    *
    * @since v1.20
    */
-  void isHidden(IsHiddenOptions options);
+  void isHidden(@Nullable IsHiddenOptions options);
   /**
    * Ensures the {@code Locator} points to an element that intersects viewport, according to the <a
    * href="https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API">intersection observer API</a>.
@@ -830,7 +831,7 @@ public interface LocatorAssertions {
    *
    * @since v1.31
    */
-  void isInViewport(IsInViewportOptions options);
+  void isInViewport(@Nullable IsInViewportOptions options);
   /**
    * Ensures that {@code Locator} points to an attached and <a
    * href="https://playwright.dev/java/docs/actionability#visible">visible</a> DOM node.
@@ -884,7 +885,7 @@ public interface LocatorAssertions {
    *
    * @since v1.20
    */
-  void isVisible(IsVisibleOptions options);
+  void isVisible(@Nullable IsVisibleOptions options);
   /**
    * Ensures the {@code Locator} points to an element with given CSS classes. All classes from the asserted value, separated
    * by spaces, must be present in the <a
@@ -930,7 +931,7 @@ public interface LocatorAssertions {
    * @param expected A string containing expected class names, separated by spaces, or a list of such strings to assert multiple elements.
    * @since v1.52
    */
-  void containsClass(String expected, ContainsClassOptions options);
+  void containsClass(String expected, @Nullable ContainsClassOptions options);
   /**
    * Ensures the {@code Locator} points to an element with given CSS classes. All classes from the asserted value, separated
    * by spaces, must be present in the <a
@@ -976,7 +977,7 @@ public interface LocatorAssertions {
    * @param expected A string containing expected class names, separated by spaces, or a list of such strings to assert multiple elements.
    * @since v1.52
    */
-  void containsClass(List<String> expected, ContainsClassOptions options);
+  void containsClass(List<String> expected, @Nullable ContainsClassOptions options);
   /**
    * Ensures the {@code Locator} points to an element that contains the given text. All nested elements will be considered
    * when computing the text content of the element. You can use regular expressions for the value as well.
@@ -1064,7 +1065,7 @@ public interface LocatorAssertions {
    * @param expected Expected substring or RegExp or a list of those.
    * @since v1.20
    */
-  void containsText(String expected, ContainsTextOptions options);
+  void containsText(String expected, @Nullable ContainsTextOptions options);
   /**
    * Ensures the {@code Locator} points to an element that contains the given text. All nested elements will be considered
    * when computing the text content of the element. You can use regular expressions for the value as well.
@@ -1152,7 +1153,7 @@ public interface LocatorAssertions {
    * @param expected Expected substring or RegExp or a list of those.
    * @since v1.20
    */
-  void containsText(Pattern expected, ContainsTextOptions options);
+  void containsText(Pattern expected, @Nullable ContainsTextOptions options);
   /**
    * Ensures the {@code Locator} points to an element that contains the given text. All nested elements will be considered
    * when computing the text content of the element. You can use regular expressions for the value as well.
@@ -1240,7 +1241,7 @@ public interface LocatorAssertions {
    * @param expected Expected substring or RegExp or a list of those.
    * @since v1.20
    */
-  void containsText(String[] expected, ContainsTextOptions options);
+  void containsText(String[] expected, @Nullable ContainsTextOptions options);
   /**
    * Ensures the {@code Locator} points to an element that contains the given text. All nested elements will be considered
    * when computing the text content of the element. You can use regular expressions for the value as well.
@@ -1328,7 +1329,7 @@ public interface LocatorAssertions {
    * @param expected Expected substring or RegExp or a list of those.
    * @since v1.20
    */
-  void containsText(Pattern[] expected, ContainsTextOptions options);
+  void containsText(Pattern[] expected, @Nullable ContainsTextOptions options);
   /**
    * Ensures the {@code Locator} points to an element with a given <a
    * href="https://w3c.github.io/accname/#dfn-accessible-description">accessible description</a>.
@@ -1358,7 +1359,7 @@ public interface LocatorAssertions {
    * @param description Expected accessible description.
    * @since v1.44
    */
-  void hasAccessibleDescription(String description, HasAccessibleDescriptionOptions options);
+  void hasAccessibleDescription(String description, @Nullable HasAccessibleDescriptionOptions options);
   /**
    * Ensures the {@code Locator} points to an element with a given <a
    * href="https://w3c.github.io/accname/#dfn-accessible-description">accessible description</a>.
@@ -1388,7 +1389,7 @@ public interface LocatorAssertions {
    * @param description Expected accessible description.
    * @since v1.44
    */
-  void hasAccessibleDescription(Pattern description, HasAccessibleDescriptionOptions options);
+  void hasAccessibleDescription(Pattern description, @Nullable HasAccessibleDescriptionOptions options);
   /**
    * Ensures the {@code Locator} points to an element with a given <a
    * href="https://w3c.github.io/aria/#aria-errormessage">aria errormessage</a>.
@@ -1418,7 +1419,7 @@ public interface LocatorAssertions {
    * @param errorMessage Expected accessible error message.
    * @since v1.50
    */
-  void hasAccessibleErrorMessage(String errorMessage, HasAccessibleErrorMessageOptions options);
+  void hasAccessibleErrorMessage(String errorMessage, @Nullable HasAccessibleErrorMessageOptions options);
   /**
    * Ensures the {@code Locator} points to an element with a given <a
    * href="https://w3c.github.io/aria/#aria-errormessage">aria errormessage</a>.
@@ -1448,7 +1449,7 @@ public interface LocatorAssertions {
    * @param errorMessage Expected accessible error message.
    * @since v1.50
    */
-  void hasAccessibleErrorMessage(Pattern errorMessage, HasAccessibleErrorMessageOptions options);
+  void hasAccessibleErrorMessage(Pattern errorMessage, @Nullable HasAccessibleErrorMessageOptions options);
   /**
    * Ensures the {@code Locator} points to an element with a given <a
    * href="https://w3c.github.io/accname/#dfn-accessible-name">accessible name</a>.
@@ -1478,7 +1479,7 @@ public interface LocatorAssertions {
    * @param name Expected accessible name.
    * @since v1.44
    */
-  void hasAccessibleName(String name, HasAccessibleNameOptions options);
+  void hasAccessibleName(String name, @Nullable HasAccessibleNameOptions options);
   /**
    * Ensures the {@code Locator} points to an element with a given <a
    * href="https://w3c.github.io/accname/#dfn-accessible-name">accessible name</a>.
@@ -1508,7 +1509,7 @@ public interface LocatorAssertions {
    * @param name Expected accessible name.
    * @since v1.44
    */
-  void hasAccessibleName(Pattern name, HasAccessibleNameOptions options);
+  void hasAccessibleName(Pattern name, @Nullable HasAccessibleNameOptions options);
   /**
    * Ensures the {@code Locator} points to an element with given attribute.
    *
@@ -1536,7 +1537,7 @@ public interface LocatorAssertions {
    * @param value Expected attribute value.
    * @since v1.20
    */
-  void hasAttribute(String name, String value, HasAttributeOptions options);
+  void hasAttribute(String name, String value, @Nullable HasAttributeOptions options);
   /**
    * Ensures the {@code Locator} points to an element with given attribute.
    *
@@ -1564,7 +1565,7 @@ public interface LocatorAssertions {
    * @param value Expected attribute value.
    * @since v1.20
    */
-  void hasAttribute(String name, Pattern value, HasAttributeOptions options);
+  void hasAttribute(String name, Pattern value, @Nullable HasAttributeOptions options);
   /**
    * Ensures the {@code Locator} points to an element with given CSS classes. When a string is provided, it must fully match
    * the element's {@code class} attribute. To match individual classes use {@link
@@ -1610,7 +1611,7 @@ public interface LocatorAssertions {
    * @param expected Expected class or RegExp or a list of those.
    * @since v1.20
    */
-  void hasClass(String expected, HasClassOptions options);
+  void hasClass(String expected, @Nullable HasClassOptions options);
   /**
    * Ensures the {@code Locator} points to an element with given CSS classes. When a string is provided, it must fully match
    * the element's {@code class} attribute. To match individual classes use {@link
@@ -1656,7 +1657,7 @@ public interface LocatorAssertions {
    * @param expected Expected class or RegExp or a list of those.
    * @since v1.20
    */
-  void hasClass(Pattern expected, HasClassOptions options);
+  void hasClass(Pattern expected, @Nullable HasClassOptions options);
   /**
    * Ensures the {@code Locator} points to an element with given CSS classes. When a string is provided, it must fully match
    * the element's {@code class} attribute. To match individual classes use {@link
@@ -1702,7 +1703,7 @@ public interface LocatorAssertions {
    * @param expected Expected class or RegExp or a list of those.
    * @since v1.20
    */
-  void hasClass(String[] expected, HasClassOptions options);
+  void hasClass(String[] expected, @Nullable HasClassOptions options);
   /**
    * Ensures the {@code Locator} points to an element with given CSS classes. When a string is provided, it must fully match
    * the element's {@code class} attribute. To match individual classes use {@link
@@ -1748,7 +1749,7 @@ public interface LocatorAssertions {
    * @param expected Expected class or RegExp or a list of those.
    * @since v1.20
    */
-  void hasClass(Pattern[] expected, HasClassOptions options);
+  void hasClass(Pattern[] expected, @Nullable HasClassOptions options);
   /**
    * Ensures the {@code Locator} resolves to an exact number of DOM nodes.
    *
@@ -1774,7 +1775,7 @@ public interface LocatorAssertions {
    * @param count Expected count.
    * @since v1.20
    */
-  void hasCount(int count, HasCountOptions options);
+  void hasCount(int count, @Nullable HasCountOptions options);
   /**
    * Ensures the {@code Locator} resolves to an element with the given computed CSS style.
    *
@@ -1802,7 +1803,7 @@ public interface LocatorAssertions {
    * @param value CSS property value.
    * @since v1.20
    */
-  void hasCSS(String name, String value, HasCSSOptions options);
+  void hasCSS(String name, String value, @Nullable HasCSSOptions options);
   /**
    * Ensures the {@code Locator} resolves to an element with the given computed CSS style.
    *
@@ -1830,7 +1831,7 @@ public interface LocatorAssertions {
    * @param value CSS property value.
    * @since v1.20
    */
-  void hasCSS(String name, Pattern value, HasCSSOptions options);
+  void hasCSS(String name, Pattern value, @Nullable HasCSSOptions options);
   /**
    * Ensures the {@code Locator} points to an element with the given DOM Node ID.
    *
@@ -1856,7 +1857,7 @@ public interface LocatorAssertions {
    * @param id Element id.
    * @since v1.20
    */
-  void hasId(String id, HasIdOptions options);
+  void hasId(String id, @Nullable HasIdOptions options);
   /**
    * Ensures the {@code Locator} points to an element with the given DOM Node ID.
    *
@@ -1882,7 +1883,7 @@ public interface LocatorAssertions {
    * @param id Element id.
    * @since v1.20
    */
-  void hasId(Pattern id, HasIdOptions options);
+  void hasId(Pattern id, @Nullable HasIdOptions options);
   /**
    * Ensures the {@code Locator} points to an element with given JavaScript property. Note that this property can be of a
    * primitive type as well as a plain serializable JavaScript object.
@@ -1912,7 +1913,7 @@ public interface LocatorAssertions {
    * @param value Property value.
    * @since v1.20
    */
-  void hasJSProperty(String name, Object value, HasJSPropertyOptions options);
+  void hasJSProperty(String name, Object value, @Nullable HasJSPropertyOptions options);
   /**
    * Ensures the {@code Locator} points to an element with a given <a href="https://www.w3.org/TR/wai-aria-1.2/#roles">ARIA
    * role</a>.
@@ -1948,7 +1949,7 @@ public interface LocatorAssertions {
    * @param role Required aria role.
    * @since v1.44
    */
-  void hasRole(AriaRole role, HasRoleOptions options);
+  void hasRole(AriaRole role, @Nullable HasRoleOptions options);
   /**
    * Ensures the {@code Locator} points to an element with the given text. All nested elements will be considered when
    * computing the text content of the element. You can use regular expressions for the value as well.
@@ -2036,7 +2037,7 @@ public interface LocatorAssertions {
    * @param expected Expected string or RegExp or a list of those.
    * @since v1.20
    */
-  void hasText(String expected, HasTextOptions options);
+  void hasText(String expected, @Nullable HasTextOptions options);
   /**
    * Ensures the {@code Locator} points to an element with the given text. All nested elements will be considered when
    * computing the text content of the element. You can use regular expressions for the value as well.
@@ -2124,7 +2125,7 @@ public interface LocatorAssertions {
    * @param expected Expected string or RegExp or a list of those.
    * @since v1.20
    */
-  void hasText(Pattern expected, HasTextOptions options);
+  void hasText(Pattern expected, @Nullable HasTextOptions options);
   /**
    * Ensures the {@code Locator} points to an element with the given text. All nested elements will be considered when
    * computing the text content of the element. You can use regular expressions for the value as well.
@@ -2212,7 +2213,7 @@ public interface LocatorAssertions {
    * @param expected Expected string or RegExp or a list of those.
    * @since v1.20
    */
-  void hasText(String[] expected, HasTextOptions options);
+  void hasText(String[] expected, @Nullable HasTextOptions options);
   /**
    * Ensures the {@code Locator} points to an element with the given text. All nested elements will be considered when
    * computing the text content of the element. You can use regular expressions for the value as well.
@@ -2300,7 +2301,7 @@ public interface LocatorAssertions {
    * @param expected Expected string or RegExp or a list of those.
    * @since v1.20
    */
-  void hasText(Pattern[] expected, HasTextOptions options);
+  void hasText(Pattern[] expected, @Nullable HasTextOptions options);
   /**
    * Ensures the {@code Locator} points to an element with the given input value. You can use regular expressions for the
    * value as well.
@@ -2328,7 +2329,7 @@ public interface LocatorAssertions {
    * @param value Expected value.
    * @since v1.20
    */
-  void hasValue(String value, HasValueOptions options);
+  void hasValue(String value, @Nullable HasValueOptions options);
   /**
    * Ensures the {@code Locator} points to an element with the given input value. You can use regular expressions for the
    * value as well.
@@ -2356,7 +2357,7 @@ public interface LocatorAssertions {
    * @param value Expected value.
    * @since v1.20
    */
-  void hasValue(Pattern value, HasValueOptions options);
+  void hasValue(Pattern value, @Nullable HasValueOptions options);
   /**
    * Ensures the {@code Locator} points to multi-select/combobox (i.e. a {@code select} with the {@code multiple} attribute)
    * and the specified values are selected.
@@ -2390,7 +2391,7 @@ public interface LocatorAssertions {
    * @param values Expected options currently selected.
    * @since v1.23
    */
-  void hasValues(String[] values, HasValuesOptions options);
+  void hasValues(String[] values, @Nullable HasValuesOptions options);
   /**
    * Ensures the {@code Locator} points to multi-select/combobox (i.e. a {@code select} with the {@code multiple} attribute)
    * and the specified values are selected.
@@ -2424,7 +2425,7 @@ public interface LocatorAssertions {
    * @param values Expected options currently selected.
    * @since v1.23
    */
-  void hasValues(Pattern[] values, HasValuesOptions options);
+  void hasValues(Pattern[] values, @Nullable HasValuesOptions options);
   /**
    * Asserts that the target element matches the given <a
    * href="https://playwright.dev/java/docs/aria-snapshots">accessibility snapshot</a>.
@@ -2458,6 +2459,6 @@ public interface LocatorAssertions {
    *
    * @since v1.49
    */
-  void matchesAriaSnapshot(String expected, MatchesAriaSnapshotOptions options);
+  void matchesAriaSnapshot(String expected, @Nullable MatchesAriaSnapshotOptions options);
 }
 

--- a/playwright/src/main/java/com/microsoft/playwright/assertions/PageAssertions.java
+++ b/playwright/src/main/java/com/microsoft/playwright/assertions/PageAssertions.java
@@ -16,6 +16,7 @@
 
 package com.microsoft.playwright.assertions;
 
+import org.jspecify.annotations.Nullable;
 import java.util.regex.Pattern;
 
 /**
@@ -41,7 +42,7 @@ public interface PageAssertions {
     /**
      * Time to retry the assertion for in milliseconds. Defaults to {@code 5000}.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * Time to retry the assertion for in milliseconds. Defaults to {@code 5000}.
@@ -55,7 +56,7 @@ public interface PageAssertions {
     /**
      * Time to retry the assertion for in milliseconds. Defaults to {@code 5000}.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * Time to retry the assertion for in milliseconds. Defaults to {@code 5000}.
@@ -70,11 +71,11 @@ public interface PageAssertions {
      * Whether to perform case-insensitive match. {@code ignoreCase} option takes precedence over the corresponding regular
      * expression parameter if specified. A provided predicate ignores this flag.
      */
-    public Boolean ignoreCase;
+    public @Nullable Boolean ignoreCase;
     /**
      * Time to retry the assertion for in milliseconds. Defaults to {@code 5000}.
      */
-    public Double timeout;
+    public @Nullable Double timeout;
 
     /**
      * Whether to perform case-insensitive match. {@code ignoreCase} option takes precedence over the corresponding regular
@@ -138,7 +139,7 @@ public interface PageAssertions {
    *
    * @since v1.60
    */
-  void matchesAriaSnapshot(String expected, MatchesAriaSnapshotOptions options);
+  void matchesAriaSnapshot(String expected, @Nullable MatchesAriaSnapshotOptions options);
   /**
    * Ensures the page has the given title.
    *
@@ -164,7 +165,7 @@ public interface PageAssertions {
    * @param titleOrRegExp Expected title or RegExp.
    * @since v1.20
    */
-  void hasTitle(String titleOrRegExp, HasTitleOptions options);
+  void hasTitle(String titleOrRegExp, @Nullable HasTitleOptions options);
   /**
    * Ensures the page has the given title.
    *
@@ -190,7 +191,7 @@ public interface PageAssertions {
    * @param titleOrRegExp Expected title or RegExp.
    * @since v1.20
    */
-  void hasTitle(Pattern titleOrRegExp, HasTitleOptions options);
+  void hasTitle(Pattern titleOrRegExp, @Nullable HasTitleOptions options);
   /**
    * Ensures the page is navigated to the given URL.
    *
@@ -216,7 +217,7 @@ public interface PageAssertions {
    * @param urlOrRegExp Expected URL string or RegExp.
    * @since v1.20
    */
-  void hasURL(String urlOrRegExp, HasURLOptions options);
+  void hasURL(String urlOrRegExp, @Nullable HasURLOptions options);
   /**
    * Ensures the page is navigated to the given URL.
    *
@@ -242,6 +243,6 @@ public interface PageAssertions {
    * @param urlOrRegExp Expected URL string or RegExp.
    * @since v1.20
    */
-  void hasURL(Pattern urlOrRegExp, HasURLOptions options);
+  void hasURL(Pattern urlOrRegExp, @Nullable HasURLOptions options);
 }
 

--- a/playwright/src/main/java/com/microsoft/playwright/assertions/package-info.java
+++ b/playwright/src/main/java/com/microsoft/playwright/assertions/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package com.microsoft.playwright.assertions;
+
+import org.jspecify.annotations.NullMarked;

--- a/playwright/src/main/java/com/microsoft/playwright/assertions/package-info.java
+++ b/playwright/src/main/java/com/microsoft/playwright/assertions/package-info.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 @NullMarked
 package com.microsoft.playwright.assertions;
 

--- a/playwright/src/main/java/com/microsoft/playwright/options/ClientCertificate.java
+++ b/playwright/src/main/java/com/microsoft/playwright/options/ClientCertificate.java
@@ -16,6 +16,7 @@
 
 package com.microsoft.playwright.options;
 
+import org.jspecify.annotations.Nullable;
 import java.nio.file.Path;
 
 public class ClientCertificate {
@@ -27,31 +28,31 @@ public class ClientCertificate {
   /**
    * Path to the file with the certificate in PEM format.
    */
-  public Path certPath;
+  public @Nullable Path certPath;
   /**
    * Direct value of the certificate in PEM format.
    */
-  public byte[] cert;
+  public byte @Nullable [] cert;
   /**
    * Path to the file with the private key in PEM format.
    */
-  public Path keyPath;
+  public @Nullable Path keyPath;
   /**
    * Direct value of the private key in PEM format.
    */
-  public byte[] key;
+  public byte @Nullable [] key;
   /**
    * Path to the PFX or PKCS12 encoded private key and certificate chain.
    */
-  public Path pfxPath;
+  public @Nullable Path pfxPath;
   /**
    * Direct value of the PFX or PKCS12 encoded private key and certificate chain.
    */
-  public byte[] pfx;
+  public byte @Nullable [] pfx;
   /**
    * Passphrase for the private key (PEM or PFX).
    */
-  public String passphrase;
+  public @Nullable String passphrase;
 
   public ClientCertificate(String origin) {
     this.origin = origin;

--- a/playwright/src/main/java/com/microsoft/playwright/options/Cookie.java
+++ b/playwright/src/main/java/com/microsoft/playwright/options/Cookie.java
@@ -16,44 +16,46 @@
 
 package com.microsoft.playwright.options;
 
+import org.jspecify.annotations.Nullable;
+
 public class Cookie {
   public String name;
   public String value;
   /**
    * Either {@code url} or both {@code domain} and {@code path} are required. Optional.
    */
-  public String url;
+  public @Nullable String url;
   /**
    * For the cookie to apply to all subdomains as well, prefix domain with a dot, like this: ".example.com". Either {@code
    * url} or both {@code domain} and {@code path} are required. Optional.
    */
-  public String domain;
+  public @Nullable String domain;
   /**
    * Either {@code url} or both {@code domain} and {@code path} are required. Optional.
    */
-  public String path;
+  public @Nullable String path;
   /**
    * Unix time in seconds. Optional.
    */
-  public Double expires;
+  public @Nullable Double expires;
   /**
    * Optional.
    */
-  public Boolean httpOnly;
+  public @Nullable Boolean httpOnly;
   /**
    * Optional.
    */
-  public Boolean secure;
+  public @Nullable Boolean secure;
   /**
    * Optional.
    */
-  public SameSiteAttribute sameSite;
+  public @Nullable SameSiteAttribute sameSite;
   /**
    * For partitioned third-party cookies (aka <a
    * href="https://developer.mozilla.org/en-US/docs/Web/Privacy/Guides/Privacy_sandbox/Partitioned_cookies">CHIPS</a>), the
    * partition key. Optional.
    */
-  public String partitionKey;
+  public @Nullable String partitionKey;
 
   public Cookie(String name, String value) {
     this.name = name;

--- a/playwright/src/main/java/com/microsoft/playwright/options/DropPayload.java
+++ b/playwright/src/main/java/com/microsoft/playwright/options/DropPayload.java
@@ -16,11 +16,12 @@
 
 package com.microsoft.playwright.options;
 
+import org.jspecify.annotations.Nullable;
 import java.util.Map;
 
 public class DropPayload {
-  public Object files;
-  public Map<String, String> data;
+  public @Nullable Object files;
+  public @Nullable Map<String, String> data;
 
   public DropPayload setFiles(Object files) {
     this.files = files;

--- a/playwright/src/main/java/com/microsoft/playwright/options/Geolocation.java
+++ b/playwright/src/main/java/com/microsoft/playwright/options/Geolocation.java
@@ -16,6 +16,8 @@
 
 package com.microsoft.playwright.options;
 
+import org.jspecify.annotations.Nullable;
+
 public class Geolocation {
   /**
    * Latitude between -90 and 90.
@@ -28,7 +30,7 @@ public class Geolocation {
   /**
    * Non-negative accuracy value. Defaults to {@code 0}.
    */
-  public Double accuracy;
+  public @Nullable Double accuracy;
 
   public Geolocation(double latitude, double longitude) {
     this.latitude = latitude;

--- a/playwright/src/main/java/com/microsoft/playwright/options/HttpCredentials.java
+++ b/playwright/src/main/java/com/microsoft/playwright/options/HttpCredentials.java
@@ -16,20 +16,22 @@
 
 package com.microsoft.playwright.options;
 
+import org.jspecify.annotations.Nullable;
+
 public class HttpCredentials {
   public String username;
   public String password;
   /**
    * Restrain sending http credentials on specific origin (scheme://host:port).
    */
-  public String origin;
+  public @Nullable String origin;
   /**
    * This option only applies to the requests sent from corresponding {@code APIRequestContext} and does not affect requests
    * sent from the browser. {@code "always"} - {@code Authorization} header with basic authentication credentials will be
    * sent with the each API request. {@code 'unauthorized} - the credentials are only sent when 401 (Unauthorized) response
    * with {@code WWW-Authenticate} header is received. Defaults to {@code "unauthorized"}.
    */
-  public HttpCredentialsSend send;
+  public @Nullable HttpCredentialsSend send;
 
   public HttpCredentials(String username, String password) {
     this.username = username;

--- a/playwright/src/main/java/com/microsoft/playwright/options/Location.java
+++ b/playwright/src/main/java/com/microsoft/playwright/options/Location.java
@@ -16,10 +16,12 @@
 
 package com.microsoft.playwright.options;
 
+import org.jspecify.annotations.Nullable;
+
 public class Location {
   public String file;
-  public Integer line;
-  public Integer column;
+  public @Nullable Integer line;
+  public @Nullable Integer column;
 
   public Location(String file) {
     this.file = file;

--- a/playwright/src/main/java/com/microsoft/playwright/options/Margin.java
+++ b/playwright/src/main/java/com/microsoft/playwright/options/Margin.java
@@ -16,23 +16,25 @@
 
 package com.microsoft.playwright.options;
 
+import org.jspecify.annotations.Nullable;
+
 public class Margin {
   /**
    * Top margin, accepts values labeled with units. Defaults to {@code 0}.
    */
-  public String top;
+  public @Nullable String top;
   /**
    * Right margin, accepts values labeled with units. Defaults to {@code 0}.
    */
-  public String right;
+  public @Nullable String right;
   /**
    * Bottom margin, accepts values labeled with units. Defaults to {@code 0}.
    */
-  public String bottom;
+  public @Nullable String bottom;
   /**
    * Left margin, accepts values labeled with units. Defaults to {@code 0}.
    */
-  public String left;
+  public @Nullable String left;
 
   /**
    * Top margin, accepts values labeled with units. Defaults to {@code 0}.

--- a/playwright/src/main/java/com/microsoft/playwright/options/Proxy.java
+++ b/playwright/src/main/java/com/microsoft/playwright/options/Proxy.java
@@ -16,6 +16,8 @@
 
 package com.microsoft.playwright.options;
 
+import org.jspecify.annotations.Nullable;
+
 public class Proxy {
   /**
    * Proxy to be used for all requests. HTTP and SOCKS proxies are supported, for example {@code http://myproxy.com:3128} or
@@ -25,15 +27,15 @@ public class Proxy {
   /**
    * Optional comma-separated domains to bypass proxy, for example {@code ".com, chromium.org, .domain.com"}.
    */
-  public String bypass;
+  public @Nullable String bypass;
   /**
    * Optional username to use if HTTP proxy requires authentication.
    */
-  public String username;
+  public @Nullable String username;
   /**
    * Optional password to use if HTTP proxy requires authentication.
    */
-  public String password;
+  public @Nullable String password;
 
   public Proxy(String server) {
     this.server = server;

--- a/playwright/src/main/java/com/microsoft/playwright/options/SecurityDetails.java
+++ b/playwright/src/main/java/com/microsoft/playwright/options/SecurityDetails.java
@@ -16,28 +16,30 @@
 
 package com.microsoft.playwright.options;
 
+import org.jspecify.annotations.Nullable;
+
 public class SecurityDetails {
   /**
    * Common Name component of the Issuer field. from the certificate. This should only be used for informational purposes.
    * Optional.
    */
-  public String issuer;
+  public @Nullable String issuer;
   /**
    * The specific TLS protocol used. (e.g. {@code TLS 1.3}). Optional.
    */
-  public String protocol;
+  public @Nullable String protocol;
   /**
    * Common Name component of the Subject field from the certificate. This should only be used for informational purposes.
    * Optional.
    */
-  public String subjectName;
+  public @Nullable String subjectName;
   /**
    * Unix timestamp (in seconds) specifying when this cert becomes valid. Optional.
    */
-  public Double validFrom;
+  public @Nullable Double validFrom;
   /**
    * Unix timestamp (in seconds) specifying when this cert becomes invalid. Optional.
    */
-  public Double validTo;
+  public @Nullable Double validTo;
 
 }

--- a/playwright/src/main/java/com/microsoft/playwright/options/SelectOption.java
+++ b/playwright/src/main/java/com/microsoft/playwright/options/SelectOption.java
@@ -16,19 +16,21 @@
 
 package com.microsoft.playwright.options;
 
+import org.jspecify.annotations.Nullable;
+
 public class SelectOption {
   /**
    * Matches by {@code option.value}. Optional.
    */
-  public String value;
+  public @Nullable String value;
   /**
    * Matches by {@code option.label}. Optional.
    */
-  public String label;
+  public @Nullable String label;
   /**
    * Matches by the index. Optional.
    */
-  public Integer index;
+  public @Nullable Integer index;
 
   /**
    * Matches by {@code option.value}. Optional.

--- a/playwright/src/main/java/com/microsoft/playwright/options/package-info.java
+++ b/playwright/src/main/java/com/microsoft/playwright/options/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package com.microsoft.playwright.options;
+
+import org.jspecify.annotations.NullMarked;

--- a/playwright/src/main/java/com/microsoft/playwright/options/package-info.java
+++ b/playwright/src/main/java/com/microsoft/playwright/options/package-info.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 @NullMarked
 package com.microsoft.playwright.options;
 

--- a/playwright/src/main/java/com/microsoft/playwright/package-info.java
+++ b/playwright/src/main/java/com/microsoft/playwright/package-info.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 @NullMarked
 package com.microsoft.playwright;
 

--- a/playwright/src/main/java/com/microsoft/playwright/package-info.java
+++ b/playwright/src/main/java/com/microsoft/playwright/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package com.microsoft.playwright;
+
+import org.jspecify.annotations.NullMarked;

--- a/playwright/src/test/java/com/microsoft/playwright/TestJSpecifyAnnotations.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestJSpecifyAnnotations.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.microsoft.playwright;
+
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class TestJSpecifyAnnotations {
+  @Test
+  void shouldMarkEvaluateReturnAndArgumentNullable() throws NoSuchMethodException {
+    Method evaluateWithoutArgument = Page.class.getMethod("evaluate", String.class);
+    assertNotNull(evaluateWithoutArgument.getAnnotatedReturnType().getAnnotation(Nullable.class));
+
+    Method evaluateWithArgument = Page.class.getMethod("evaluate", String.class, Object.class);
+    assertNotNull(evaluateWithArgument.getAnnotatedReturnType().getAnnotation(Nullable.class));
+    assertNotNull(evaluateWithArgument.getAnnotatedParameterTypes()[1].getAnnotation(Nullable.class));
+  }
+}

--- a/playwright/src/test/java/com/microsoft/playwright/nullability/JSpecifyApiConsumer.java
+++ b/playwright/src/test/java/com/microsoft/playwright/nullability/JSpecifyApiConsumer.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.microsoft.playwright.nullability;
+
+import com.microsoft.playwright.Browser;
+import com.microsoft.playwright.ElementHandle;
+import com.microsoft.playwright.Frame;
+import com.microsoft.playwright.JSHandle;
+import com.microsoft.playwright.Page;
+import com.microsoft.playwright.WebSocketFrame;
+import com.microsoft.playwright.options.Cookie;
+import org.jspecify.annotations.NullMarked;
+
+@NullMarked
+final class JSpecifyApiConsumer {
+  static void useApi(Page page, JSHandle handle, Frame frame, WebSocketFrame webSocketFrame) {
+    ElementHandle element = handle.asElement();
+    if (element != null) {
+      element.dispose();
+    }
+
+    Frame parent = frame.parentFrame();
+    if (parent != null) {
+      parent.name();
+    }
+
+    byte[] binary = webSocketFrame.binary();
+    if (binary != null) {
+      binary.clone();
+    }
+
+    frame.name().length();
+
+    Object result = page.evaluate("() => null", null);
+    if (result != null) {
+      result.toString();
+    }
+    page.addScriptTag(null);
+
+    Browser.NewContextOptions options = new Browser.NewContextOptions();
+    options.setColorScheme(null);
+    options.colorScheme = null;
+
+    Cookie cookie = new Cookie("name", "value");
+    cookie.url = null;
+  }
+}

--- a/playwright/src/test/java/com/microsoft/playwright/nullability/JSpecifyApiConsumer.java
+++ b/playwright/src/test/java/com/microsoft/playwright/nullability/JSpecifyApiConsumer.java
@@ -17,38 +17,19 @@
 package com.microsoft.playwright.nullability;
 
 import com.microsoft.playwright.Browser;
-import com.microsoft.playwright.ElementHandle;
 import com.microsoft.playwright.Frame;
-import com.microsoft.playwright.JSHandle;
 import com.microsoft.playwright.Page;
-import com.microsoft.playwright.WebSocketFrame;
 import com.microsoft.playwright.options.Cookie;
 import org.jspecify.annotations.NullMarked;
 
 @NullMarked
 final class JSpecifyApiConsumer {
-  static void useApi(Page page, JSHandle handle, Frame frame, WebSocketFrame webSocketFrame) {
-    ElementHandle element = handle.asElement();
-    if (element != null) {
-      element.dispose();
-    }
-
-    Frame parent = frame.parentFrame();
-    if (parent != null) {
-      parent.name();
-    }
-
-    byte[] binary = webSocketFrame.binary();
-    if (binary != null) {
-      binary.clone();
-    }
-
+  // Only unguarded dereferences and null arguments/assignments are checked by NullAway,
+  // so this file exercises non-null returns and nullable inputs.
+  static void useApi(Page page, Frame frame) {
     frame.name().length();
 
-    Object result = page.evaluate("() => null", null);
-    if (result != null) {
-      result.toString();
-    }
+    page.evaluate("() => null", null);
     page.addScriptTag(null);
 
     Browser.NewContextOptions options = new Browser.NewContextOptions();

--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,9 @@
     <maven.compiler.target>8</maven.compiler.target>
     <maven.compiler.parameters>true</maven.compiler.parameters>
     <gson.version>2.14.0</gson.version>
+    <jspecify.version>1.0.1</jspecify.version>
+    <error-prone.version>2.50.0</error-prone.version>
+    <nullaway.version>0.14.1</nullaway.version>
     <junit.version>5.14.1</junit.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <websocket.version>1.6.0</websocket.version>
@@ -68,6 +71,11 @@
         <groupId>com.google.code.gson</groupId>
         <artifactId>gson</artifactId>
         <version>${gson.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jspecify</groupId>
+        <artifactId>jspecify</artifactId>
+        <version>${jspecify.version}</version>
       </dependency>
       <dependency>
         <groupId>org.opentest4j</groupId>

--- a/tools/api-generator/src/main/java/com/microsoft/playwright/tools/ApiGenerator.java
+++ b/tools/api-generator/src/main/java/com/microsoft/playwright/tools/ApiGenerator.java
@@ -370,12 +370,17 @@ class TypeRef extends Element {
   }
 
   String toJavaWithNullability() {
-    String javaType = toJava();
-    return isNullableInJava() ? nullable(javaType) : javaType;
+    return withNullability(toJava(), false);
+  }
+
+  // Adds @Nullable to the given Java rendering of this type when the type itself admits null
+  // or when it is used in an optional slot (parameter or field).
+  String withNullability(String javaType, boolean optional) {
+    return optional || isNullableInJava() ? nullable(javaType) : javaType;
   }
 
   // Serializable is mapped to Object and JSON null is a valid value for it.
-  boolean isNullableInJava() {
+  private boolean isNullableInJava() {
     return isNullable() || "Serializable".equals(stripNullable().get("name").getAsString());
   }
 
@@ -392,10 +397,6 @@ class TypeRef extends Element {
     BOXED_TYPES.put("int", "Integer");
     BOXED_TYPES.put("double", "Double");
     BOXED_TYPES.put("boolean", "Boolean");
-  }
-
-  static boolean isPrimitive(String javaType) {
-    return "void".equals(javaType) || BOXED_TYPES.containsKey(javaType);
   }
 
   static String boxed(String javaType) {
@@ -908,16 +909,11 @@ class Param extends Element {
   }
 
   String toJavaOverload(int overoadIndex) {
-    return withNullability(type.formatTypeFromUnion(overoadIndex)) + " " + jsonName;
+    return type.withNullability(type.formatTypeFromUnion(overoadIndex), isOptional()) + " " + jsonName;
   }
 
   String toJava() {
-    return withNullability(type.toJava()) + " " + jsonName;
-  }
-
-  private String withNullability(String javaType) {
-    boolean nullable = type.isNullableInJava() || (isOptional() && !TypeRef.isPrimitive(javaType));
-    return nullable ? TypeRef.nullable(javaType) : javaType;
+    return type.withNullability(type.toJava(), isOptional()) + " " + jsonName;
   }
 }
 
@@ -942,15 +938,12 @@ class Field extends Element {
     if (type.isNullable()) {
       typeStr = "Optional<" + typeStr + ">";
     }
-    // Convert optional fields to boxed types.
-    if (!isRequired()) {
-      typeStr = TypeRef.boxed(typeStr);
-    }
     if (isBrowserChannelOption()) {
       typeStr = "Object";
     }
+    // Optional fields are boxed so that they can hold null.
     if (!isRequired()) {
-      typeStr = TypeRef.nullable(typeStr);
+      typeStr = TypeRef.nullable(TypeRef.boxed(typeStr));
     }
     output.add(offset + "public " + typeStr + " " + name + ";");
   }
@@ -1006,10 +999,8 @@ class Field extends Element {
 
   private void writeGenericBuilderMethod(List<String> output, String offset, String parentClass, String paramType) {
     writeJavadoc(output, offset, comment());
-    if (type.isNullable()) {
-      paramType = TypeRef.nullable(paramType);
-    }
-    output.add(offset + "public " + parentClass + " set" + toTitle(name) + "(" + paramType + " " + name + ") {");
+    String param = type.withNullability(paramType, false);
+    output.add(offset + "public " + parentClass + " set" + toTitle(name) + "(" + param + " " + name + ") {");
     String rvalue = type.isNullable() ? "Optional.ofNullable(" + name + ")" : name;
     output.add(offset + "  this." + name + " = " + rvalue + ";");
     output.add(offset + "  return this;");
@@ -1280,10 +1271,7 @@ class CustomInterface extends TypeDefinition {
       }
       first = false;
       writeJavadoc(output, bodyOffset, f.comment());
-      String returnType = f.type.toJava();
-      if (!f.isRequired() || f.type.isNullable()) {
-        returnType = TypeRef.nullable(returnType);
-      }
+      String returnType = f.type.withNullability(f.type.toJava(), !f.isRequired());
       output.add(bodyOffset + returnType + " " + f.name + "();");
     }
     output.add(offset + "}");
@@ -1343,32 +1331,29 @@ public class ApiGenerator {
 
   private void writeTopLevelTypes(Map<String, TypeDefinition> topLevelTypes, File dir, File optionsDir, String packageName) throws IOException {
     for (TypeDefinition e : topLevelTypes.values()) {
-      List<String> lines = new ArrayList<>();
-      lines.add(Interface.header);
-      File targetDir;
+      List<String> body = new ArrayList<>();
+      e.writeTo(body, "");
       if (e instanceof CustomInterface) {
-        lines.add("package " + packageName + ";");
-        targetDir = dir;
+        writeFile(new File(dir, e.name() + ".java"), packageName, body);
       } else {
-        lines.add("package " + packageName + ".options;");
-        targetDir = optionsDir;
+        writeFile(new File(optionsDir, e.name() + ".java"), packageName + ".options", body);
       }
-      lines.add("");
-      e.writeTo(lines, "");
-      writeFile(lines, new File(targetDir, e.name() + ".java"));
     }
   }
 
-  // Lines are expected to start with the license header, package declaration and an empty line.
-  private static void writeFile(List<String> lines, File file) throws IOException {
-    if (lines.stream().anyMatch(line -> line.contains("@Nullable"))) {
-      int index = 3;
-      lines.add(index++, "import org.jspecify.annotations.Nullable;");
-      String next = lines.get(index);
-      if (!next.isEmpty() && !next.startsWith("import ")) {
-        lines.add(index, "");
+  private static void writeFile(File file, String packageName, List<String> body) throws IOException {
+    List<String> lines = new ArrayList<>();
+    lines.add(Interface.header);
+    lines.add("package " + packageName + ";");
+    lines.add("");
+    if (body.stream().anyMatch(line -> line.contains("@Nullable"))) {
+      lines.add("import org.jspecify.annotations.Nullable;");
+      String first = body.get(0);
+      if (!first.isEmpty() && !first.startsWith("import ")) {
+        lines.add("");
       }
     }
+    lines.addAll(body);
     try (FileWriter writer = new FileWriter(file)) {
       writer.write(String.join("\n", lines));
     }
@@ -1402,12 +1387,9 @@ public class ApiGenerator {
         topLevelTypes.put(name, iface);
         continue;
       }
-      List<String> lines = new ArrayList<>();
-      lines.add(Interface.header);
-      lines.add("package " + packageName + ";");
-      lines.add("");
-      iface.writeTo(lines, "");
-      writeFile(lines, new File(dir, name + ".java"));
+      List<String> body = new ArrayList<>();
+      iface.writeTo(body, "");
+      writeFile(new File(dir, name + ".java"), packageName, body);
     }
 
   }

--- a/tools/api-generator/src/main/java/com/microsoft/playwright/tools/ApiGenerator.java
+++ b/tools/api-generator/src/main/java/com/microsoft/playwright/tools/ApiGenerator.java
@@ -369,6 +369,39 @@ class TypeRef extends Element {
     return convertBuiltinType(stripNullable());
   }
 
+  String toJavaWithNullability() {
+    String javaType = toJava();
+    return isNullableInJava() ? nullable(javaType) : javaType;
+  }
+
+  // Serializable is mapped to Object and JSON null is a valid value for it.
+  boolean isNullableInJava() {
+    return isNullable() || "Serializable".equals(stripNullable().get("name").getAsString());
+  }
+
+  static String nullable(String javaType) {
+    if (javaType.endsWith("[]")) {
+      return javaType.substring(0, javaType.length() - 2) + " @Nullable []";
+    }
+    return "@Nullable " + javaType;
+  }
+
+  // Primitive types produced by convertBuiltinType and their boxed counterparts.
+  private static final Map<String, String> BOXED_TYPES = new HashMap<>();
+  static {
+    BOXED_TYPES.put("int", "Integer");
+    BOXED_TYPES.put("double", "Double");
+    BOXED_TYPES.put("boolean", "Boolean");
+  }
+
+  static boolean isPrimitive(String javaType) {
+    return "void".equals(javaType) || BOXED_TYPES.containsKey(javaType);
+  }
+
+  static String boxed(String javaType) {
+    return BOXED_TYPES.getOrDefault(javaType, javaType);
+  }
+
   boolean isCustomClass() {
     JsonObject jsonObject = stripNullable();
     if (!"Object".equals(jsonObject.get("name").getAsString())) {
@@ -675,7 +708,7 @@ class Event extends Element {
   void writeListenerMethods(List<String> output, String offset) {
     writeJavadoc(output, offset, comment());
     String name = toTitle(jsonName);
-    String paramType = type.toJava();
+    String paramType = type.toJavaWithNullability();
     String listenerType = "void".equals(paramType) ? "Runnable" : "Consumer<" + paramType + ">";
     output.add(offset + "void on" + name + "(" + listenerType + " handler);");
     writeJavadoc(output, offset, "Removes handler that was previously added with {@link #on" + name + " on" + name + "(handler)}.");
@@ -705,7 +738,7 @@ class Method extends Element {
   void writeTo(List<String> output, String offset) {
     if ("Playwright.create".equals(jsonPath)) {
       writeJavadoc(params, output, offset);
-      output.add(offset + "static Playwright create(CreateOptions options) {");
+      output.add(offset + "static Playwright create(" + params.get(0).toJava() + ") {");
       output.add(offset + "  return PlaywrightImpl.create(options);");
       output.add(offset + "}");
       output.add("");
@@ -787,7 +820,7 @@ class Method extends Element {
 
     List<String> paramList = params.stream().map(p -> p.type.isTypeUnion() ? p.toJavaOverload(overloadIndex) : p.toJava()).collect(toList());
     writeJavadoc(params, output, offset);
-    output.add(offset + returnType.toJava() + " " + jsonName + "(" + String.join(", ", paramList) + ");");
+    output.add(offset + returnType.toJavaWithNullability() + " " + jsonName + "(" + String.join(", ", paramList) + ");");
   }
 
 
@@ -820,7 +853,7 @@ class Method extends Element {
       .collect(joining(", "));
     String returns = returnType.toJava().equals("void") ? "" : "return ";
     writeJavadoc(paramList, output, offset);
-    output.add(offset + "default " + returnType.toJava() + " " + jsonName + "(" + paramsStr + ") {");
+    output.add(offset + "default " + returnType.toJavaWithNullability() + " " + jsonName + "(" + paramsStr + ") {");
     output.add(offset + "  " + returns + jsonName + "(" + String.join(", ", argList) + ");");
     output.add(offset + "}");
   }
@@ -875,11 +908,16 @@ class Param extends Element {
   }
 
   String toJavaOverload(int overoadIndex) {
-    return type.formatTypeFromUnion(overoadIndex) + " " + jsonName;
+    return withNullability(type.formatTypeFromUnion(overoadIndex)) + " " + jsonName;
   }
 
   String toJava() {
-    return type.toJava() + " " + jsonName;
+    return withNullability(type.toJava()) + " " + jsonName;
+  }
+
+  private String withNullability(String javaType) {
+    boolean nullable = type.isNullableInJava() || (isOptional() && !TypeRef.isPrimitive(javaType));
+    return nullable ? TypeRef.nullable(javaType) : javaType;
   }
 }
 
@@ -906,16 +944,13 @@ class Field extends Element {
     }
     // Convert optional fields to boxed types.
     if (!isRequired()) {
-      if (typeStr.equals("int")) {
-        typeStr = "Integer";
-      } else if (typeStr.equals("double")) {
-        typeStr = "Double";
-      } else if (typeStr.equals("boolean")) {
-        typeStr = "Boolean";
-      }
+      typeStr = TypeRef.boxed(typeStr);
     }
     if (isBrowserChannelOption()) {
       typeStr = "Object";
+    }
+    if (!isRequired()) {
+      typeStr = TypeRef.nullable(typeStr);
     }
     output.add(offset + "public " + typeStr + " " + name + ";");
   }
@@ -957,7 +992,7 @@ class Field extends Element {
       if (!f.isRequired()) {
         continue;
       }
-      params.add(f.type.toJava() + " " + f.name);
+      params.add(f.type.toJavaWithNullability() + " " + f.name);
       args.add(f.name);
     }
     if (params.isEmpty()) {
@@ -971,6 +1006,9 @@ class Field extends Element {
 
   private void writeGenericBuilderMethod(List<String> output, String offset, String parentClass, String paramType) {
     writeJavadoc(output, offset, comment());
+    if (type.isNullable()) {
+      paramType = TypeRef.nullable(paramType);
+    }
     output.add(offset + "public " + parentClass + " set" + toTitle(name) + "(" + paramType + " " + name + ") {");
     String rvalue = type.isNullable() ? "Optional.ofNullable(" + name + ")" : name;
     output.add(offset + "  this." + name + " = " + rvalue + ";");
@@ -1204,7 +1242,7 @@ class CustomClass extends TypeDefinition {
     if (requiredFields.isEmpty()) {
       return;
     }
-    List<String> args = requiredFields.stream().map(f -> f.type.toJava() + " " + f.name).collect(toList());
+    List<String> args = requiredFields.stream().map(f -> f.type.toJavaWithNullability() + " " + f.name).collect(toList());
     output.add(bodyOffset + "public " + name + "(" + String.join(", ", args) + ") {");
     requiredFields.forEach(f -> output.add(bodyOffset + "  this." + f.name + " = " + f.name + ";"));
     output.add(bodyOffset + "}");
@@ -1242,7 +1280,11 @@ class CustomInterface extends TypeDefinition {
       }
       first = false;
       writeJavadoc(output, bodyOffset, f.comment());
-      output.add(bodyOffset + f.type.toJava() + " " + f.name + "();");
+      String returnType = f.type.toJava();
+      if (!f.isRequired() || f.type.isNullable()) {
+        returnType = TypeRef.nullable(returnType);
+      }
+      output.add(bodyOffset + returnType + " " + f.name + "();");
     }
     output.add(offset + "}");
   }
@@ -1313,10 +1355,22 @@ public class ApiGenerator {
       }
       lines.add("");
       e.writeTo(lines, "");
-      String text = String.join("\n", lines);
-      try (FileWriter writer = new FileWriter(new File(targetDir, e.name() + ".java"))) {
-        writer.write(text);
+      writeFile(lines, new File(targetDir, e.name() + ".java"));
+    }
+  }
+
+  // Lines are expected to start with the license header, package declaration and an empty line.
+  private static void writeFile(List<String> lines, File file) throws IOException {
+    if (lines.stream().anyMatch(line -> line.contains("@Nullable"))) {
+      int index = 3;
+      lines.add(index++, "import org.jspecify.annotations.Nullable;");
+      String next = lines.get(index);
+      if (!next.isEmpty() && !next.startsWith("import ")) {
+        lines.add(index, "");
       }
+    }
+    try (FileWriter writer = new FileWriter(file)) {
+      writer.write(String.join("\n", lines));
     }
   }
 
@@ -1353,10 +1407,7 @@ public class ApiGenerator {
       lines.add("package " + packageName + ";");
       lines.add("");
       iface.writeTo(lines, "");
-      String text = String.join("\n", lines);
-      try (FileWriter writer = new FileWriter(new File(dir, name + ".java"))) {
-        writer.write(text);
-      }
+      writeFile(lines, new File(dir, name + ".java"));
     }
 
   }


### PR DESCRIPTION
## Summary
- generate JSpecify nullability annotations for the public API
- mark public API packages as null-marked
- verify annotations with a Java NullAway consumer check

Fixes https://github.com/microsoft/playwright-java/issues/473