### PR TITLE
devops(pipeline): resolve Maven and npm packages from DevDiv_PublicPackages feed

### DIFF
--- a/.azure-pipelines/publish.yml
+++ b/.azure-pipelines/publish.yml
@@ -58,6 +58,11 @@ extends:
            GPG_PRIVATE_KEY_BASE64: $(GPG_PRIVATE_KEY_BASE64) # secret variable has to be mapped to an env variable
           displayName: "Import gpg key"
         
+        - task: UseNode@1
+          inputs:
+            version: '26.x'
+          displayName: "Install Node.js"
+
         - task: Bash@3
           displayName: "setup .npmrc"
           inputs:

--- a/.azure-pipelines/publish.yml
+++ b/.azure-pipelines/publish.yml
@@ -45,6 +45,8 @@ extends:
           env:
             CURRENT_BRANCH: ${{ variables['Build.SourceBranchName'] }}
           displayName: "Check the branch is a release branch"
+          # Allow manual runs on any branch to exercise the build without publishing.
+          condition: ne(variables['Build.Reason'], 'Manual')
         
         - bash: |
             echo "importing GPG key:"
@@ -56,9 +58,33 @@ extends:
            GPG_PRIVATE_KEY_BASE64: $(GPG_PRIVATE_KEY_BASE64) # secret variable has to be mapped to an env variable
           displayName: "Import gpg key"
         
+        - task: Bash@3
+          displayName: "setup .npmrc"
+          inputs:
+            targetType: "inline"
+            script: |
+              echo "registry=https://devdiv.pkgs.visualstudio.com/DevDiv/_packaging/DevDiv_PublicPackages/npm/registry/" >> .npmrc
+
+        - task: npmAuthenticate@0
+          displayName: "authenticate the private npm registry"
+          inputs:
+            workingFile: .npmrc
+
         - bash: ./scripts/download_driver.sh
           displayName: 'Download driver'
-        
+
+        # Must run before MavenAuthenticate@0 so the credentials it injects into
+        # ~/.m2/settings.xml are not overwritten by the copy.
+        - bash: |
+            mkdir -p ~/.m2
+            cp .azure-pipelines/settings.xml ~/.m2/settings.xml
+          displayName: 'Copy settings.xml (mirror Maven Central to DevDiv_PublicPackages)'
+
+        - task: MavenAuthenticate@0
+          displayName: 'Authenticate to DevDiv_PublicPackages feed'
+          inputs:
+            artifactsFeeds: DevDiv_PublicPackages
+
         - bash: mvn -B deploy -D skipTests --no-transfer-progress --activate-profiles release -D gpg.passphrase=$GPG_PASSPHRASE -DaltDeploymentRepository=snapshot-repo::default::file:$(Build.ArtifactStagingDirectory)/esrp-build
           displayName: 'Build and deploy to a local directory'
           env:
@@ -66,6 +92,8 @@ extends:
 
       - job: Publish
         dependsOn: Build
+        # Only publish from release tags; manual runs stop after Build.
+        condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/v1.'))
         templateContext:
           type: releaseJob
           isProduction: true

--- a/.azure-pipelines/settings.xml
+++ b/.azure-pipelines/settings.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Maven settings used only by the Azure Pipelines release build (publish.yml).
+
+  Routes all remote artifact and plugin resolution through the DevDiv_PublicPackages
+  Azure Artifacts feed instead of Maven Central, as required by SFI-ES4.2.4.
+  The mirror id must match the feed name passed to MavenAuthenticate@0, which
+  injects matching <server> credentials into this file on the build agent.
+-->
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <mirrors>
+    <mirror>
+      <id>DevDiv_PublicPackages</id>
+      <url>https://pkgs.dev.azure.com/devdiv/DevDiv/_packaging/DevDiv_PublicPackages/maven/v1</url>
+      <mirrorOf>*</mirrorOf>
+    </mirror>
+  </mirrors>
+</settings>

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ target/
 .idea
 *.iml
 
+.npmrc

--- a/scripts/download_driver.sh
+++ b/scripts/download_driver.sh
@@ -37,10 +37,18 @@ download() {
 }
 
 DRIVER_VERSION=$(head -1 ./DRIVER_VERSION)
+ROOT="$(cd .. && pwd)"
+
+# All npm commands run from the repository root so that a root-level .npmrc (e.g. the one
+# the release pipeline writes to point at the internal Azure Artifacts feed) is honoured.
+# Locally, NPM_CONFIG_REGISTRY=<url> can be used to the same effect.
+npm_at_root() {
+  (cd "$ROOT" && npm "$@")
+}
 
 # Resolve the exact upstream commit that produced this driver version, so that the
 # bundled Node.js version matches the driver exactly.
-GIT_HEAD=$(npm view playwright@"$DRIVER_VERSION" gitHead)
+GIT_HEAD=$(npm_at_root view playwright@"$DRIVER_VERSION" gitHead)
 if [[ -z "$GIT_HEAD" ]]; then
   echo "Failed to resolve upstream commit (gitHead) for playwright@$DRIVER_VERSION"
   exit 1
@@ -66,7 +74,6 @@ echo "Node.js version: $NODE_VERSION"
 
 # The platform-independent driver code (playwright-core) is assembled once into the driver module;
 # the Node.js binary for each platform is assembled into the driver-bundle module. See issue #1196.
-ROOT="$(cd .. && pwd)"
 CORE_DEST="$ROOT/driver/src/main/resources/driver"
 NODE_DEST="$ROOT/driver-bundle/src/main/resources/driver"
 
@@ -77,8 +84,11 @@ trap 'rm -rf "$TMP_DIR"' EXIT
 echo "Assembling playwright-core package to $CORE_DEST/package"
 rm -rf "$CORE_DEST/package"
 mkdir -p "$CORE_DEST"
+# Fetched via npm rather than a hard-coded registry URL so that the configured registry
+# (and its credentials) are used.
 CORE_TGZ="$TMP_DIR/playwright-core-$DRIVER_VERSION.tgz"
-download "https://registry.npmjs.org/playwright-core/-/playwright-core-$DRIVER_VERSION.tgz" "$CORE_TGZ"
+echo "Downloading playwright-core@$DRIVER_VERSION from $(npm_at_root config get registry)"
+npm_at_root pack "playwright-core@$DRIVER_VERSION" --pack-destination "$TMP_DIR" --silent > /dev/null
 # The npm tarball has a top-level package/ directory, so this creates $CORE_DEST/package.
 tar -xzf "$CORE_TGZ" -C "$CORE_DEST"
 rm -f "$CORE_TGZ"

--- a/scripts/download_driver.sh
+++ b/scripts/download_driver.sh
@@ -46,30 +46,17 @@ npm_at_root() {
   (cd "$ROOT" && npm "$@")
 }
 
-# Resolve the exact upstream commit that produced this driver version, so that the
-# bundled Node.js version matches the driver exactly.
-GIT_HEAD=$(npm_at_root view playwright@"$DRIVER_VERSION" gitHead)
-if [[ -z "$GIT_HEAD" ]]; then
-  echo "Failed to resolve upstream commit (gitHead) for playwright@$DRIVER_VERSION"
-  exit 1
-fi
-
 # The Node.js version used to be pinned in the upstream driver build script. The script was
-# removed in microsoft/playwright#41518, so for newer versions we follow the same policy it
-# had: the latest Node.js LTS (see upstream utils/build/update-playwright-node.mjs).
-NODE_VERSION=$(curl -fsSL "https://raw.githubusercontent.com/microsoft/playwright/$GIT_HEAD/utils/build/build-playwright-driver.sh" 2>/dev/null \
-  | sed -n 's/^NODE_VERSION="\([^"]*\)".*/\1/p')
+# removed in microsoft/playwright#41518, so we follow the same policy it had: the latest
+# Node.js LTS (see upstream utils/build/update-playwright-node.mjs).
+NODE_VERSION=$(curl -fsSL "https://nodejs.org/dist/index.json" \
+  | node -e "let s='';process.stdin.on('data',d=>s+=d).on('end',()=>console.log(JSON.parse(s).find(r=>r.lts).version.slice(1)))")
 if [[ -z "$NODE_VERSION" ]]; then
-  NODE_VERSION=$(curl -fsSL "https://nodejs.org/dist/index.json" \
-    | node -e "let s='';process.stdin.on('data',d=>s+=d).on('end',()=>console.log(JSON.parse(s).find(r=>r.lts).version.slice(1)))")
-fi
-if [[ -z "$NODE_VERSION" ]]; then
-  echo "Failed to determine Node.js version for playwright@$DRIVER_VERSION ($GIT_HEAD)"
+  echo "Failed to determine the latest Node.js LTS version"
   exit 1
 fi
 
 echo "Driver version:  $DRIVER_VERSION"
-echo "Upstream commit: $GIT_HEAD"
 echo "Node.js version: $NODE_VERSION"
 
 # The platform-independent driver code (playwright-core) is assembled once into the driver module;


### PR DESCRIPTION
## Summary
- Release pipeline resolves Maven artifacts/plugins and the npm driver package from the `DevDiv_PublicPackages` Azure Artifacts feed (SFI-ES4.2.4) instead of Maven Central / npmjs.com.
- Maven mirror lives in a pipeline-only `settings.xml`; `pom.xml` and public CI are unchanged.
- `download_driver.sh` uses `npm pack` and honours the configured registry instead of a hard-coded npmjs.org URL.
- Manual pipeline runs skip the release-branch check and the ESRP publish job, so the setup can be tested without publishing.