### PR TITLE
feat: add hasAttribute(name) for attribute presence assertions

### DIFF
--- a/playwright/src/main/java/com/microsoft/playwright/assertions/LocatorAssertions.java
+++ b/playwright/src/main/java/com/microsoft/playwright/assertions/LocatorAssertions.java
@@ -1566,6 +1566,36 @@ public interface LocatorAssertions {
    */
   void hasAttribute(String name, Pattern value, HasAttributeOptions options);
   /**
+   * Ensures the {@code Locator} points to an element with given attribute. When only the attribute name is provided, the
+   * method asserts attribute presence.
+   *
+   * <p> <strong>Usage</strong>
+   * <pre>{@code
+   * assertThat(page.locator("input")).hasAttribute("disabled");
+   * assertThat(page.locator("input")).not().hasAttribute("open");
+   * }</pre>
+   *
+   * @param name Attribute name.
+   * @since v1.62
+   */
+  default void hasAttribute(String name) {
+    hasAttribute(name, (HasAttributeOptions) null);
+  }
+  /**
+   * Ensures the {@code Locator} points to an element with given attribute. When only the attribute name is provided, the
+   * method asserts attribute presence.
+   *
+   * <p> <strong>Usage</strong>
+   * <pre>{@code
+   * assertThat(page.locator("input")).hasAttribute("disabled");
+   * assertThat(page.locator("input")).not().hasAttribute("open");
+   * }</pre>
+   *
+   * @param name Attribute name.
+   * @since v1.62
+   */
+  void hasAttribute(String name, HasAttributeOptions options);
+  /**
    * Ensures the {@code Locator} points to an element with given CSS classes. When a string is provided, it must fully match
    * the element's {@code class} attribute. To match individual classes use {@link
    * com.microsoft.playwright.assertions.LocatorAssertions#containsClass LocatorAssertions.containsClass()}.

--- a/playwright/src/main/java/com/microsoft/playwright/impl/LocatorAssertionsImpl.java
+++ b/playwright/src/main/java/com/microsoft/playwright/impl/LocatorAssertionsImpl.java
@@ -191,6 +191,18 @@ public class LocatorAssertionsImpl extends AssertionsBase implements LocatorAsse
   }
 
   @Override
+  public void hasAttribute(String name, HasAttributeOptions options) {
+    if (options == null) {
+      options = new HasAttributeOptions();
+    }
+    FrameExpectOptions commonOptions = convertType(options, FrameExpectOptions.class);
+    commonOptions.expressionArg = name;
+    String message = "Locator expected to have attribute '" + name + "'";
+    List<ExpectedTextValue> expectedText = null;
+    expectImpl("to.have.attribute", expectedText, null, message, commonOptions, "Assert \"hasAttribute\"");
+  }
+
+  @Override
   public void hasClass(String text, HasClassOptions options) {
     ExpectedTextValue expected = new ExpectedTextValue();
     expected.string = text;

--- a/playwright/src/test/java/com/microsoft/playwright/TestLocatorAssertions.java
+++ b/playwright/src/test/java/com/microsoft/playwright/TestLocatorAssertions.java
@@ -295,6 +295,27 @@ public class TestLocatorAssertions extends TestBase {
   }
 
   @Test
+  void hasAttributeNamePass() {
+    page.setContent("<div checked id=node>Text content</div>");
+    Locator locator = page.locator("#node");
+    assertThat(locator).hasAttribute("id");
+    assertThat(locator).hasAttribute("checked");
+    assertThat(locator).not().hasAttribute("open");
+  }
+
+  @Test
+  void hasAttributeNameFail() {
+    page.setContent("<div checked id=node>Text content</div>");
+    Locator locator = page.locator("#node");
+    AssertionFailedError e = assertThrows(AssertionFailedError.class,
+      () -> assertThat(locator).hasAttribute("disabled", new LocatorAssertions.HasAttributeOptions().setTimeout(1000)));
+    assertTrue(e.getMessage().contains("Locator expected to have attribute 'disabled'"), e.getMessage());
+    e = assertThrows(AssertionFailedError.class,
+      () -> assertThat(locator).not().hasAttribute("checked", new LocatorAssertions.HasAttributeOptions().setTimeout(1000)));
+    assertTrue(e.getMessage().contains("Locator expected not to have attribute 'checked'"), e.getMessage());
+  }
+
+  @Test
   void hasClassTextPass() {
     page.setContent("<div class=\"foo bar baz\"></div>");
     Locator locator = page.locator("div");


### PR DESCRIPTION
Fixes #1844

## Summary
Adds `LocatorAssertions.hasAttribute(String name)` and an options overload so callers can assert attribute **presence** / **absence** (via `.not()`), matching Node's presence-only `toHaveAttribute(name)`.

## Changes
- **Interface** `LocatorAssertions`: `hasAttribute(name)` + `hasAttribute(name, HasAttributeOptions)`
- **Impl** `LocatorAssertionsImpl`: `expectImpl("to.have.attribute", ...)` with `expressionArg = name` (value assertions continue to use `to.have.attribute.value`)
- **Tests**: presence pass + fail, and `.not()` absence pass + fail

## Notes
- `ApiGenerator` already special-cases the `HasAttributeOptions` null cast for `LocatorAssertions.hasAttribute` overloads.
- LocatorAssertions is regenerated from upstream API docs; lasting inclusion after driver rolls needs the optional `value` param marked for Java in upstream `docs/src/api/class-locatorassertions.md` (today that optional overload is `langs: python` only), then a regenerate.
